### PR TITLE
Align demo card styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -144,18 +144,18 @@
     <h2 class="text-3xl font-bold mb-10">Our Work</h2>
     <div class="grid gap-8 md:grid-cols-3">
       <!-- Demo project cards -->
-      <div class="rounded-lg overflow-hidden shadow-lg flex flex-col items-center text-center p-4">
-        <img src="https://placehold.co/600x400/2B2B2B/FFFFFF?text=Demo+Yard+1" alt="">
+      <div class="rounded-xl bg-white shadow-sm overflow-hidden flex flex-col items-center text-center p-4">
+        <img class="w-full" src="https://placehold.co/600x400/2B2B2B/FFFFFF?text=Demo+Yard+1" alt="">
         <h3 class="font-semibold mt-4">Demo Yard 1</h3>
         <p class="text-sm text-brand-steel mt-1">Custom design for a busy metro scrapyard.</p>
       </div>
-      <div class="rounded-lg overflow-hidden shadow-lg flex flex-col items-center text-center p-4">
-        <img src="https://placehold.co/600x400/2B2B2B/FFFFFF?text=Demo+Yard+2" alt="">
+      <div class="rounded-xl bg-white shadow-sm overflow-hidden flex flex-col items-center text-center p-4">
+        <img class="w-full" src="https://placehold.co/600x400/2B2B2B/FFFFFF?text=Demo+Yard+2" alt="">
         <h3 class="font-semibold mt-4">Demo Yard 2</h3>
         <p class="text-sm text-brand-steel mt-1">Mobile friendly layout with fast quote form.</p>
       </div>
-      <div class="rounded-lg overflow-hidden shadow-lg flex flex-col items-center text-center p-4">
-        <img src="https://placehold.co/600x400/2B2B2B/FFFFFF?text=Demo+Yard+3" alt="">
+      <div class="rounded-xl bg-white shadow-sm overflow-hidden flex flex-col items-center text-center p-4">
+        <img class="w-full" src="https://placehold.co/600x400/2B2B2B/FFFFFF?text=Demo+Yard+3" alt="">
         <h3 class="font-semibold mt-4">Demo Yard 3</h3>
         <p class="text-sm text-brand-steel mt-1">Highlighting services for industrial clients.</p>
       </div>


### PR DESCRIPTION
## Summary
- match demo card styling with other sections by using `rounded-xl bg-white shadow-sm`
- ensure demo images span full width

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685f138696c48329bcc9a86037d54826