### PR TITLE
Fix privacy page header/footer spacing

### DIFF
--- a/privacy/index.html
+++ b/privacy/index.html
@@ -112,8 +112,8 @@
       </div>
     </div>
   </header>
-  <main class="max-w-3xl mx-auto pt-20 px-6 prose prose-a:text-brand-orange">
-    <h1 class="text-3xl font-bold mb-4">Privacy Policy for Scrapyard&nbsp;Sites</h1>
+  <main class="max-w-3xl mx-auto pt-24 pb-20 px-6 prose prose-a:text-brand-orange">
+    <h1 class="text-3xl font-bold mb-4">Privacy Policy</h1>
     <p class="mb-4"><strong>Effective Date: 4&nbsp;July&nbsp;2025</strong></p>
     <p class="mb-4">Scrapyard Sites (“Company,” “we,” “our,” or “us”) is committed to protecting your privacy. This Privacy Policy explains how we collect, use, disclose, and safeguard your information when you visit scrapyardsites.com (the “Site”) or interact with any of our services, prototypes, or test sites hosted on GitHub or other platforms (collectively, the “Services”). By accessing or using our Services, you agree to the terms of this Privacy Policy.</p>
 
@@ -247,7 +247,7 @@
     <p class="mb-8">Thank you for trusting Scrapyard&nbsp;Sites. We value your privacy and strive to be transparent about our practices while providing you with exceptional service and spam&#8209;free communications.</p>
   </main>
 
-  <footer class="text-center text-xs text-gray-400">
+  <footer class="bg-white py-8 text-center text-xs text-gray-400">
     <p>© <span id="year"></span> Scrapyard Sites — All rights reserved.</p>
   </footer>
 


### PR DESCRIPTION
## Summary
- adjust privacy page top padding
- update main header text
- align footer styling with rest of site

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68683ec0e300832994bc45fe865dd8cd