### PR TITLE
Fix favicon for Safari

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,8 +11,10 @@
   <meta property="og:image" content="assets/hero.jpg"/>
   <meta name="thumbnail" content="assets/thumbnail.jpg"/>
   <meta property="og:type" content="website"/>
+  <!-- Favicon -->
+  <link rel="icon" href="assets/logo.png" sizes="any"/>
   <link rel="icon" href="assets/logo.svg" type="image/svg+xml"/>
-  <link rel="alternate icon" href="assets/logo.png" type="image/png"/>
+  <link rel="apple-touch-icon" href="assets/logo.png"/>
   <!--  Tailwind 3 CDN  -->
   <script src="https://cdn.tailwindcss.com"></script>
   <script>


### PR DESCRIPTION
## Summary
- make Safari use PNG favicon by default
- keep SVG icon for modern browsers
- add Apple touch icon

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6860374622fc83298a0548bfea25840b