### PR TITLE
Add fade-up animation for icons

### DIFF
--- a/index.html
+++ b/index.html
@@ -99,6 +99,20 @@
       width: 100%;
     }
 
+    /* AOS fade-up utility */
+    [data-aos] {
+      opacity: 0;
+      transform: translateY(20px);
+    }
+    .aos-active {
+      opacity: 1;
+      transform: translateY(0);
+      transition: opacity 0.6s ease-out, transform 0.6s ease-out;
+    }
+    #cta-final.aos-active {
+      transition-duration: 0.25s;
+    }
+
   </style>
 </head>
 
@@ -173,7 +187,7 @@
     <div class="mt-16 grid gap-8 md:grid-cols-3 max-w-6xl mx-auto px-6">
       <!-- card -->
       <div class="rounded-xl bg-white border border-brand-steel/10 shadow-sm p-8 flex items-center md:flex-col md:text-center">
-        <div class="text-brand-orange text-4xl mr-6 md:mr-0 md:mb-4">
+        <div class="text-brand-orange text-4xl mr-6 md:mr-0 md:mb-4" data-aos="fade-up" data-aos-delay="0">
           <i class="fa-solid fa-magnet"></i>
         </div>
         <div class="text-left md:text-center">
@@ -182,7 +196,7 @@
         </div>
       </div>
       <div class="rounded-xl bg-white border border-brand-steel/10 shadow-sm p-8 flex items-center md:flex-col md:text-center">
-        <div class="text-brand-orange text-4xl mr-6 md:mr-0 md:mb-4">
+        <div class="text-brand-orange text-4xl mr-6 md:mr-0 md:mb-4" data-aos="fade-up" data-aos-delay="100">
           <i class="fa-solid fa-chart-line"></i>
         </div>
         <div class="text-left md:text-center">
@@ -191,7 +205,7 @@
         </div>
       </div>
       <div class="rounded-xl bg-white border border-brand-steel/10 shadow-sm p-8 flex items-center md:flex-col md:text-center">
-        <div class="text-brand-orange text-4xl mr-6 md:mr-0 md:mb-4">
+        <div class="text-brand-orange text-4xl mr-6 md:mr-0 md:mb-4" data-aos="fade-up" data-aos-delay="200">
           <i class="fa-solid fa-hard-hat"></i>
         </div>
         <div class="text-left md:text-center">
@@ -239,17 +253,17 @@
     <h2 class="text-3xl font-bold mb-8">How We Work</h2>
     <div class="grid gap-10 md:grid-cols-3">
       <div>
-        <div class="text-brand-orange text-6xl font-black">1</div>
+        <div class="text-brand-orange text-6xl font-black" data-aos="fade-up" data-aos-delay="0">1</div>
         <h3 class="font-semibold text-lg mt-3">Discovery Call</h3>
         <p class="text-base md:text-sm text-brand-steel mt-1">15 minutes to learn your yard, materials & amp draw area.</p>
       </div>
       <div>
-        <div class="text-brand-orange text-6xl font-black">2</div>
+        <div class="text-brand-orange text-6xl font-black" data-aos="fade-up" data-aos-delay="100">2</div>
         <h3 class="font-semibold text-lg mt-3">Build Week</h3>
         <p class="text-base md:text-sm text-brand-steel mt-1">We design, write and code. You review once—done.</p>
       </div>
       <div>
-        <div class="text-brand-orange text-6xl font-black">3</div>
+        <div class="text-brand-orange text-6xl font-black" data-aos="fade-up" data-aos-delay="200">3</div>
         <h3 class="font-semibold text-lg mt-3">Launch & Maintain</h3>
         <p class="text-base md:text-sm text-brand-steel mt-1">Site goes live, Google Business updated, $99/mo care plan kicks in.</p>
       </div>
@@ -429,6 +443,23 @@
 <script>
   /* dynamic year for footer */
   document.getElementById('year').textContent = new Date().getFullYear();
+</script>
+<script>
+  const prefersReduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  const aosEls = document.querySelectorAll('[data-aos]');
+  if (aosEls.length && !prefersReduced) {
+    const aosObserver = new IntersectionObserver((entries, obs) => {
+      entries.forEach(entry => {
+        if (entry.isIntersecting) {
+          entry.target.classList.add('aos-active');
+          obs.unobserve(entry.target);
+        }
+      });
+    }, { threshold: 0.1 });
+    aosEls.forEach(el => aosObserver.observe(el));
+  } else if (prefersReduced) {
+    aosEls.forEach(el => el.classList.add('aos-active'));
+  }
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- implement CSS utility for fade-up effect
- trigger animation with IntersectionObserver
- add fade-up to Why Specialized Matters icons
- fade-up the numeric icons in How We Work section

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6861d97410108329b15d93d71151fd1b