### PR TITLE
Fix typography for scrapyard

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
   <title>ScrapYardSites – Premium Websites for Scrap & Recycling Yards</title>
   <meta name="description"
         content="ScrapYardSites builds tough, high‑performing single‑page websites for scrap & recycling yards. $2,499 to launch, $99/mo to maintain."/>
-  <meta property="og:title" content="Websites Built Tough for Scrap Yards"/>
+  <meta property="og:title" content="Websites Built Tough for Scrapyards"/>
   <meta property="og:description" content="Launch in 7 days. Haul in more leads. Zero tech headaches."/>
   <meta property="og:image" content="assets/hero.jpg"/>
   <meta property="og:type" content="website"/>
@@ -45,7 +45,7 @@
     <div class="flex items-center gap-2">
       <img src="assets/logo.svg" alt="ScrapYardSites logo" class="h-6 w-6 md:h-8 md:w-8"/>
       <a href="#top" class="text-xl md:text-2xl font-black tracking-tight">
-        Scrap<span class="text-brand-orange">Yard</span>Sites
+        <span class="text-brand-orange">Scrapyard</span>Sites
       </a>
     </div>
     <nav class="hidden md:flex items-center gap-8 text-sm font-medium">
@@ -75,7 +75,7 @@
   <div class="mx-auto max-w-3xl px-6">
     <h1 class="text-4xl sm:text-5xl md:text-6xl font-extrabold leading-tight text-white drop-shadow-lg">
       Websites Built Tough <br class="hidden sm:block"/>
-      for <span class="text-brand-orange">Scrap&nbsp;Yards</span>
+      for <span class="text-brand-orange">Scrapyards</span>
     </h1>
     <p class="mt-5 text-lg sm:text-xl text-gray-100">
       Launch in 7 days. Haul in more leads. Zero tech headaches.
@@ -98,7 +98,7 @@
   <div class="mx-auto max-w-6xl px-6 text-center">
     <h2 class="text-3xl font-bold mb-4">Why Specialized Matters</h2>
     <p class="mx-auto max-w-3xl text-brand-steel text-lg">
-      Scrap yards aren’t coffee shops. Your buyers want <em>fast quotes, clear directions, 
+      Scrapyards aren’t coffee shops. Your buyers want <em>fast quotes, clear directions,
         and proof you run a serious operation.</em> Off‑the‑shelf templates miss that.
       We speak metal and heavy industrial workflows—so you get a site that
       <b>pays for itself</b>.


### PR DESCRIPTION
## Summary
- updated hero tagline and SEO title to say **Scrapyards**
- fixed nav branding to make "Scrapyard" orange
- updated body copy to use "Scrapyards" as one word

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685f0cb19b4c8329808a2dab7ab46096