### PR TITLE
Add logo in header and responsive brand size

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,9 +38,12 @@
 <!-- ── Header ─────────────────────────────────────────────── -->
 <header class="bg-white sticky top-0 z-50 shadow-sm">
   <div class="mx-auto max-w-7xl flex items-center justify-between px-6 py-3">
-    <a href="#top" class="text-2xl font-black tracking-tight">
-      Scrap<span class="text-brand-orange">Yard</span>Sites
-    </a>
+    <div class="flex items-center gap-2">
+      <img src="assets/logo.svg" alt="ScrapYardSites logo" class="h-6 w-6 md:h-8 md:w-8"/>
+      <a href="#top" class="text-xl md:text-2xl font-black tracking-tight">
+        Scrap<span class="text-brand-orange">Yard</span>Sites
+      </a>
+    </div>
     <nav class="hidden md:flex gap-8 text-sm font-medium">
       <a href="#why"   class="hover:text-brand-orange">Why Us</a>
       <a href="#work"  class="hover:text-brand-orange">Work</a>


### PR DESCRIPTION
## Summary
- place logo.svg at the start of the nav bar
- resize site title on small screens so header fits

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_685f061e3a20832982e6fdb941da5e82