### PR TITLE
Add reputation risk calculator page

### DIFF
--- a/risk-calculator/index.html
+++ b/risk-calculator/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8"/>
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-  <title>Loss Calculator | Scrapyard Sites</title>
+  <title>Risk Calculator | Scrapyard Sites</title>
   <link rel="icon" href="/assets/logo.png" sizes="any"/>
   <link rel="mask-icon" href="/assets/logo.svg" color="#D75E02"/>
   <link rel="apple-touch-icon" href="/assets/logo.png"/>
@@ -36,20 +36,24 @@
         <a href="/portfolio" class="hover:text-brand-orange">Portfolio</a>
         <a href="/pricing" class="hover:text-brand-orange">Pricing</a>
         <a href="/contact" class="hover:text-brand-orange">Contact</a>
+        <a href="/risk-calculator" class="hover:text-brand-orange">Calculator</a>
       </nav>
       <div class="flex items-center gap-3">
         <a href="/contact" class="inline-block rounded-md bg-brand-orange px-5 py-2 text-white font-semibold shadow hover:opacity-90 transition">Book a Call</a>
       </div>
     </div>
   </header>
-  <main class="pt-24 pb-20 px-6">
-    <h1 class="text-3xl font-bold text-center mb-8">Loss Calculator</h1>
+  <main class="pt-24 pb-32 px-6">
+    <h1 class="text-3xl font-bold text-center mb-8">Reputation Risk Calculator</h1>
     <div class="mx-auto max-w-md bg-gray-50 border border-brand-steel/10 rounded-xl p-6 shadow">
-      <label class="block mb-4">Missed loads per month
-        <input id="loads" type="number" class="mt-1 w-full rounded-md border border-brand-steel/20 px-3 py-2" />
+      <label class="block mb-4">Average load weight (tons)
+        <input id="weight" type="number" step="0.1" class="mt-1 w-full rounded-md border border-brand-steel/20 px-3 py-2" />
       </label>
-      <label class="block mb-4">Average revenue per load ($)
-        <input id="price" type="number" class="mt-1 w-full rounded-md border border-brand-steel/20 px-3 py-2" />
+      <label class="block mb-4">Average margin ($/ton)
+        <input id="margin" type="number" step="0.01" class="mt-1 w-full rounded-md border border-brand-steel/20 px-3 py-2" />
+      </label>
+      <label class="block mb-4">Loads missed per month
+        <input id="missed" type="number" value="1" class="mt-1 w-full rounded-md border border-brand-steel/20 px-3 py-2" />
       </label>
       <button onclick="calc()" class="w-full rounded-md bg-brand-orange text-white font-semibold py-2">Calculate</button>
       <p id="result" class="mt-4 font-bold text-brand-orange"></p>
@@ -58,13 +62,17 @@
   <footer class="bg-white py-8 text-center text-xs text-gray-400">
     <p>© <span id="year"></span> Scrapyard Sites — All rights reserved.</p>
   </footer>
+  <div class="fixed bottom-0 left-0 right-0 bg-brand-orange text-white text-center py-3 z-40 shadow-md">
+    <a href="/contact" class="font-semibold hover:opacity-90">Book 15‑min Reputation Risk Scan</a>
+  </div>
   <script>
     document.getElementById('year').textContent=new Date().getFullYear();
     function calc(){
-      var loads=parseFloat(document.getElementById('loads').value)||0;
-      var price=parseFloat(document.getElementById('price').value)||0;
-      var loss=loads*price;
-      document.getElementById('result').textContent='Potential monthly loss: $'+loss.toLocaleString();
+      var weight=parseFloat(document.getElementById('weight').value)||0;
+      var margin=parseFloat(document.getElementById('margin').value)||0;
+      var missed=parseFloat(document.getElementById('missed').value)||1;
+      var loss=weight*margin*missed;
+      document.getElementById('result').textContent="That's $"+loss.toLocaleString(undefined,{maximumFractionDigits:0})+"/mo walking off your scale because drivers can't find or trust you online.";
     }
   </script>
 </body>


### PR DESCRIPTION
## Summary
- update `/risk-calculator` to compute monthly losses based on load weight, margin and missed loads
- include sticky CTA to book a reputation risk scan

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686ac0b0975083299289704f73eadc47