### PR TITLE
Disable horizontal scroll on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,7 +39,7 @@
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css"/>
 </head>
 
-<body class="font-sans text-brand-charcoal antialiased bg-white">
+<body class="font-sans text-brand-charcoal antialiased bg-white overflow-x-hidden">
 
 <!-- ── Header ─────────────────────────────────────────────── -->
   <header class="bg-white sticky top-0 z-50 shadow-sm">


### PR DESCRIPTION
## Summary
- prevent horizontal scrolling on mobile by hiding body overflow

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68600252d2cc8329a4934430102b0402