### PR TITLE
Add standalone pages for services and tools

### DIFF
--- a/contact/index.html
+++ b/contact/index.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html lang="en" class="scroll-smooth overflow-x-hidden">
+<head>
+  <meta charset="UTF-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>Contact | Scrapyard Sites</title>
+  <link rel="icon" href="/assets/logo.png" sizes="any"/>
+  <link rel="mask-icon" href="/assets/logo.svg" color="#D75E02"/>
+  <link rel="apple-touch-icon" href="/assets/logo.png"/>
+  <script src="https://cdn.tailwindcss.com?plugins=typography"></script>
+  <script>
+    tailwind.config={theme:{extend:{fontFamily:{sans:['Inter','system-ui','sans-serif']},colors:{brand:{orange:'#D75E02',steel:'#5E6367',charcoal:'#2B2B2B'}}}}};
+  </script>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;900&display=swap" rel="stylesheet"/>
+  <style>
+    :root{--color-links:#D75E02;}
+    header nav a,#mobileMenu a:not(.bg-yellow-500){position:relative;text-decoration:none;}
+    header nav a:hover,#mobileMenu a:not(.bg-yellow-500):hover{color:currentColor!important;}
+    header nav a.text-yellow-400:hover{color:var(--color-links)!important;}
+    header nav a::after,#mobileMenu a:not(.bg-yellow-500)::after{content:'';position:absolute;left:0;bottom:-2px;width:0;height:2px;background-color:var(--color-links);transition:width .3s ease;}
+    header nav a:hover::after,#mobileMenu a:not(.bg-yellow-500):hover::after{width:100%;}
+    .site-title{position:relative;display:inline-block;}
+    .site-title::after{content:'';position:absolute;left:0;bottom:-2px;width:0;height:2px;background-color:var(--color-links);transition:width .3s ease;}
+    a:hover .site-title::after{width:100%;}
+  </style>
+</head>
+<body class="font-sans text-brand-charcoal antialiased bg-white overflow-x-hidden">
+  <header class="bg-white fixed top-0 left-0 right-0 w-full z-50 shadow-sm">
+    <div class="mx-auto max-w-7xl relative flex items-center justify-between px-6 py-3">
+      <a href="/" class="flex items-center gap-2">
+        <img src="/assets/logo.svg" alt="ScrapYardSites logo" class="h-6 w-6 md:h-8 md:w-8"/>
+        <span class="site-title text-xl md:text-2xl font-black tracking-tight"><span class="text-brand-orange">Scrapyard</span> Sites</span>
+      </a>
+      <nav class="hidden md:flex absolute left-1/2 -translate-x-1/2 justify-center items-center gap-8 text-sm font-medium">
+        <a href="/#why" class="hover:text-brand-orange">Why Us</a>
+        <a href="/portfolio" class="hover:text-brand-orange">Portfolio</a>
+        <a href="/pricing" class="hover:text-brand-orange">Pricing</a>
+        <a href="/risk-calculator" class="hover:text-brand-orange">Calculator</a>
+      </nav>
+      <div class="flex items-center gap-3">
+        <a href="/contact" class="inline-block rounded-md bg-brand-orange px-5 py-2 text-white font-semibold shadow hover:opacity-90 transition">Book a Call</a>
+      </div>
+    </div>
+  </header>
+  <main class="pt-24 pb-20 px-6">
+    <h1 class="text-3xl font-bold text-center mb-8">Get in Touch</h1>
+    <div class="mx-auto max-w-4xl text-center">
+      <p class="mt-2 text-brand-steel">Fill the form or call <a href="tel:9493568762" class="underline">949‑356‑8762</a>.</p>
+      <form action="https://formspree.io/f/yourID" method="POST" class="mt-10 grid gap-6">
+        <input type="text" name="name" required placeholder="Name" class="w-full rounded-md px-4 py-3 bg-white border border-brand-steel/20 text-brand-charcoal" />
+        <input type="email" name="email" required placeholder="Email" class="w-full rounded-md px-4 py-3 bg-white border border-brand-steel/20 text-brand-charcoal" />
+        <input type="text" name="company" required placeholder="Yard / Company" class="w-full rounded-md px-4 py-3 bg-white border border-brand-steel/20 text-brand-charcoal" />
+        <textarea name="message" rows="4" placeholder="Tell us what you need…" class="w-full rounded-md px-4 py-3 bg-white border border-brand-steel/20 text-brand-charcoal"></textarea>
+        <button type="submit" class="rounded-md bg-brand-orange px-8 py-3 font-semibold text-white shadow hover:opacity-90 transition">Send →</button>
+      </form>
+      <div class="mt-10">
+        <iframe class="w-full h-64" loading="lazy" allowfullscreen src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d10000!2d-97.7431!3d30.2672"></iframe>
+      </div>
+      <div class="mt-10">
+        <iframe src="https://calendly.com/your-calendar" class="w-full h-[630px]"></iframe>
+      </div>
+    </div>
+  </main>
+  <footer class="bg-white py-8 text-center text-xs text-gray-400">
+    <p>© <span id="year"></span> Scrapyard Sites — All rights reserved.</p>
+  </footer>
+  <script>document.getElementById('year').textContent=new Date().getFullYear();</script>
+</body>
+</html>

--- a/portfolio/demo-yard-1/index.html
+++ b/portfolio/demo-yard-1/index.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en" class="scroll-smooth overflow-x-hidden">
+<head>
+  <meta charset="UTF-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>Demo Yard 1 | Scrapyard Sites</title>
+  <link rel="icon" href="/assets/logo.png" sizes="any"/>
+  <link rel="mask-icon" href="/assets/logo.svg" color="#D75E02"/>
+  <link rel="apple-touch-icon" href="/assets/logo.png"/>
+  <script src="https://cdn.tailwindcss.com?plugins=typography"></script>
+  <script>
+    tailwind.config={theme:{extend:{fontFamily:{sans:['Inter','system-ui','sans-serif']},colors:{brand:{orange:'#D75E02',steel:'#5E6367',charcoal:'#2B2B2B'}}}}};
+  </script>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;900&display=swap" rel="stylesheet"/>
+  <style>
+    :root{--color-links:#D75E02;}
+    header nav a,#mobileMenu a:not(.bg-yellow-500){position:relative;text-decoration:none;}
+    header nav a:hover,#mobileMenu a:not(.bg-yellow-500):hover{color:currentColor!important;}
+    header nav a.text-yellow-400:hover{color:var(--color-links)!important;}
+    header nav a::after,#mobileMenu a:not(.bg-yellow-500)::after{content:'';position:absolute;left:0;bottom:-2px;width:0;height:2px;background-color:var(--color-links);transition:width .3s ease;}
+    header nav a:hover::after,#mobileMenu a:not(.bg-yellow-500):hover::after{width:100%;}
+    .site-title{position:relative;display:inline-block;}
+    .site-title::after{content:'';position:absolute;left:0;bottom:-2px;width:0;height:2px;background-color:var(--color-links);transition:width .3s ease;}
+    a:hover .site-title::after{width:100%;}
+  </style>
+</head>
+<body class="font-sans text-brand-charcoal antialiased bg-white overflow-x-hidden">
+  <header class="bg-white fixed top-0 left-0 right-0 w-full z-50 shadow-sm">
+    <div class="mx-auto max-w-7xl relative flex items-center justify-between px-6 py-3">
+      <a href="/" class="flex items-center gap-2">
+        <img src="/assets/logo.svg" alt="ScrapYardSites logo" class="h-6 w-6 md:h-8 md:w-8"/>
+        <span class="site-title text-xl md:text-2xl font-black tracking-tight"><span class="text-brand-orange">Scrapyard</span> Sites</span>
+      </a>
+      <nav class="hidden md:flex absolute left-1/2 -translate-x-1/2 justify-center items-center gap-8 text-sm font-medium">
+        <a href="/#why" class="hover:text-brand-orange">Why Us</a>
+        <a href="/pricing" class="hover:text-brand-orange">Pricing</a>
+        <a href="/contact" class="hover:text-brand-orange">Contact</a>
+        <a href="/risk-calculator" class="hover:text-brand-orange">Calculator</a>
+      </nav>
+      <div class="flex items-center gap-3">
+        <a href="/contact" class="inline-block rounded-md bg-brand-orange px-5 py-2 text-white font-semibold shadow hover:opacity-90 transition">Book a Call</a>
+      </div>
+    </div>
+  </header>
+  <main class="pt-24 pb-20 px-6 max-w-3xl mx-auto">
+    <h1 class="text-3xl font-bold mb-6">Demo Yard 1</h1>
+    <p class="text-brand-steel mb-4">Case study details coming soon.</p>
+    <a href="../" class="text-brand-orange underline">Back to portfolio</a>
+  </main>
+  <footer class="bg-white py-8 text-center text-xs text-gray-400">
+    <p>© <span id="year"></span> Scrapyard Sites — All rights reserved.</p>
+  </footer>
+  <script>document.getElementById('year').textContent=new Date().getFullYear();</script>
+</body>
+</html>

--- a/portfolio/demo-yard-2/index.html
+++ b/portfolio/demo-yard-2/index.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en" class="scroll-smooth overflow-x-hidden">
+<head>
+  <meta charset="UTF-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>Demo Yard 2 | Scrapyard Sites</title>
+  <link rel="icon" href="/assets/logo.png" sizes="any"/>
+  <link rel="mask-icon" href="/assets/logo.svg" color="#D75E02"/>
+  <link rel="apple-touch-icon" href="/assets/logo.png"/>
+  <script src="https://cdn.tailwindcss.com?plugins=typography"></script>
+  <script>
+    tailwind.config={theme:{extend:{fontFamily:{sans:['Inter','system-ui','sans-serif']},colors:{brand:{orange:'#D75E02',steel:'#5E6367',charcoal:'#2B2B2B'}}}}};
+  </script>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;900&display=swap" rel="stylesheet"/>
+  <style>
+    :root{--color-links:#D75E02;}
+    header nav a,#mobileMenu a:not(.bg-yellow-500){position:relative;text-decoration:none;}
+    header nav a:hover,#mobileMenu a:not(.bg-yellow-500):hover{color:currentColor!important;}
+    header nav a.text-yellow-400:hover{color:var(--color-links)!important;}
+    header nav a::after,#mobileMenu a:not(.bg-yellow-500)::after{content:'';position:absolute;left:0;bottom:-2px;width:0;height:2px;background-color:var(--color-links);transition:width .3s ease;}
+    header nav a:hover::after,#mobileMenu a:not(.bg-yellow-500):hover::after{width:100%;}
+    .site-title{position:relative;display:inline-block;}
+    .site-title::after{content:'';position:absolute;left:0;bottom:-2px;width:0;height:2px;background-color:var(--color-links);transition:width .3s ease;}
+    a:hover .site-title::after{width:100%;}
+  </style>
+</head>
+<body class="font-sans text-brand-charcoal antialiased bg-white overflow-x-hidden">
+  <header class="bg-white fixed top-0 left-0 right-0 w-full z-50 shadow-sm">
+    <div class="mx-auto max-w-7xl relative flex items-center justify-between px-6 py-3">
+      <a href="/" class="flex items-center gap-2">
+        <img src="/assets/logo.svg" alt="ScrapYardSites logo" class="h-6 w-6 md:h-8 md:w-8"/>
+        <span class="site-title text-xl md:text-2xl font-black tracking-tight"><span class="text-brand-orange">Scrapyard</span> Sites</span>
+      </a>
+      <nav class="hidden md:flex absolute left-1/2 -translate-x-1/2 justify-center items-center gap-8 text-sm font-medium">
+        <a href="/#why" class="hover:text-brand-orange">Why Us</a>
+        <a href="/pricing" class="hover:text-brand-orange">Pricing</a>
+        <a href="/contact" class="hover:text-brand-orange">Contact</a>
+        <a href="/risk-calculator" class="hover:text-brand-orange">Calculator</a>
+      </nav>
+      <div class="flex items-center gap-3">
+        <a href="/contact" class="inline-block rounded-md bg-brand-orange px-5 py-2 text-white font-semibold shadow hover:opacity-90 transition">Book a Call</a>
+      </div>
+    </div>
+  </header>
+  <main class="pt-24 pb-20 px-6 max-w-3xl mx-auto">
+    <h1 class="text-3xl font-bold mb-6">Demo Yard 2</h1>
+    <p class="text-brand-steel mb-4">Case study details coming soon.</p>
+    <a href="../" class="text-brand-orange underline">Back to portfolio</a>
+  </main>
+  <footer class="bg-white py-8 text-center text-xs text-gray-400">
+    <p>© <span id="year"></span> Scrapyard Sites — All rights reserved.</p>
+  </footer>
+  <script>document.getElementById('year').textContent=new Date().getFullYear();</script>
+</body>
+</html>

--- a/portfolio/demo-yard-3/index.html
+++ b/portfolio/demo-yard-3/index.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en" class="scroll-smooth overflow-x-hidden">
+<head>
+  <meta charset="UTF-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>Demo Yard 3 | Scrapyard Sites</title>
+  <link rel="icon" href="/assets/logo.png" sizes="any"/>
+  <link rel="mask-icon" href="/assets/logo.svg" color="#D75E02"/>
+  <link rel="apple-touch-icon" href="/assets/logo.png"/>
+  <script src="https://cdn.tailwindcss.com?plugins=typography"></script>
+  <script>
+    tailwind.config={theme:{extend:{fontFamily:{sans:['Inter','system-ui','sans-serif']},colors:{brand:{orange:'#D75E02',steel:'#5E6367',charcoal:'#2B2B2B'}}}}};
+  </script>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;900&display=swap" rel="stylesheet"/>
+  <style>
+    :root{--color-links:#D75E02;}
+    header nav a,#mobileMenu a:not(.bg-yellow-500){position:relative;text-decoration:none;}
+    header nav a:hover,#mobileMenu a:not(.bg-yellow-500):hover{color:currentColor!important;}
+    header nav a.text-yellow-400:hover{color:var(--color-links)!important;}
+    header nav a::after,#mobileMenu a:not(.bg-yellow-500)::after{content:'';position:absolute;left:0;bottom:-2px;width:0;height:2px;background-color:var(--color-links);transition:width .3s ease;}
+    header nav a:hover::after,#mobileMenu a:not(.bg-yellow-500):hover::after{width:100%;}
+    .site-title{position:relative;display:inline-block;}
+    .site-title::after{content:'';position:absolute;left:0;bottom:-2px;width:0;height:2px;background-color:var(--color-links);transition:width .3s ease;}
+    a:hover .site-title::after{width:100%;}
+  </style>
+</head>
+<body class="font-sans text-brand-charcoal antialiased bg-white overflow-x-hidden">
+  <header class="bg-white fixed top-0 left-0 right-0 w-full z-50 shadow-sm">
+    <div class="mx-auto max-w-7xl relative flex items-center justify-between px-6 py-3">
+      <a href="/" class="flex items-center gap-2">
+        <img src="/assets/logo.svg" alt="ScrapYardSites logo" class="h-6 w-6 md:h-8 md:w-8"/>
+        <span class="site-title text-xl md:text-2xl font-black tracking-tight"><span class="text-brand-orange">Scrapyard</span> Sites</span>
+      </a>
+      <nav class="hidden md:flex absolute left-1/2 -translate-x-1/2 justify-center items-center gap-8 text-sm font-medium">
+        <a href="/#why" class="hover:text-brand-orange">Why Us</a>
+        <a href="/pricing" class="hover:text-brand-orange">Pricing</a>
+        <a href="/contact" class="hover:text-brand-orange">Contact</a>
+        <a href="/risk-calculator" class="hover:text-brand-orange">Calculator</a>
+      </nav>
+      <div class="flex items-center gap-3">
+        <a href="/contact" class="inline-block rounded-md bg-brand-orange px-5 py-2 text-white font-semibold shadow hover:opacity-90 transition">Book a Call</a>
+      </div>
+    </div>
+  </header>
+  <main class="pt-24 pb-20 px-6 max-w-3xl mx-auto">
+    <h1 class="text-3xl font-bold mb-6">Demo Yard 3</h1>
+    <p class="text-brand-steel mb-4">Case study details coming soon.</p>
+    <a href="../" class="text-brand-orange underline">Back to portfolio</a>
+  </main>
+  <footer class="bg-white py-8 text-center text-xs text-gray-400">
+    <p>© <span id="year"></span> Scrapyard Sites — All rights reserved.</p>
+  </footer>
+  <script>document.getElementById('year').textContent=new Date().getFullYear();</script>
+</body>
+</html>

--- a/portfolio/index.html
+++ b/portfolio/index.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html lang="en" class="scroll-smooth overflow-x-hidden">
+<head>
+  <meta charset="UTF-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>Portfolio | Scrapyard Sites</title>
+  <link rel="icon" href="/assets/logo.png" sizes="any"/>
+  <link rel="mask-icon" href="/assets/logo.svg" color="#D75E02"/>
+  <link rel="apple-touch-icon" href="/assets/logo.png"/>
+  <script src="https://cdn.tailwindcss.com?plugins=typography"></script>
+  <script>
+    tailwind.config={theme:{extend:{fontFamily:{sans:['Inter','system-ui','sans-serif']},colors:{brand:{orange:'#D75E02',steel:'#5E6367',charcoal:'#2B2B2B'}}}}};
+  </script>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;900&display=swap" rel="stylesheet"/>
+  <style>
+    :root{--color-links:#D75E02;}
+    header nav a,#mobileMenu a:not(.bg-yellow-500){position:relative;text-decoration:none;}
+    header nav a:hover,#mobileMenu a:not(.bg-yellow-500):hover{color:currentColor!important;}
+    header nav a.text-yellow-400:hover{color:var(--color-links)!important;}
+    header nav a::after,#mobileMenu a:not(.bg-yellow-500)::after{content:'';position:absolute;left:0;bottom:-2px;width:0;height:2px;background-color:var(--color-links);transition:width .3s ease;}
+    header nav a:hover::after,#mobileMenu a:not(.bg-yellow-500):hover::after{width:100%;}
+    .site-title{position:relative;display:inline-block;}
+    .site-title::after{content:'';position:absolute;left:0;bottom:-2px;width:0;height:2px;background-color:var(--color-links);transition:width .3s ease;}
+    a:hover .site-title::after{width:100%;}
+  </style>
+</head>
+<body class="font-sans text-brand-charcoal antialiased bg-white overflow-x-hidden">
+  <header class="bg-white fixed top-0 left-0 right-0 w-full z-50 shadow-sm">
+    <div class="mx-auto max-w-7xl relative flex items-center justify-between px-6 py-3">
+      <a href="/" class="flex items-center gap-2">
+        <img src="/assets/logo.svg" alt="ScrapYardSites logo" class="h-6 w-6 md:h-8 md:w-8"/>
+        <span class="site-title text-xl md:text-2xl font-black tracking-tight"><span class="text-brand-orange">Scrapyard</span> Sites</span>
+      </a>
+      <nav class="hidden md:flex absolute left-1/2 -translate-x-1/2 justify-center items-center gap-8 text-sm font-medium">
+        <a href="/#why" class="hover:text-brand-orange">Why Us</a>
+        <a href="/pricing" class="hover:text-brand-orange">Pricing</a>
+        <a href="/contact" class="hover:text-brand-orange">Contact</a>
+        <a href="/risk-calculator" class="hover:text-brand-orange">Calculator</a>
+      </nav>
+      <div class="flex items-center gap-3">
+        <a href="/contact" class="inline-block rounded-md bg-brand-orange px-5 py-2 text-white font-semibold shadow hover:opacity-90 transition">Book a Call</a>
+      </div>
+    </div>
+  </header>
+  <main class="pt-24 pb-20 px-6">
+    <h1 class="text-3xl font-bold text-center mb-12">Our Portfolio</h1>
+    <div class="mx-auto max-w-6xl text-center">
+      <div class="grid gap-8 md:grid-cols-3">
+        <a href="demo-yard-1/" class="block bg-gray-50 border border-brand-steel/10 rounded-xl shadow-sm p-10 flex flex-col items-center text-center hover:bg-gray-100 hover:shadow-lg transition transform hover:-translate-y-1">
+          <div class="w-full rounded-xl overflow-hidden border border-brand-steel/10">
+            <img class="w-full" src="https://placehold.co/600x400/2B2B2B/FFFFFF?text=Demo+Yard+1" alt="Demo Yard 1">
+          </div>
+          <h2 class="font-semibold mt-4">Demo Yard 1</h2>
+          <p class="text-sm text-brand-steel mt-1">Custom design for a busy metro scrapyard.</p>
+        </a>
+        <a href="demo-yard-2/" class="block bg-gray-50 border border-brand-steel/10 rounded-xl shadow-sm p-10 flex flex-col items-center text-center hover:bg-gray-100 hover:shadow-lg transition transform hover:-translate-y-1">
+          <div class="w-full rounded-xl overflow-hidden border border-brand-steel/10">
+            <img class="w-full" src="https://placehold.co/600x400/2B2B2B/FFFFFF?text=Demo+Yard+2" alt="Demo Yard 2">
+          </div>
+          <h2 class="font-semibold mt-4">Demo Yard 2</h2>
+          <p class="text-sm text-brand-steel mt-1">Mobile friendly layout with fast quote form.</p>
+        </a>
+        <a href="demo-yard-3/" class="block bg-gray-50 border border-brand-steel/10 rounded-xl shadow-sm p-10 flex flex-col items-center text-center hover:bg-gray-100 hover:shadow-lg transition transform hover:-translate-y-1">
+          <div class="w-full rounded-xl overflow-hidden border border-brand-steel/10">
+            <img class="w-full" src="https://placehold.co/600x400/2B2B2B/FFFFFF?text=Demo+Yard+3" alt="Demo Yard 3">
+          </div>
+          <h2 class="font-semibold mt-4">Demo Yard 3</h2>
+          <p class="text-sm text-brand-steel mt-1">Highlighting services for industrial clients.</p>
+        </a>
+      </div>
+    </div>
+  </main>
+  <footer class="bg-white py-8 text-center text-xs text-gray-400">
+    <p>© <span id="year"></span> Scrapyard Sites — All rights reserved.</p>
+  </footer>
+  <script>document.getElementById('year').textContent=new Date().getFullYear();</script>
+</body>
+</html>

--- a/pricing/index.html
+++ b/pricing/index.html
@@ -1,0 +1,105 @@
+<!DOCTYPE html>
+<html lang="en" class="scroll-smooth overflow-x-hidden">
+<head>
+  <meta charset="UTF-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>Pricing | Scrapyard Sites</title>
+  <link rel="icon" href="/assets/logo.png" sizes="any"/>
+  <link rel="mask-icon" href="/assets/logo.svg" color="#D75E02"/>
+  <link rel="apple-touch-icon" href="/assets/logo.png"/>
+  <script src="https://cdn.tailwindcss.com?plugins=typography"></script>
+  <script>
+    tailwind.config={theme:{extend:{fontFamily:{sans:['Inter','system-ui','sans-serif']},colors:{brand:{orange:'#D75E02',steel:'#5E6367',charcoal:'#2B2B2B'}}}}};
+  </script>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;900&display=swap" rel="stylesheet"/>
+  <style>
+    :root{--color-links:#D75E02;}
+    header nav a,#mobileMenu a:not(.bg-yellow-500){position:relative;text-decoration:none;}
+    header nav a:hover,#mobileMenu a:not(.bg-yellow-500):hover{color:currentColor!important;}
+    header nav a.text-yellow-400:hover{color:var(--color-links)!important;}
+    header nav a::after,#mobileMenu a:not(.bg-yellow-500)::after{content:'';position:absolute;left:0;bottom:-2px;width:0;height:2px;background-color:var(--color-links);transition:width .3s ease;}
+    header nav a:hover::after,#mobileMenu a:not(.bg-yellow-500):hover::after{width:100%;}
+    .site-title{position:relative;display:inline-block;}
+    .site-title::after{content:'';position:absolute;left:0;bottom:-2px;width:0;height:2px;background-color:var(--color-links);transition:width .3s ease;}
+    a:hover .site-title::after{width:100%;}
+  </style>
+</head>
+<body class="font-sans text-brand-charcoal antialiased bg-white overflow-x-hidden">
+  <header class="bg-white fixed top-0 left-0 right-0 w-full z-50 shadow-sm">
+    <div class="mx-auto max-w-7xl relative flex items-center justify-between px-6 py-3">
+      <a href="/" class="flex items-center gap-2">
+        <img src="/assets/logo.svg" alt="ScrapYardSites logo" class="h-6 w-6 md:h-8 md:w-8"/>
+        <span class="site-title text-xl md:text-2xl font-black tracking-tight"><span class="text-brand-orange">Scrapyard</span> Sites</span>
+      </a>
+      <nav class="hidden md:flex absolute left-1/2 -translate-x-1/2 justify-center items-center gap-8 text-sm font-medium">
+        <a href="/#why" class="hover:text-brand-orange">Why Us</a>
+        <a href="/portfolio" class="hover:text-brand-orange">Portfolio</a>
+        <a href="/contact" class="hover:text-brand-orange">Contact</a>
+        <a href="/risk-calculator" class="hover:text-brand-orange">Calculator</a>
+      </nav>
+      <div class="flex items-center gap-3">
+        <a href="/contact" class="inline-block rounded-md bg-brand-orange px-5 py-2 text-white font-semibold shadow hover:opacity-90 transition">Book a Call</a>
+      </div>
+    </div>
+  </header>
+  <main class="pt-24 pb-20 px-6">
+    <section class="max-w-4xl mx-auto text-center">
+      <h1 class="text-3xl font-bold">Straight‑Shooter Pricing</h1>
+      <p class="mt-2 text-brand-steel max-w-xl mx-auto">No hidden fees, no “call for quote”. You’ll know the cost before we write a line of code.</p>
+      <div class="mt-14 grid gap-10 md:grid-cols-3">
+        <div class="relative bg-gray-50 border border-brand-steel/10 rounded-xl shadow-sm p-10">
+          <span class="absolute -top-4 left-1/2 -translate-x-1/2 bg-brand-orange text-white text-xs font-semibold px-3 py-1 rounded-full shadow">Most yards start here</span>
+          <h2 class="text-xl font-semibold mb-4">Standard Launch</h2>
+          <p class="text-5xl font-extrabold tracking-tight">$2,499</p>
+          <ul class="text-base md:text-sm text-brand-steel mt-6 space-y-2 text-left">
+            <li>&bull; One scrolling page, built mobile-first</li>
+            <li>&bull; Contact form straight to your inbox</li>
+            <li>&bull; Google Maps embed</li>
+            <li>&bull; Google Business Profile tune-up + basic SEO</li>
+            <li>&bull; 30 days of free tweaks</li>
+          </ul>
+        </div>
+        <div class="bg-gray-50 border border-brand-steel/10 rounded-xl shadow-sm p-10">
+          <h2 class="text-xl font-semibold mb-4">Premium Launch</h2>
+          <p class="text-5xl font-extrabold tracking-tight">$5,499</p>
+          <ul class="text-base md:text-sm text-brand-steel mt-6 space-y-2 text-left">
+            <li>&bull; Up to 8 pages (Home, Services, Locations, Contact, etc.)</li>
+            <li>&bull; Contact forms on every key page</li>
+            <li>&bull; Location pages with Google Maps</li>
+            <li>&bull; Structured-data SEO + GBP cleanup</li>
+            <li>&bull; 60 days of fine-tuning after go-live</li>
+          </ul>
+        </div>
+        <div class="bg-gray-50 border border-brand-steel/10 rounded-xl shadow-sm p-10">
+          <h2 class="text-xl font-semibold mb-4">Care Plan</h2>
+          <p class="text-5xl font-extrabold tracking-tight">$99<span class="text-2xl font-bold">/mo</span></p>
+          <ul class="text-base md:text-sm text-brand-steel mt-6 space-y-2 text-left">
+            <li>&bull; Unlimited text & photo updates (24 hour turnaround)</li>
+            <li>&bull; Security patches, backups, uptime checks</li>
+            <li>&bull; Quarterly performance report</li>
+            <li>&bull; Priority email support</li>
+          </ul>
+        </div>
+      </div>
+    </section>
+    <section class="mt-20 max-w-4xl mx-auto" id="faq">
+      <h2 class="text-3xl font-bold text-center mb-10">FAQ</h2>
+      <div class="space-y-6 text-center md:text-left">
+        <details class="group"><summary class="cursor-pointer font-semibold text-brand-charcoal group-open:text-brand-orange">How fast can my site go live?</summary><p class="mt-1 text-brand-steel text-base md:text-sm md:pl-4 md:border-l md:border-brand-orange/40">Seven calendar days from signed agreement and content hand-off.</p></details>
+        <details class="group"><summary class="cursor-pointer font-semibold text-brand-charcoal group-open:text-brand-orange">Do I own the domain and content?</summary><p class="mt-1 text-brand-steel text-base md:text-sm md:pl-4 md:border-l md:border-brand-orange/40">Yes. At launch the domain, copy, and images are 100% yours.</p></details>
+        <details class="group"><summary class="cursor-pointer font-semibold text-brand-charcoal group-open:text-brand-orange">Can I cancel the Care Plan?</summary><p class="mt-1 text-brand-steel text-base md:text-sm md:pl-4 md:border-l md:border-brand-orange/40">Anytime, no hard feelings—just email us and we’ll hand over full admin access.</p></details>
+        <details class="group"><summary class="cursor-pointer font-semibold text-brand-charcoal group-open:text-brand-orange">What do you need from me to start?</summary><p class="mt-1 text-brand-steel text-base md:text-sm md:pl-4 md:border-l md:border-brand-orange/40">Logo (if you have one), yard photos (phone pics are fine), and a brief call to nail your services, hours, and pricing flow.</p></details>
+        <details class="group"><summary class="cursor-pointer font-semibold text-brand-charcoal group-open:text-brand-orange">How do payments work?</summary><p class="mt-1 text-brand-steel text-base md:text-sm md:pl-4 md:border-l md:border-brand-orange/40">50% deposit to book your build week, 50% on launch day. Card, ACH, or check—whatever’s easiest.</p></details>
+        <details class="group"><summary class="cursor-pointer font-semibold text-brand-charcoal group-open:text-brand-orange">Is hosting included?</summary><p class="mt-1 text-brand-steel text-base md:text-sm md:pl-4 md:border-l md:border-brand-orange/40">Yes. Hosting, SSL, and domain hookup are baked into the $99/mo Care Plan. Prefer to self-host? We’ll deploy to your server for a one-time $199 hand-off.</p></details>
+        <details class="group"><summary class="cursor-pointer font-semibold text-brand-charcoal group-open:text-brand-orange">Can you add more pages later?</summary><p class="mt-1 text-brand-steel text-base md:text-sm md:pl-4 md:border-l md:border-brand-orange/40">Sure. Extra pages are $350 each or jump to Power-Launch if you need a larger build from the start.</p></details>
+        <details class="group"><summary class="cursor-pointer font-semibold text-brand-charcoal group-open:text-brand-orange">Will you write the copy and handle SEO?</summary><p class="mt-1 text-brand-steel text-base md:text-sm md:pl-4 md:border-l md:border-brand-orange/40">Absolutely. We draft the text, bake in industry keywords, and fine-tune meta tags so Google knows exactly what you buy and where you are.</p></details>
+        <details class="group"><summary class="cursor-pointer font-semibold text-brand-charcoal group-open:text-brand-orange">Do you shoot photos or video?</summary><p class="mt-1 text-brand-steel text-base md:text-sm md:pl-4 md:border-l md:border-brand-orange/40">We can—onsite photo/video packages start at $750 in the lower 48. Most yards start with their own shots and upgrade later.</p></details>
+      </div>
+    </section>
+  </main>
+  <footer class="bg-white py-8 text-center text-xs text-gray-400">
+    <p>© <span id="year"></span> Scrapyard Sites — All rights reserved.</p>
+  </footer>
+  <script>document.getElementById('year').textContent=new Date().getFullYear();</script>
+</body>
+</html>

--- a/process/index.html
+++ b/process/index.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html lang="en" class="scroll-smooth overflow-x-hidden">
+<head>
+  <meta charset="UTF-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>Our Process | Scrapyard Sites</title>
+  <link rel="icon" href="/assets/logo.png" sizes="any"/>
+  <link rel="mask-icon" href="/assets/logo.svg" color="#D75E02"/>
+  <link rel="apple-touch-icon" href="/assets/logo.png"/>
+  <script src="https://cdn.tailwindcss.com?plugins=typography"></script>
+  <script>
+    tailwind.config = {
+      theme: {
+        extend: {
+          fontFamily: { sans: ['Inter','system-ui','sans-serif'] },
+          colors: { brand:{ orange:'#D75E02', steel:'#5E6367', charcoal:'#2B2B2B' } }
+        }
+      }
+    };
+  </script>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;900&display=swap" rel="stylesheet"/>
+  <style>
+    :root { --color-links: #D75E02; }
+    header nav a, #mobileMenu a:not(.bg-yellow-500) { position: relative; text-decoration: none; }
+    header nav a:hover, #mobileMenu a:not(.bg-yellow-500):hover { color: currentColor !important; }
+    header nav a.text-yellow-400:hover { color: var(--color-links) !important; }
+    header nav a::after, #mobileMenu a:not(.bg-yellow-500)::after { content:''; position:absolute; left:0; bottom:-2px; width:0; height:2px; background-color:var(--color-links); transition:width .3s ease; }
+    header nav a:hover::after, #mobileMenu a:not(.bg-yellow-500):hover::after { width:100%; }
+    .site-title { position:relative; display:inline-block; }
+    .site-title::after { content:''; position:absolute; left:0; bottom:-2px; width:0; height:2px; background-color:var(--color-links); transition:width .3s ease; }
+    a:hover .site-title::after { width:100%; }
+  </style>
+</head>
+<body class="font-sans text-brand-charcoal antialiased bg-white overflow-x-hidden">
+  <header class="bg-white fixed top-0 left-0 right-0 w-full z-50 shadow-sm">
+    <div class="mx-auto max-w-7xl relative flex items-center justify-between px-6 py-3">
+      <a href="/" class="flex items-center gap-2">
+        <img src="/assets/logo.svg" alt="ScrapYardSites logo" class="h-6 w-6 md:h-8 md:w-8"/>
+        <span class="site-title text-xl md:text-2xl font-black tracking-tight"><span class="text-brand-orange">Scrapyard</span> Sites</span>
+      </a>
+      <nav class="hidden md:flex absolute left-1/2 -translate-x-1/2 justify-center items-center gap-8 text-sm font-medium">
+        <a href="/#why" class="hover:text-brand-orange">Why Us</a>
+        <a href="/portfolio" class="hover:text-brand-orange">Portfolio</a>
+        <a href="/pricing" class="hover:text-brand-orange">Pricing</a>
+        <a href="/contact" class="hover:text-brand-orange">Contact</a>
+        <a href="/risk-calculator" class="hover:text-brand-orange">Calculator</a>
+      </nav>
+      <div class="flex items-center gap-3">
+        <a href="/contact" class="inline-block rounded-md bg-brand-orange px-5 py-2 text-white font-semibold shadow hover:opacity-90 transition">Book a Call</a>
+      </div>
+    </div>
+  </header>
+  <main class="pt-24 pb-20 px-6">
+    <h1 class="text-3xl font-bold text-center mb-12">Our Process</h1>
+    <div class="mx-auto max-w-6xl text-center">
+      <div class="grid gap-10 md:grid-cols-3">
+        <div>
+          <div class="text-brand-orange text-6xl font-black" data-aos="fade-up" data-aos-delay="0">1</div>
+          <h2 class="font-semibold text-lg mt-3">Discovery Call</h2>
+          <p class="text-base md:text-sm text-brand-steel mt-1">15&nbsp;minutes to learn your yard, materials &amp; draw area.</p>
+        </div>
+        <div>
+          <div class="text-brand-orange text-6xl font-black" data-aos="fade-up" data-aos-delay="100">2</div>
+          <h2 class="font-semibold text-lg mt-3">Build Week</h2>
+          <p class="text-base md:text-sm text-brand-steel mt-1">We design, write and code. You review once—done.</p>
+        </div>
+        <div>
+          <div class="text-brand-orange text-6xl font-black" data-aos="fade-up" data-aos-delay="200">3</div>
+          <h2 class="font-semibold text-lg mt-3">Launch &amp; Maintain</h2>
+          <p class="text-base md:text-sm text-brand-steel mt-1">Site goes live, Google Business updated, $99/mo care plan kicks in.</p>
+        </div>
+      </div>
+    </div>
+  </main>
+  <footer class="bg-white py-8 text-center text-xs text-gray-400">
+    <p>© <span id="year"></span> Scrapyard Sites — All rights reserved.</p>
+  </footer>
+  <script>document.getElementById('year').textContent = new Date().getFullYear();</script>
+</body>
+</html>

--- a/risk-calculator/index.html
+++ b/risk-calculator/index.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html lang="en" class="scroll-smooth overflow-x-hidden">
+<head>
+  <meta charset="UTF-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>Loss Calculator | Scrapyard Sites</title>
+  <link rel="icon" href="/assets/logo.png" sizes="any"/>
+  <link rel="mask-icon" href="/assets/logo.svg" color="#D75E02"/>
+  <link rel="apple-touch-icon" href="/assets/logo.png"/>
+  <script src="https://cdn.tailwindcss.com?plugins=typography"></script>
+  <script>
+    tailwind.config={theme:{extend:{fontFamily:{sans:['Inter','system-ui','sans-serif']},colors:{brand:{orange:'#D75E02',steel:'#5E6367',charcoal:'#2B2B2B'}}}}};
+  </script>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;900&display=swap" rel="stylesheet"/>
+  <style>
+    :root{--color-links:#D75E02;}
+    header nav a,#mobileMenu a:not(.bg-yellow-500){position:relative;text-decoration:none;}
+    header nav a:hover,#mobileMenu a:not(.bg-yellow-500):hover{color:currentColor!important;}
+    header nav a.text-yellow-400:hover{color:var(--color-links)!important;}
+    header nav a::after,#mobileMenu a:not(.bg-yellow-500)::after{content:'';position:absolute;left:0;bottom:-2px;width:0;height:2px;background-color:var(--color-links);transition:width .3s ease;}
+    header nav a:hover::after,#mobileMenu a:not(.bg-yellow-500):hover::after{width:100%;}
+    .site-title{position:relative;display:inline-block;}
+    .site-title::after{content:'';position:absolute;left:0;bottom:-2px;width:0;height:2px;background-color:var(--color-links);transition:width .3s ease;}
+    a:hover .site-title::after{width:100%;}
+  </style>
+</head>
+<body class="font-sans text-brand-charcoal antialiased bg-white overflow-x-hidden">
+  <header class="bg-white fixed top-0 left-0 right-0 w-full z-50 shadow-sm">
+    <div class="mx-auto max-w-7xl relative flex items-center justify-between px-6 py-3">
+      <a href="/" class="flex items-center gap-2">
+        <img src="/assets/logo.svg" alt="ScrapYardSites logo" class="h-6 w-6 md:h-8 md:w-8"/>
+        <span class="site-title text-xl md:text-2xl font-black tracking-tight"><span class="text-brand-orange">Scrapyard</span> Sites</span>
+      </a>
+      <nav class="hidden md:flex absolute left-1/2 -translate-x-1/2 justify-center items-center gap-8 text-sm font-medium">
+        <a href="/#why" class="hover:text-brand-orange">Why Us</a>
+        <a href="/portfolio" class="hover:text-brand-orange">Portfolio</a>
+        <a href="/pricing" class="hover:text-brand-orange">Pricing</a>
+        <a href="/contact" class="hover:text-brand-orange">Contact</a>
+      </nav>
+      <div class="flex items-center gap-3">
+        <a href="/contact" class="inline-block rounded-md bg-brand-orange px-5 py-2 text-white font-semibold shadow hover:opacity-90 transition">Book a Call</a>
+      </div>
+    </div>
+  </header>
+  <main class="pt-24 pb-20 px-6">
+    <h1 class="text-3xl font-bold text-center mb-8">Loss Calculator</h1>
+    <div class="mx-auto max-w-md bg-gray-50 border border-brand-steel/10 rounded-xl p-6 shadow">
+      <label class="block mb-4">Missed loads per month
+        <input id="loads" type="number" class="mt-1 w-full rounded-md border border-brand-steel/20 px-3 py-2" />
+      </label>
+      <label class="block mb-4">Average revenue per load ($)
+        <input id="price" type="number" class="mt-1 w-full rounded-md border border-brand-steel/20 px-3 py-2" />
+      </label>
+      <button onclick="calc()" class="w-full rounded-md bg-brand-orange text-white font-semibold py-2">Calculate</button>
+      <p id="result" class="mt-4 font-bold text-brand-orange"></p>
+    </div>
+  </main>
+  <footer class="bg-white py-8 text-center text-xs text-gray-400">
+    <p>© <span id="year"></span> Scrapyard Sites — All rights reserved.</p>
+  </footer>
+  <script>
+    document.getElementById('year').textContent=new Date().getFullYear();
+    function calc(){
+      var loads=parseFloat(document.getElementById('loads').value)||0;
+      var price=parseFloat(document.getElementById('price').value)||0;
+      var loss=loads*price;
+      document.getElementById('result').textContent='Potential monthly loss: $'+loss.toLocaleString();
+    }
+  </script>
+</body>
+</html>

--- a/services/index.html
+++ b/services/index.html
@@ -1,0 +1,151 @@
+<!DOCTYPE html>
+<html lang="en" class="scroll-smooth overflow-x-hidden">
+<head>
+  <meta charset="UTF-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>Services | Scrapyard Sites</title>
+  <link rel="icon" href="/assets/logo.png" sizes="any"/>
+  <link rel="mask-icon" href="/assets/logo.svg" color="#D75E02"/>
+  <link rel="apple-touch-icon" href="/assets/logo.png"/>
+  <script src="https://cdn.tailwindcss.com?plugins=typography"></script>
+  <script>
+    tailwind.config = {
+      theme: {
+        extend: {
+          fontFamily: {
+            sans: ['Inter', 'system-ui', 'sans-serif']
+          },
+          colors: {
+            brand: {
+              orange: '#D75E02',
+              steel: '#5E6367',
+              charcoal: '#2B2B2B'
+            }
+          }
+        }
+      }
+    };
+  </script>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;900&display=swap" rel="stylesheet"/>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css"/>
+  <style>
+    :root {
+      --color-links: #D75E02;
+    }
+    header nav a,
+    #mobileMenu a:not(.bg-yellow-500) {
+      position: relative;
+      text-decoration: none;
+    }
+    header nav a:hover,
+    #mobileMenu a:not(.bg-yellow-500):hover {
+      color: currentColor !important;
+    }
+    header nav a.text-yellow-400:hover {
+      color: var(--color-links) !important;
+    }
+    header nav a::after,
+    #mobileMenu a:not(.bg-yellow-500)::after {
+      content: '';
+      position: absolute;
+      left: 0;
+      bottom: -2px;
+      width: 0;
+      height: 2px;
+      background-color: var(--color-links);
+      transition: width 0.3s ease;
+    }
+    header nav a:hover::after,
+    #mobileMenu a:not(.bg-yellow-500):hover::after {
+      width: 100%;
+    }
+    .site-title {
+      position: relative;
+      display: inline-block;
+    }
+    .site-title::after {
+      content: '';
+      position: absolute;
+      left: 0;
+      bottom: -2px;
+      width: 0;
+      height: 2px;
+      background-color: var(--color-links);
+      transition: width 0.3s ease;
+    }
+    a:hover .site-title::after {
+      width: 100%;
+    }
+  </style>
+</head>
+<body class="font-sans text-brand-charcoal antialiased bg-white overflow-x-hidden">
+  <header class="bg-white fixed top-0 left-0 right-0 w-full z-50 shadow-sm">
+    <div class="mx-auto max-w-7xl relative flex items-center justify-between px-6 py-3">
+      <a href="/" class="flex items-center gap-2">
+        <img src="/assets/logo.svg" alt="ScrapYardSites logo" class="h-6 w-6 md:h-8 md:w-8"/>
+        <span class="site-title text-xl md:text-2xl font-black tracking-tight">
+          <span class="text-brand-orange">Scrapyard</span> Sites
+        </span>
+      </a>
+      <nav class="hidden md:flex absolute left-1/2 -translate-x-1/2 justify-center items-center gap-8 text-sm font-medium">
+        <a href="/#why" class="hover:text-brand-orange">Why Us</a>
+        <a href="/portfolio" class="hover:text-brand-orange">Portfolio</a>
+        <a href="/pricing" class="hover:text-brand-orange">Pricing</a>
+        <a href="/contact" class="hover:text-brand-orange">Contact</a>
+        <a href="/risk-calculator" class="hover:text-brand-orange">Calculator</a>
+      </nav>
+      <div class="flex items-center gap-3">
+        <a href="/contact" class="inline-block rounded-md bg-brand-orange px-5 py-2 text-white font-semibold shadow hover:opacity-90 transition">
+          Book a Call
+        </a>
+      </div>
+    </div>
+  </header>
+  <main class="pt-24 pb-20 px-6">
+    <h1 class="text-3xl font-bold text-center mb-12">Our Services</h1>
+    <div class="mx-auto max-w-4xl text-center">
+      <div class="grid gap-10 md:grid-cols-3">
+        <div class="relative bg-gray-50 border border-brand-steel/10 rounded-xl shadow-sm p-10">
+          <span class="absolute -top-4 left-1/2 -translate-x-1/2 bg-brand-orange text-white text-xs font-semibold px-3 py-1 rounded-full shadow">Most yards start here</span>
+          <h2 class="text-xl font-semibold mb-4">Standard Launch</h2>
+          <p class="text-5xl font-extrabold tracking-tight">$2,499</p>
+          <ul class="text-base md:text-sm text-brand-steel mt-6 space-y-2 text-left">
+            <li>&bull; One scrolling page, built mobile-first</li>
+            <li>&bull; Contact form straight to your inbox</li>
+            <li>&bull; Google Maps embed</li>
+            <li>&bull; Google Business Profile tune-up + basic SEO</li>
+            <li>&bull; 30 days of free tweaks</li>
+          </ul>
+        </div>
+        <div class="bg-gray-50 border border-brand-steel/10 rounded-xl shadow-sm p-10">
+          <h2 class="text-xl font-semibold mb-4">Premium Launch</h2>
+          <p class="text-5xl font-extrabold tracking-tight">$5,499</p>
+          <ul class="text-base md:text-sm text-brand-steel mt-6 space-y-2 text-left">
+            <li>&bull; Up to 8 pages (Home, Services, Locations, Contact, etc.)</li>
+            <li>&bull; Contact forms on every key page</li>
+            <li>&bull; Location pages with Google Maps</li>
+            <li>&bull; Structured-data SEO + GBP cleanup</li>
+            <li>&bull; 60 days of fine-tuning after go-live</li>
+          </ul>
+        </div>
+        <div class="bg-gray-50 border border-brand-steel/10 rounded-xl shadow-sm p-10">
+          <h2 class="text-xl font-semibold mb-4">Care Plan</h2>
+          <p class="text-5xl font-extrabold tracking-tight">$99<span class="text-2xl font-bold">/mo</span></p>
+          <ul class="text-base md:text-sm text-brand-steel mt-6 space-y-2 text-left">
+            <li>&bull; Unlimited text & photo updates (24 hour turnaround)</li>
+            <li>&bull; Security patches, backups, uptime checks</li>
+            <li>&bull; Quarterly performance report</li>
+            <li>&bull; Priority email support</li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </main>
+  <footer class="bg-white py-8 text-center text-xs text-gray-400">
+    <p>© <span id="year"></span> Scrapyard Sites — All rights reserved.</p>
+  </footer>
+  <script>
+    document.getElementById('year').textContent = new Date().getFullYear();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- break out single-page anchors into standalone pages
- add Services page with plan details
- add Process page with discovery-build-launch steps
- add Portfolio grid with case study pages
- add Pricing page with full FAQ
- add Risk Calculator tool
- add Contact page with form, map and Calendly

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686abde8a33883299c4e818f153a9013