### PR TITLE
Revert nav title underline alignment

### DIFF
--- a/index.html
+++ b/index.html
@@ -88,8 +88,7 @@
       content: '';
       position: absolute;
       left: 0;
-      /* Raise underline to match bottom of logo */
-      bottom: 0;
+      bottom: -2px;
       width: 0;
       height: 2px;
       background-color: var(--color-links);


### PR DESCRIPTION
## Summary
- revert positioning change for nav title underline

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6861749fe0ec83299833d2fd71cc7d75