### PR TITLE
Add trust stack and FAQ to contact page

### DIFF
--- a/contact/index.html
+++ b/contact/index.html
@@ -49,6 +49,12 @@
     <h1 class="text-3xl font-bold text-center mb-8">Get in Touch</h1>
     <div class="mx-auto max-w-4xl text-center">
       <p class="mt-2 text-brand-steel">Fill the form or call <a href="tel:9493568762" class="underline">949‑356‑8762</a>.</p>
+      <ul class="mt-6 text-base md:text-sm text-brand-steel space-y-2 text-left max-w-md mx-auto">
+        <li>• Confidentiality pledge: We never share competitive intel.</li>
+        <li>• No‑pitch promise: 15&nbsp;minutes max. Hang up whenever—no hard feelings.</li>
+        <li>• Owner time guarantee: Elias answers personally or buys you lunch.</li>
+        <li>• Prefer text? SMS <a href="sms:9493568762" class="underline">949‑356‑8762</a> “STOP BLEED”—we’ll reply within 15&nbsp;min.</li>
+      </ul>
       <form action="https://formspree.io/f/yourID" method="POST" class="mt-10 grid gap-6">
         <input type="text" name="name" required placeholder="Name" class="w-full rounded-md px-4 py-3 bg-white border border-brand-steel/20 text-brand-charcoal" />
         <input type="email" name="email" required placeholder="Email" class="w-full rounded-md px-4 py-3 bg-white border border-brand-steel/20 text-brand-charcoal" />
@@ -63,6 +69,13 @@
         <iframe src="https://calendly.com/your-calendar" class="w-full h-[630px]"></iframe>
       </div>
     </div>
+    <section class="mt-20 max-w-4xl mx-auto" id="faq">
+      <h2 class="text-3xl font-bold text-center mb-10">FAQ</h2>
+      <div class="space-y-6 text-center md:text-left">
+        <details class="group"><summary class="cursor-pointer font-semibold text-brand-charcoal group-open:text-brand-orange">What happens after I hit send?</summary><p class="mt-1 text-brand-steel text-base md:text-sm md:pl-4 md:border-l md:border-brand-orange/40">We'll reply within 15 minutes to confirm details and schedule your call. No spam.</p></details>
+        <details class="group"><summary class="cursor-pointer font-semibold text-brand-charcoal group-open:text-brand-orange">Can we just get the price?</summary><p class="mt-1 text-brand-steel text-base md:text-sm md:pl-4 md:border-l md:border-brand-orange/40">Of course. No hidden fees, no “call for quote.” You’ll know the cost before we write a line of code.</p></details>
+      </div>
+    </section>
   </main>
   <footer class="bg-white py-8 text-center text-xs text-gray-400">
     <p>© <span id="year"></span> Scrapyard Sites — All rights reserved.</p>


### PR DESCRIPTION
## Summary
- add bullet list trust stack under contact headline
- add mini FAQ answering next steps and pricing transparency

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686acdf063c483298e2509564197656b