### PR TITLE
Enhance pricing info with risk messaging

### DIFF
--- a/pricing/index.html
+++ b/pricing/index.html
@@ -41,7 +41,7 @@
         <a href="/risk-calculator" class="hover:text-brand-orange">Calculator</a>
       </nav>
       <div class="flex items-center gap-3">
-        <a href="/contact" class="inline-block rounded-md bg-brand-orange px-5 py-2 text-white font-semibold shadow hover:opacity-90 transition">Book a Call</a>
+        <a href="/contact" class="inline-block rounded-md bg-brand-orange px-5 py-2 text-white font-semibold shadow hover:opacity-90 transition">Stop the Bleed—Reserve Build Week</a>
       </div>
     </div>
   </header>
@@ -49,6 +49,9 @@
     <section class="max-w-4xl mx-auto text-center">
       <h1 class="text-3xl font-bold">Straight‑Shooter Pricing</h1>
       <p class="mt-2 text-brand-steel max-w-xl mx-auto">No hidden fees, no “call for quote”. You’ll know the cost before we write a line of code.</p>
+      <div class="mt-6 bg-brand-orange text-white font-semibold px-4 py-3 rounded-md">
+        One missed roll-off a month (~$8k margin) &gt; Standard Launch fee. Doing nothing is the most expensive option.
+      </div>
       <div class="mt-14 grid gap-10 md:grid-cols-3">
         <div class="relative bg-gray-50 border border-brand-steel/10 rounded-xl shadow-sm p-10">
           <span class="absolute -top-4 left-1/2 -translate-x-1/2 bg-brand-orange text-white text-xs font-semibold px-3 py-1 rounded-full shadow">Most yards start here</span>
@@ -61,6 +64,7 @@
             <li>&bull; Google Business Profile tune-up + basic SEO</li>
             <li>&bull; 30 days of free tweaks</li>
           </ul>
+          <p class="mt-4 text-xs font-semibold text-brand-orange">If inbound calls don’t rise in 90 days, we rebuild free until they do.</p>
         </div>
         <div class="bg-gray-50 border border-brand-steel/10 rounded-xl shadow-sm p-10">
           <h2 class="text-xl font-semibold mb-4">Premium Launch</h2>
@@ -72,6 +76,7 @@
             <li>&bull; Structured-data SEO + GBP cleanup</li>
             <li>&bull; 60 days of fine-tuning after go-live</li>
           </ul>
+          <p class="mt-4 text-xs font-semibold text-brand-orange">If inbound calls don’t rise in 90 days, we rebuild free until they do.</p>
         </div>
         <div class="bg-gray-50 border border-brand-steel/10 rounded-xl shadow-sm p-10">
           <h2 class="text-xl font-semibold mb-4">Care Plan</h2>
@@ -82,7 +87,31 @@
             <li>&bull; Quarterly performance report</li>
             <li>&bull; Priority email support</li>
           </ul>
+          <p class="mt-4 text-xs font-semibold text-brand-orange">If inbound calls don’t rise in 90 days, we rebuild free until they do.</p>
         </div>
+      </div>
+      <div class="mt-10">
+        <table class="w-full text-sm text-center border-collapse">
+          <thead>
+            <tr>
+              <th class="py-2"></th>
+              <th class="py-2 font-semibold">Standard Launch</th>
+              <th class="py-2 font-semibold">Do Nothing</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr class="border-t">
+              <td class="py-2 font-semibold text-left">12-month cash flow</td>
+              <td class="py-2 text-green-700 font-bold">+$93,501</td>
+              <td class="py-2 text-red-600 font-bold">-$96,000</td>
+            </tr>
+            <tr class="border-t">
+              <td class="py-2 font-semibold text-left">Site ownership</td>
+              <td class="py-2">100% yours</td>
+              <td class="py-2">Competitor owns your customers</td>
+            </tr>
+          </tbody>
+        </table>
       </div>
     </section>
     <section class="mt-20 max-w-4xl mx-auto" id="faq">


### PR DESCRIPTION
## Summary
- update CTA text for urgency
- call out the cost of inaction
- show action vs inaction table
- show guarantee next to each tier

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_686acdc870048329a104ff5d262f929e