### PR TITLE
Fix privacy link, tweak policy layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -351,7 +351,7 @@
       </button>
     </form>
     <p class="mt-4 text-xs text-brand-steel">
-      By submitting you agree to our <a href="/privacy.html" class="underline">privacy policy</a>. No spam—ever.
+        By submitting you agree to our <a href="/privacy" class="underline">privacy policy</a>. No spam—ever.
     </p>
   </div>
   </section>

--- a/privacy/index.html
+++ b/privacy/index.html
@@ -7,7 +7,7 @@
   <link rel="icon" href="/assets/logo.png" sizes="any"/>
   <link rel="mask-icon" href="/assets/logo.svg" color="#D75E02"/>
   <link rel="apple-touch-icon" href="/assets/logo.png"/>
-  <script src="https://cdn.tailwindcss.com"></script>
+  <script src="https://cdn.tailwindcss.com?plugins=typography"></script>
   <script>
     tailwind.config = {
       theme: {
@@ -112,7 +112,7 @@
       </div>
     </div>
   </header>
-  <main class="max-w-3xl mx-auto pt-20 px-6">
+  <main class="max-w-3xl mx-auto pt-20 px-6 prose prose-a:text-brand-orange">
     <h1 class="text-3xl font-bold mb-4">Privacy Policy for Scrapyard&nbsp;Sites</h1>
     <p class="mb-4"><strong>Effective Date: 4&nbsp;July&nbsp;2025</strong></p>
     <p class="mb-4">Scrapyard Sites (“Company,” “we,” “our,” or “us”) is committed to protecting your privacy. This Privacy Policy explains how we collect, use, disclose, and safeguard your information when you visit scrapyardsites.com (the “Site”) or interact with any of our services, prototypes, or test sites hosted on GitHub or other platforms (collectively, the “Services”). By accessing or using our Services, you agree to the terms of this Privacy Policy.</p>


### PR DESCRIPTION
## Summary
- fix contact form privacy policy link to use `/privacy`
- tweak privacy policy page layout with Tailwind typography plugin

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_68683d19171c8329bea76224ac196a20