### PR TITLE
Add PNG favicon as Safari fallback

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,6 +12,7 @@
   <meta name="thumbnail" content="assets/thumbnail.jpg"/>
   <meta property="og:type" content="website"/>
   <link rel="icon" href="assets/logo.svg" type="image/svg+xml"/>
+  <link rel="alternate icon" href="assets/logo.png" type="image/png"/>
   <!--  Tailwind 3 CDN  -->
   <script src="https://cdn.tailwindcss.com"></script>
   <script>


### PR DESCRIPTION
## Summary
- support Safari by linking a PNG favicon

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685f5da255288329b060c381c54d9123