### PR TITLE
Improve button hover effect

### DIFF
--- a/index.html
+++ b/index.html
@@ -61,7 +61,7 @@
     </nav>
     <div class="flex items-center gap-3">
       <a href="#contact"
-         class="inline-block rounded-md bg-brand-orange px-5 py-2 text-white font-semibold shadow hover:opacity-90 transition">
+         class="inline-block rounded-md bg-brand-orange px-5 py-2 text-white font-semibold shadow hover:brightness-110 transition">
         Book a Call
       </a>
     </div>
@@ -86,7 +86,7 @@
     </p>
     <div class="mt-8 flex flex-col sm:flex-row justify-center gap-4">
       <a href="#pricing"
-         class="rounded-md bg-brand-orange px-8 py-3 text-white font-semibold shadow hover:opacity-90 transition">
+         class="rounded-md bg-brand-orange px-8 py-3 text-white font-semibold shadow hover:brightness-110 transition">
         See Pricing
       </a>
       <a href="#work"
@@ -247,7 +247,7 @@
     </div>
 
     <a href="#contact"
-       class="mt-12 inline-block rounded-md bg-brand-orange px-10 py-3 text-white font-semibold shadow hover:opacity-90 transition">
+       class="mt-12 inline-block rounded-md bg-brand-orange px-10 py-3 text-white font-semibold shadow hover:brightness-110 transition">
       Get Started
     </a>
   </div>
@@ -272,7 +272,7 @@
       <textarea name="message" rows="4" placeholder="Tell us what you need…"
                 class="w-full rounded-md px-4 py-3 bg-white border border-brand-steel/20 text-brand-charcoal"></textarea>
       <button type="submit"
-              class="rounded-md bg-brand-orange px-8 py-3 font-semibold text-white shadow hover:opacity-90 transition">
+              class="rounded-md bg-brand-orange px-8 py-3 font-semibold text-white shadow hover:brightness-110 transition">
         Send →
       </button>
     </form>


### PR DESCRIPTION
## Summary
- adjust brand buttons to darken on hover instead of fading with opacity

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68607debc7c48329a8d194420bca2036