### PR TITLE
Adjust icon layout for responsiveness

### DIFF
--- a/index.html
+++ b/index.html
@@ -99,23 +99,23 @@
 
     <div class="mt-16 grid gap-8 md:grid-cols-3 max-w-6xl mx-auto px-6">
       <!-- card -->
-      <div class="rounded-xl bg-white shadow-sm p-8 flex items-center">
-        <div class="text-4xl font-extrabold text-brand-orange mr-6">①</div>
-        <div>
+      <div class="rounded-xl bg-white shadow-sm p-8 flex items-start md:flex-col">
+        <div class="text-4xl font-extrabold text-brand-orange mr-6 md:mr-0 md:mb-4">①</div>
+        <div class="text-left">
           <h3 class="font-semibold text-lg mb-2">Lead Funnels</h3>
           <p class="text-sm text-brand-steel">Quote forms drop hot leads straight in your inbox—no missed trucks.</p>
         </div>
       </div>
-      <div class="rounded-xl bg-white shadow-sm p-8 flex items-center">
-        <div class="text-4xl font-extrabold text-brand-orange mr-6">②</div>
-        <div>
+      <div class="rounded-xl bg-white shadow-sm p-8 flex items-start md:flex-col">
+        <div class="text-4xl font-extrabold text-brand-orange mr-6 md:mr-0 md:mb-4">②</div>
+        <div class="text-left">
           <h3 class="font-semibold text-lg mb-2">High-Converting Pages</h3>
           <p class="text-sm text-brand-steel">Clear calls-to-action drive inbound calls instead of price-shoppers.</p>
         </div>
       </div>
-      <div class="rounded-xl bg-white shadow-sm p-8 flex items-center">
-        <div class="text-4xl font-extrabold text-brand-orange mr-6">③</div>
-        <div>
+      <div class="rounded-xl bg-white shadow-sm p-8 flex items-start md:flex-col">
+        <div class="text-4xl font-extrabold text-brand-orange mr-6 md:mr-0 md:mb-4">③</div>
+        <div class="text-left">
           <h3 class="font-semibold text-lg mb-2">Industrial Credibility</h3>
           <p class="text-sm text-brand-steel">Professional design signals trust to brokers, suppliers, and walk-in sellers.</p>
         </div>


### PR DESCRIPTION
## Summary
- adapt icon layout in "Why Specialized Matters" section to stack icons above the copy on wider screens while keeping them to the left on mobile

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685eeada556c83298d81b2962a4f3ace