### PR TITLE
Make demo cards clickable

### DIFF
--- a/index.html
+++ b/index.html
@@ -144,29 +144,28 @@
     <h2 class="text-3xl font-bold mb-10">Our Work</h2>
     <div class="grid gap-8 md:grid-cols-3">
       <!-- Demo project cards -->
-      <div class="bg-gray-50 border border-brand-steel/10 rounded-xl shadow-sm p-10 flex flex-col items-center text-center">
+      <a href="#contact" class="block bg-gray-50 border border-brand-steel/10 rounded-xl shadow-sm p-10 flex flex-col items-center text-center hover:bg-gray-100 hover:shadow-lg transition">
         <div class="w-full rounded-xl overflow-hidden border border-brand-steel/10">
           <img class="w-full" src="https://placehold.co/600x400/2B2B2B/FFFFFF?text=Demo+Yard+1" alt="">
         </div>
         <h3 class="font-semibold mt-4">Demo Yard 1</h3>
         <p class="text-sm text-brand-steel mt-1">Custom design for a busy metro scrapyard.</p>
-      </div>
-      <div class="bg-gray-50 border border-brand-steel/10 rounded-xl shadow-sm p-10 flex flex-col items-center text-center">
+      </a>
+      <a href="#contact" class="block bg-gray-50 border border-brand-steel/10 rounded-xl shadow-sm p-10 flex flex-col items-center text-center hover:bg-gray-100 hover:shadow-lg transition">
         <div class="w-full rounded-xl overflow-hidden border border-brand-steel/10">
           <img class="w-full" src="https://placehold.co/600x400/2B2B2B/FFFFFF?text=Demo+Yard+2" alt="">
         </div>
         <h3 class="font-semibold mt-4">Demo Yard 2</h3>
         <p class="text-sm text-brand-steel mt-1">Mobile friendly layout with fast quote form.</p>
-      </div>
-      <div class="bg-gray-50 border border-brand-steel/10 rounded-xl shadow-sm p-10 flex flex-col items-center text-center">
+      </a>
+      <a href="#contact" class="block bg-gray-50 border border-brand-steel/10 rounded-xl shadow-sm p-10 flex flex-col items-center text-center hover:bg-gray-100 hover:shadow-lg transition">
         <div class="w-full rounded-xl overflow-hidden border border-brand-steel/10">
           <img class="w-full" src="https://placehold.co/600x400/2B2B2B/FFFFFF?text=Demo+Yard+3" alt="">
         </div>
         <h3 class="font-semibold mt-4">Demo Yard 3</h3>
         <p class="text-sm text-brand-steel mt-1">Highlighting services for industrial clients.</p>
-      </div>
+      </a>
     </div>
-    <p class="mt-8 text-brand-steel text-base md:text-sm">Full interactive demos available on request.</p>
   </div>
 </section>
 


### PR DESCRIPTION
## Summary
- make 'Our Work' demo cards clickable
- add hover shading
- remove note about interactive demos

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_685f3be6313483298a0d16a3ff5b77da