### PR TITLE
Enhance risk calculator UI and results

### DIFF
--- a/risk-calculator/index.html
+++ b/risk-calculator/index.html
@@ -46,7 +46,8 @@
     </div>
   </header>
   <main class="pt-24 pb-32 px-6">
-    <h1 class="text-3xl font-bold text-center mb-8">Reputation Risk Calculator</h1>
+    <h1 class="text-3xl font-bold text-center mb-4">Reputation Risk Calculator</h1>
+    <p class="text-center text-brand-steel mb-8">Every missed call is metal on your competitor’s scale. Run the numbers—see what procrastination costs.</p>
     <div class="mx-auto max-w-md bg-gray-50 border border-brand-steel/10 rounded-xl p-6 shadow">
       <label class="block mb-4">Average load weight (tons)
         <input id="weight" type="number" step="0.1" class="mt-1 w-full rounded-md border border-brand-steel/20 px-3 py-2" />
@@ -58,13 +59,20 @@
         <input id="missed" type="number" value="1" class="mt-1 w-full rounded-md border border-brand-steel/20 px-3 py-2" />
       </label>
       <button onclick="calc()" class="w-full rounded-md bg-brand-orange text-white font-semibold py-2">Calculate</button>
-      <p id="result" class="mt-4 font-bold text-brand-orange"></p>
+      <div id="result" class="mt-6 text-center hidden">
+        <p id="loss" class="font-bold text-brand-orange text-lg"></p>
+        <p id="days" class="font-bold text-brand-orange"></p>
+        <p class="mt-2 text-brand-steel italic text-sm">That’s one forklift you could have paid off—or one raise you could have given your scale operator.</p>
+      </div>
     </div>
   </main>
   <footer class="bg-white py-8 text-center text-xs text-gray-400">
     <p>© <span id="year"></span> Scrapyard Sites — All rights reserved.</p>
   </footer>
-  <div class="fixed bottom-0 left-0 right-0 bg-brand-orange text-white text-center py-3 z-40 shadow-md">
+  <div id="cta" class="hidden fixed top-1/2 right-0 -translate-y-1/2 z-40 pr-4">
+    <a id="ctaLink" href="/contact" class="block bg-brand-orange text-white font-semibold px-4 py-2 rounded-l-md shadow hover:opacity-90">Patch My Leak</a>
+  </div>
+  <div class="fixed bottom-0 left-0 right-0 bg-brand-orange text-white text-center py-3 z-30 shadow-md">
     <a href="/contact" class="font-semibold hover:opacity-90">Book 15‑min Reputation Risk Scan</a>
   </div>
   <script>
@@ -73,8 +81,15 @@
       var weight=parseFloat(document.getElementById('weight').value)||0;
       var margin=parseFloat(document.getElementById('margin').value)||0;
       var missed=parseFloat(document.getElementById('missed').value)||1;
-      var loss=weight*margin*missed;
-      document.getElementById('result').textContent="That's $"+loss.toLocaleString(undefined,{maximumFractionDigits:0})+"/mo walking off your scale because drivers can't find or trust you online.";
+      var monthly=weight*margin*missed;
+      var annual=monthly*12;
+      var days=monthly>0?Math.ceil((2499)/(monthly/30)):0;
+      document.getElementById('loss').textContent='Annual lost profit $'+annual.toLocaleString(undefined,{maximumFractionDigits:0});
+      document.getElementById('days').textContent='Days until a Standard Launch pays for itself '+days+' days';
+      document.getElementById('result').classList.remove('hidden');
+      var link=document.getElementById('ctaLink');
+      link.href='/contact?leak=$'+annual.toLocaleString(undefined,{maximumFractionDigits:0});
+      document.getElementById('cta').classList.remove('hidden');
     }
   </script>
 </body>


### PR DESCRIPTION
## Summary
- add lead-in text explaining missed call losses
- display annual lost profit and ROI days with emotional follow up
- show "Patch My Leak" sticky CTA linking to contact page

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_686acdde4d088329a04195448807eb54