### PR TITLE
Fix Safari favicon support

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
   <meta property="og:type" content="website"/>
   <!-- Favicon -->
   <link rel="icon" href="assets/logo.png" sizes="any"/>
-  <link rel="icon" href="assets/logo.svg" type="image/svg+xml"/>
+  <link rel="mask-icon" href="assets/logo.svg" color="#D75E02"/>
   <link rel="apple-touch-icon" href="assets/logo.png"/>
   <!--  Tailwind 3 CDN  -->
   <script src="https://cdn.tailwindcss.com"></script>


### PR DESCRIPTION
## Summary
- adjust link tag so Safari can load PNG favicon

## Testing
- `npx htmlhint index.html` *(fails: network access)*

------
https://chatgpt.com/codex/tasks/task_e_68603c0717048329899951817ec1a249