### PR TITLE
Apply global nav and head template

### DIFF
--- a/contact/index.html
+++ b/contact/index.html
@@ -2,11 +2,10 @@
 <html lang="en" class="scroll-smooth overflow-x-hidden">
 <head>
   <meta charset="UTF-8"/>
-  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <link rel="preload" href="/assets/fonts/Inter-Variable.woff2" as="font" type="font/woff2" crossorigin>
   <title>Contact | Scrapyard Sites</title>
-  <link rel="icon" href="/assets/logo.png" sizes="any"/>
-  <link rel="mask-icon" href="/assets/logo.svg" color="#D75E02"/>
-  <link rel="apple-touch-icon" href="/assets/logo.png"/>
+  <link rel="icon" href="/favicon.svg"> <!-- prevents 404s on mobile -->
   <script src="https://cdn.tailwindcss.com?plugins=typography"></script>
   <script>
     tailwind.config={theme:{extend:{fontFamily:{sans:['Inter','system-ui','sans-serif']},colors:{brand:{orange:'#D75E02',steel:'#5E6367',charcoal:'#2B2B2B'}}}}};
@@ -25,26 +24,29 @@
   </style>
 </head>
 <body class="font-sans text-brand-charcoal antialiased bg-white overflow-x-hidden">
-  <header class="bg-white fixed top-0 left-0 right-0 w-full z-50 shadow-sm">
-    <div class="mx-auto max-w-7xl relative flex items-center justify-between px-6 py-3">
-      <a href="/" class="flex items-center gap-2">
-        <img src="/assets/logo.svg" alt="ScrapYardSites logo" class="h-6 w-6 md:h-8 md:w-8"/>
-        <span class="site-title text-xl md:text-2xl font-black tracking-tight"><span class="text-brand-orange">Scrapyard</span> Sites</span>
-      </a>
-      <nav class="hidden md:flex absolute left-1/2 -translate-x-1/2 justify-center items-center gap-8 text-sm font-medium">
-        <a href="/#why" class="text-brand-steel hover:text-brand-orange" title="Leaking here? ->">Why Us</a>
-        <a href="/portfolio" class="text-brand-steel hover:text-brand-orange" title="Leaking here? ->">Portfolio</a>
-        <a href="/pricing" class="text-brand-steel hover:text-brand-orange" title="Leaking here? ->">Pricing</a>
-        <a href="/services" class="text-brand-steel hover:text-brand-orange" title="Leaking here? ->">Services</a>
-        <a href="/process" class="text-brand-steel hover:text-brand-orange" title="Leaking here? ->">Process</a>
-        <a href="/contact" class="text-brand-steel hover:text-brand-orange" title="Leaking here? ->">Contact</a>
-        <a href="/risk-calculator" class="text-brand-steel hover:text-brand-orange" title="Leaking here? ->">Calculator</a>
-      </nav>
-      <div class="flex items-center gap-3">
-        <a href="/contact" class="group inline-block rounded-md bg-brand-orange px-5 py-2 text-white font-semibold shadow hover:opacity-90 transition"><span class="group-hover:hidden">Keep Leaking ▸</span><span class="hidden group-hover:inline">Stop It ✓</span></a>
-      </div>
-    </div>
+  <header class="sticky top-0 z-50 bg-white shadow-sm">
+    <nav class="container flex items-center justify-between py-3">
+      <a href="/" class="text-xl font-bold">Scrapyard Sites</a>
+      <!-- Mobile hamburger (≤ 768 px) -->
+      <button id="menuToggle" class="md:hidden p-2">
+        <svg class="w-6 h-6" viewBox="0 0 24 24" fill="none"><path d="M3 6h18M3 12h18M3 18h18" stroke="currentColor" stroke-width="2"/></svg>
+      </button>
+      <!-- Desktop links -->
+      <ul id="menu" class="hidden md:flex gap-6 text-sm font-medium">
+        <li><a href="/services">Services</a></li>
+        <li><a href="/process">Process</a></li>
+        <li><a href="/portfolio">Portfolio</a></li>
+        <li><a href="/pricing">Pricing</a></li>
+        <li><a href="/risk-calculator">Calculator</a></li>
+        <li><a href="/contact" class="btn-primary">Book Call</a></li>
+      </ul>
+    </nav>
   </header>
+  <script>
+  /* basic mobile toggle */
+  document.getElementById('menuToggle')
+    ?.addEventListener('click', () => document.getElementById('menu').classList.toggle('hidden'));
+  </script>
   <main class="pt-24 pb-20 px-6">
     <h1 class="text-3xl font-bold text-center mb-8">Get in Touch</h1>
     <div class="mx-auto max-w-4xl text-center">

--- a/index.html
+++ b/index.html
@@ -2,7 +2,8 @@
 <html lang="en" class="scroll-smooth overflow-x-hidden">
 <head>
   <meta charset="UTF-8"/>
-  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <link rel="preload" href="/assets/fonts/Inter-Variable.woff2" as="font" type="font/woff2" crossorigin>
   <title>Scrapyard Sites | More leads. More loads.</title>
   <meta name="description"
         content="Launch a high-converting website for your scrap or recycling yard in 7 days. $2,499 build, $99/mo care. Turn clicks into trucks-at-the-scale."/>
@@ -11,10 +12,7 @@
   <meta property="og:image" content="assets/hero.jpg"/>
   <meta name="thumbnail" content="assets/thumbnail.jpg"/>
   <meta property="og:type" content="website"/>
-  <!-- Favicon -->
-  <link rel="icon" href="assets/logo.png" sizes="any"/>
-  <link rel="mask-icon" href="assets/logo.svg" color="#D75E02"/>
-  <link rel="apple-touch-icon" href="assets/logo.png"/>
+  <link rel="icon" href="/favicon.svg"> <!-- prevents 404s on mobile -->
   <!--  Tailwind 3 CDN  -->
   <script src="https://cdn.tailwindcss.com"></script>
   <script>
@@ -119,28 +117,29 @@
 <body class="font-sans text-brand-charcoal antialiased bg-white overflow-x-hidden">
 
 <!-- ── Header ─────────────────────────────────────────────── -->
-  <header class="bg-white fixed top-0 left-0 right-0 w-full z-50 shadow-sm">
-    <div class="mx-auto max-w-7xl relative flex items-center justify-between px-6 py-3">
-    <a href="#top" class="flex items-center gap-2">
-      <img src="assets/logo.svg" alt="ScrapYardSites logo" class="h-6 w-6 md:h-8 md:w-8"/>
-      <span class="site-title text-xl md:text-2xl font-black tracking-tight">
-        <span class="text-brand-orange">Scrapyard</span> Sites
-      </span>
-    </a>
-      <nav class="hidden md:flex absolute left-1/2 -translate-x-1/2 justify-center items-center gap-8 text-sm font-medium">
-        <a href="#why" class="text-brand-steel hover:text-brand-orange" title="Leaking here? ->">Why Us</a>
-        <a href="/portfolio" class="text-brand-steel hover:text-brand-orange" title="Leaking here? ->">Portfolio</a>
-        <a href="/pricing" class="text-brand-steel hover:text-brand-orange" title="Leaking here? ->">Pricing</a>
-        <a href="/services" class="text-brand-steel hover:text-brand-orange" title="Leaking here? ->">Services</a>
-        <a href="/process" class="text-brand-steel hover:text-brand-orange" title="Leaking here? ->">Process</a>
-        <a href="/contact" class="text-brand-steel hover:text-brand-orange" title="Leaking here? ->">Contact</a>
-        <a href="/risk-calculator" class="text-brand-steel hover:text-brand-orange" title="Leaking here? ->">Calculator</a>
-      </nav>
-      <div class="flex items-center gap-3">
-        <a href="/contact" class="group inline-block rounded-md bg-brand-orange px-5 py-2 text-white font-semibold shadow hover:opacity-90 transition"><span class="group-hover:hidden">Keep Leaking ▸</span><span class="hidden group-hover:inline">Stop It ✓</span></a>
-      </div>
-  </div>
-</header>
+  <header class="sticky top-0 z-50 bg-white shadow-sm">
+    <nav class="container flex items-center justify-between py-3">
+      <a href="/" class="text-xl font-bold">Scrapyard Sites</a>
+      <!-- Mobile hamburger (≤ 768 px) -->
+      <button id="menuToggle" class="md:hidden p-2">
+        <svg class="w-6 h-6" viewBox="0 0 24 24" fill="none"><path d="M3 6h18M3 12h18M3 18h18" stroke="currentColor" stroke-width="2"/></svg>
+      </button>
+      <!-- Desktop links -->
+      <ul id="menu" class="hidden md:flex gap-6 text-sm font-medium">
+        <li><a href="/services">Services</a></li>
+        <li><a href="/process">Process</a></li>
+        <li><a href="/portfolio">Portfolio</a></li>
+        <li><a href="/pricing">Pricing</a></li>
+        <li><a href="/risk-calculator">Calculator</a></li>
+        <li><a href="/contact" class="btn-primary">Book Call</a></li>
+      </ul>
+    </nav>
+  </header>
+  <script>
+  /* basic mobile toggle */
+  document.getElementById('menuToggle')
+    ?.addEventListener('click', () => document.getElementById('menu').classList.toggle('hidden'));
+  </script>
 
 <!-- ── Hero ───────────────────────────────────────────────── -->
 <section id="top"

--- a/portfolio/index.html
+++ b/portfolio/index.html
@@ -2,11 +2,10 @@
 <html lang="en" class="scroll-smooth overflow-x-hidden">
 <head>
   <meta charset="UTF-8"/>
-  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <link rel="preload" href="/assets/fonts/Inter-Variable.woff2" as="font" type="font/woff2" crossorigin>
   <title>Portfolio | Scrapyard Sites</title>
-  <link rel="icon" href="/assets/logo.png" sizes="any"/>
-  <link rel="mask-icon" href="/assets/logo.svg" color="#D75E02"/>
-  <link rel="apple-touch-icon" href="/assets/logo.png"/>
+  <link rel="icon" href="/favicon.svg"> <!-- prevents 404s on mobile -->
   <script src="https://cdn.tailwindcss.com?plugins=typography"></script>
   <script>
     tailwind.config={theme:{extend:{fontFamily:{sans:['Inter','system-ui','sans-serif']},colors:{brand:{orange:'#D75E02',steel:'#5E6367',charcoal:'#2B2B2B'}}}}};
@@ -25,26 +24,29 @@
   </style>
 </head>
 <body class="font-sans text-brand-charcoal antialiased bg-white overflow-x-hidden">
-  <header class="bg-white fixed top-0 left-0 right-0 w-full z-50 shadow-sm">
-    <div class="mx-auto max-w-7xl relative flex items-center justify-between px-6 py-3">
-      <a href="/" class="flex items-center gap-2">
-        <img src="/assets/logo.svg" alt="ScrapYardSites logo" class="h-6 w-6 md:h-8 md:w-8"/>
-        <span class="site-title text-xl md:text-2xl font-black tracking-tight"><span class="text-brand-orange">Scrapyard</span> Sites</span>
-      </a>
-      <nav class="hidden md:flex absolute left-1/2 -translate-x-1/2 justify-center items-center gap-8 text-sm font-medium">
-        <a href="/#why" class="text-brand-steel hover:text-brand-orange" title="Leaking here? ->">Why Us</a>
-        <a href="/portfolio" class="text-brand-steel hover:text-brand-orange" title="Leaking here? ->">Portfolio</a>
-        <a href="/pricing" class="text-brand-steel hover:text-brand-orange" title="Leaking here? ->">Pricing</a>
-        <a href="/services" class="text-brand-steel hover:text-brand-orange" title="Leaking here? ->">Services</a>
-        <a href="/process" class="text-brand-steel hover:text-brand-orange" title="Leaking here? ->">Process</a>
-        <a href="/contact" class="text-brand-steel hover:text-brand-orange" title="Leaking here? ->">Contact</a>
-        <a href="/risk-calculator" class="text-brand-steel hover:text-brand-orange" title="Leaking here? ->">Calculator</a>
-      </nav>
-      <div class="flex items-center gap-3">
-        <a href="/contact" class="group inline-block rounded-md bg-brand-orange px-5 py-2 text-white font-semibold shadow hover:opacity-90 transition"><span class="group-hover:hidden">Keep Leaking ▸</span><span class="hidden group-hover:inline">Stop It ✓</span></a>
-      </div>
-    </div>
+  <header class="sticky top-0 z-50 bg-white shadow-sm">
+    <nav class="container flex items-center justify-between py-3">
+      <a href="/" class="text-xl font-bold">Scrapyard Sites</a>
+      <!-- Mobile hamburger (≤ 768 px) -->
+      <button id="menuToggle" class="md:hidden p-2">
+        <svg class="w-6 h-6" viewBox="0 0 24 24" fill="none"><path d="M3 6h18M3 12h18M3 18h18" stroke="currentColor" stroke-width="2"/></svg>
+      </button>
+      <!-- Desktop links -->
+      <ul id="menu" class="hidden md:flex gap-6 text-sm font-medium">
+        <li><a href="/services">Services</a></li>
+        <li><a href="/process">Process</a></li>
+        <li><a href="/portfolio">Portfolio</a></li>
+        <li><a href="/pricing">Pricing</a></li>
+        <li><a href="/risk-calculator">Calculator</a></li>
+        <li><a href="/contact" class="btn-primary">Book Call</a></li>
+      </ul>
+    </nav>
   </header>
+  <script>
+  /* basic mobile toggle */
+  document.getElementById('menuToggle')
+    ?.addEventListener('click', () => document.getElementById('menu').classList.toggle('hidden'));
+  </script>
   <main class="pt-24 pb-20 px-6">
     <h1 class="text-3xl font-bold text-center mb-12">Our Portfolio</h1>
     <div class="mx-auto max-w-6xl text-center">

--- a/pricing/index.html
+++ b/pricing/index.html
@@ -2,11 +2,10 @@
 <html lang="en" class="scroll-smooth overflow-x-hidden">
 <head>
   <meta charset="UTF-8"/>
-  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <link rel="preload" href="/assets/fonts/Inter-Variable.woff2" as="font" type="font/woff2" crossorigin>
   <title>Pricing | Scrapyard Sites</title>
-  <link rel="icon" href="/assets/logo.png" sizes="any"/>
-  <link rel="mask-icon" href="/assets/logo.svg" color="#D75E02"/>
-  <link rel="apple-touch-icon" href="/assets/logo.png"/>
+  <link rel="icon" href="/favicon.svg"> <!-- prevents 404s on mobile -->
   <script src="https://cdn.tailwindcss.com?plugins=typography"></script>
   <script>
     tailwind.config={theme:{extend:{fontFamily:{sans:['Inter','system-ui','sans-serif']},colors:{brand:{orange:'#D75E02',steel:'#5E6367',charcoal:'#2B2B2B'}}}}};
@@ -25,26 +24,29 @@
   </style>
 </head>
 <body class="font-sans text-brand-charcoal antialiased bg-white overflow-x-hidden">
-  <header class="bg-white fixed top-0 left-0 right-0 w-full z-50 shadow-sm">
-    <div class="mx-auto max-w-7xl relative flex items-center justify-between px-6 py-3">
-      <a href="/" class="flex items-center gap-2">
-        <img src="/assets/logo.svg" alt="ScrapYardSites logo" class="h-6 w-6 md:h-8 md:w-8"/>
-        <span class="site-title text-xl md:text-2xl font-black tracking-tight"><span class="text-brand-orange">Scrapyard</span> Sites</span>
-      </a>
-      <nav class="hidden md:flex absolute left-1/2 -translate-x-1/2 justify-center items-center gap-8 text-sm font-medium">
-        <a href="/#why" class="text-brand-steel hover:text-brand-orange" title="Leaking here? ->">Why Us</a>
-        <a href="/portfolio" class="text-brand-steel hover:text-brand-orange" title="Leaking here? ->">Portfolio</a>
-        <a href="/pricing" class="text-brand-steel hover:text-brand-orange" title="Leaking here? ->">Pricing</a>
-        <a href="/services" class="text-brand-steel hover:text-brand-orange" title="Leaking here? ->">Services</a>
-        <a href="/process" class="text-brand-steel hover:text-brand-orange" title="Leaking here? ->">Process</a>
-        <a href="/contact" class="text-brand-steel hover:text-brand-orange" title="Leaking here? ->">Contact</a>
-        <a href="/risk-calculator" class="text-brand-steel hover:text-brand-orange" title="Leaking here? ->">Calculator</a>
-      </nav>
-      <div class="flex items-center gap-3">
-        <a href="/contact" class="group inline-block rounded-md bg-brand-orange px-5 py-2 text-white font-semibold shadow hover:opacity-90 transition"><span class="group-hover:hidden">Keep Leaking ▸</span><span class="hidden group-hover:inline">Stop It ✓</span></a>
-      </div>
-    </div>
+  <header class="sticky top-0 z-50 bg-white shadow-sm">
+    <nav class="container flex items-center justify-between py-3">
+      <a href="/" class="text-xl font-bold">Scrapyard Sites</a>
+      <!-- Mobile hamburger (≤ 768 px) -->
+      <button id="menuToggle" class="md:hidden p-2">
+        <svg class="w-6 h-6" viewBox="0 0 24 24" fill="none"><path d="M3 6h18M3 12h18M3 18h18" stroke="currentColor" stroke-width="2"/></svg>
+      </button>
+      <!-- Desktop links -->
+      <ul id="menu" class="hidden md:flex gap-6 text-sm font-medium">
+        <li><a href="/services">Services</a></li>
+        <li><a href="/process">Process</a></li>
+        <li><a href="/portfolio">Portfolio</a></li>
+        <li><a href="/pricing">Pricing</a></li>
+        <li><a href="/risk-calculator">Calculator</a></li>
+        <li><a href="/contact" class="btn-primary">Book Call</a></li>
+      </ul>
+    </nav>
   </header>
+  <script>
+  /* basic mobile toggle */
+  document.getElementById('menuToggle')
+    ?.addEventListener('click', () => document.getElementById('menu').classList.toggle('hidden'));
+  </script>
   <main class="pt-24 pb-20 px-6">
     <section class="max-w-4xl mx-auto text-center">
       <h1 class="text-3xl font-bold">Straight‑Shooter Pricing</h1>

--- a/privacy/index.html
+++ b/privacy/index.html
@@ -2,11 +2,10 @@
 <html lang="en" class="scroll-smooth overflow-x-hidden">
 <head>
   <meta charset="UTF-8"/>
-  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <link rel="preload" href="/assets/fonts/Inter-Variable.woff2" as="font" type="font/woff2" crossorigin>
   <title>Privacy Policy | Scrapyard Sites</title>
-  <link rel="icon" href="/assets/logo.png" sizes="any"/>
-  <link rel="mask-icon" href="/assets/logo.svg" color="#D75E02"/>
-  <link rel="apple-touch-icon" href="/assets/logo.png"/>
+  <link rel="icon" href="/favicon.svg"> <!-- prevents 404s on mobile -->
   <script src="https://cdn.tailwindcss.com?plugins=typography"></script>
   <script>
     tailwind.config = {
@@ -90,28 +89,29 @@
 </style>
 </head>
 <body class="font-sans text-brand-charcoal antialiased bg-white overflow-x-hidden">
-  <header class="bg-white fixed top-0 left-0 right-0 w-full z-50 shadow-sm">
-    <div class="mx-auto max-w-7xl relative flex items-center justify-between px-6 py-3">
-      <a href="/" class="flex items-center gap-2">
-        <img src="/assets/logo.svg" alt="ScrapYardSites logo" class="h-6 w-6 md:h-8 md:w-8"/>
-        <span class="site-title text-xl md:text-2xl font-black tracking-tight">
-          <span class="text-brand-orange">Scrapyard</span> Sites
-        </span>
-      </a>
-      <nav class="hidden md:flex absolute left-1/2 -translate-x-1/2 justify-center items-center gap-8 text-sm font-medium">
-        <a href="/#why" class="text-brand-steel hover:text-brand-orange" title="Leaking here? ->">Why Us</a>
-        <a href="/portfolio" class="text-brand-steel hover:text-brand-orange" title="Leaking here? ->">Portfolio</a>
-        <a href="/pricing" class="text-brand-steel hover:text-brand-orange" title="Leaking here? ->">Pricing</a>
-        <a href="/services" class="text-brand-steel hover:text-brand-orange" title="Leaking here? ->">Services</a>
-        <a href="/process" class="text-brand-steel hover:text-brand-orange" title="Leaking here? ->">Process</a>
-        <a href="/contact" class="text-brand-steel hover:text-brand-orange" title="Leaking here? ->">Contact</a>
-        <a href="/risk-calculator" class="text-brand-steel hover:text-brand-orange" title="Leaking here? ->">Calculator</a>
-      </nav>
-      <div class="flex items-center gap-3">
-        <a href="/contact" class="group inline-block rounded-md bg-brand-orange px-5 py-2 text-white font-semibold shadow hover:opacity-90 transition"><span class="group-hover:hidden">Keep Leaking ▸</span><span class="hidden group-hover:inline">Stop It ✓</span></a>
-      </div>
-    </div>
+  <header class="sticky top-0 z-50 bg-white shadow-sm">
+    <nav class="container flex items-center justify-between py-3">
+      <a href="/" class="text-xl font-bold">Scrapyard Sites</a>
+      <!-- Mobile hamburger (≤ 768 px) -->
+      <button id="menuToggle" class="md:hidden p-2">
+        <svg class="w-6 h-6" viewBox="0 0 24 24" fill="none"><path d="M3 6h18M3 12h18M3 18h18" stroke="currentColor" stroke-width="2"/></svg>
+      </button>
+      <!-- Desktop links -->
+      <ul id="menu" class="hidden md:flex gap-6 text-sm font-medium">
+        <li><a href="/services">Services</a></li>
+        <li><a href="/process">Process</a></li>
+        <li><a href="/portfolio">Portfolio</a></li>
+        <li><a href="/pricing">Pricing</a></li>
+        <li><a href="/risk-calculator">Calculator</a></li>
+        <li><a href="/contact" class="btn-primary">Book Call</a></li>
+      </ul>
+    </nav>
   </header>
+  <script>
+  /* basic mobile toggle */
+  document.getElementById('menuToggle')
+    ?.addEventListener('click', () => document.getElementById('menu').classList.toggle('hidden'));
+  </script>
   <main class="max-w-3xl mx-auto pt-24 pb-20 px-6 prose prose-a:text-brand-orange">
     <h1 class="text-3xl font-bold mb-4">Privacy Policy</h1>
     <p class="mb-4"><strong>Effective Date: 4&nbsp;July&nbsp;2025</strong></p>

--- a/process/index.html
+++ b/process/index.html
@@ -2,11 +2,10 @@
 <html lang="en" class="scroll-smooth overflow-x-hidden">
 <head>
   <meta charset="UTF-8"/>
-  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <link rel="preload" href="/assets/fonts/Inter-Variable.woff2" as="font" type="font/woff2" crossorigin>
   <title>Our Process | Scrapyard Sites</title>
-  <link rel="icon" href="/assets/logo.png" sizes="any"/>
-  <link rel="mask-icon" href="/assets/logo.svg" color="#D75E02"/>
-  <link rel="apple-touch-icon" href="/assets/logo.png"/>
+  <link rel="icon" href="/favicon.svg"> <!-- prevents 404s on mobile -->
   <script src="https://cdn.tailwindcss.com?plugins=typography"></script>
   <script>
     tailwind.config = {
@@ -32,26 +31,29 @@
   </style>
 </head>
 <body class="font-sans text-brand-charcoal antialiased bg-white overflow-x-hidden">
-  <header class="bg-white fixed top-0 left-0 right-0 w-full z-50 shadow-sm">
-    <div class="mx-auto max-w-7xl relative flex items-center justify-between px-6 py-3">
-      <a href="/" class="flex items-center gap-2">
-        <img src="/assets/logo.svg" alt="ScrapYardSites logo" class="h-6 w-6 md:h-8 md:w-8"/>
-        <span class="site-title text-xl md:text-2xl font-black tracking-tight"><span class="text-brand-orange">Scrapyard</span> Sites</span>
-      </a>
-      <nav class="hidden md:flex absolute left-1/2 -translate-x-1/2 justify-center items-center gap-8 text-sm font-medium">
-        <a href="/#why" class="text-brand-steel hover:text-brand-orange" title="Leaking here? ->">Why Us</a>
-        <a href="/portfolio" class="text-brand-steel hover:text-brand-orange" title="Leaking here? ->">Portfolio</a>
-        <a href="/pricing" class="text-brand-steel hover:text-brand-orange" title="Leaking here? ->">Pricing</a>
-        <a href="/services" class="text-brand-steel hover:text-brand-orange" title="Leaking here? ->">Services</a>
-        <a href="/process" class="text-brand-steel hover:text-brand-orange" title="Leaking here? ->">Process</a>
-        <a href="/contact" class="text-brand-steel hover:text-brand-orange" title="Leaking here? ->">Contact</a>
-        <a href="/risk-calculator" class="text-brand-steel hover:text-brand-orange" title="Leaking here? ->">Calculator</a>
-      </nav>
-      <div class="flex items-center gap-3">
-        <a href="/contact" class="group inline-block rounded-md bg-brand-orange px-5 py-2 text-white font-semibold shadow hover:opacity-90 transition"><span class="group-hover:hidden">Keep Leaking ▸</span><span class="hidden group-hover:inline">Stop It ✓</span></a>
-      </div>
-    </div>
+  <header class="sticky top-0 z-50 bg-white shadow-sm">
+    <nav class="container flex items-center justify-between py-3">
+      <a href="/" class="text-xl font-bold">Scrapyard Sites</a>
+      <!-- Mobile hamburger (≤ 768 px) -->
+      <button id="menuToggle" class="md:hidden p-2">
+        <svg class="w-6 h-6" viewBox="0 0 24 24" fill="none"><path d="M3 6h18M3 12h18M3 18h18" stroke="currentColor" stroke-width="2"/></svg>
+      </button>
+      <!-- Desktop links -->
+      <ul id="menu" class="hidden md:flex gap-6 text-sm font-medium">
+        <li><a href="/services">Services</a></li>
+        <li><a href="/process">Process</a></li>
+        <li><a href="/portfolio">Portfolio</a></li>
+        <li><a href="/pricing">Pricing</a></li>
+        <li><a href="/risk-calculator">Calculator</a></li>
+        <li><a href="/contact" class="btn-primary">Book Call</a></li>
+      </ul>
+    </nav>
   </header>
+  <script>
+  /* basic mobile toggle */
+  document.getElementById('menuToggle')
+    ?.addEventListener('click', () => document.getElementById('menu').classList.toggle('hidden'));
+  </script>
   <main class="pt-24 pb-20 px-6">
     <h1 class="text-3xl font-bold text-center mb-2">Our Process</h1>
     <p class="text-brand-steel text-center text-lg md:text-xl mb-12">From Ghost-Site to Google-Proof in 7 Calendar Days—Guaranteed.</p>

--- a/risk-calculator/index.html
+++ b/risk-calculator/index.html
@@ -2,11 +2,10 @@
 <html lang="en" class="scroll-smooth overflow-x-hidden">
 <head>
   <meta charset="UTF-8"/>
-  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <link rel="preload" href="/assets/fonts/Inter-Variable.woff2" as="font" type="font/woff2" crossorigin>
   <title>Risk Calculator | Scrapyard Sites</title>
-  <link rel="icon" href="/assets/logo.png" sizes="any"/>
-  <link rel="mask-icon" href="/assets/logo.svg" color="#D75E02"/>
-  <link rel="apple-touch-icon" href="/assets/logo.png"/>
+  <link rel="icon" href="/favicon.svg"> <!-- prevents 404s on mobile -->
   <script src="https://cdn.tailwindcss.com?plugins=typography"></script>
   <script>
     tailwind.config={theme:{extend:{fontFamily:{sans:['Inter','system-ui','sans-serif']},colors:{brand:{orange:'#D75E02',steel:'#5E6367',charcoal:'#2B2B2B'}}}}};
@@ -25,26 +24,29 @@
   </style>
 </head>
 <body class="font-sans text-brand-charcoal antialiased bg-white overflow-x-hidden">
-  <header class="bg-white fixed top-0 left-0 right-0 w-full z-50 shadow-sm">
-    <div class="mx-auto max-w-7xl relative flex items-center justify-between px-6 py-3">
-      <a href="/" class="flex items-center gap-2">
-        <img src="/assets/logo.svg" alt="ScrapYardSites logo" class="h-6 w-6 md:h-8 md:w-8"/>
-        <span class="site-title text-xl md:text-2xl font-black tracking-tight"><span class="text-brand-orange">Scrapyard</span> Sites</span>
-      </a>
-      <nav class="hidden md:flex absolute left-1/2 -translate-x-1/2 justify-center items-center gap-8 text-sm font-medium">
-        <a href="/#why" class="text-brand-steel hover:text-brand-orange" title="Leaking here? ->">Why Us</a>
-        <a href="/portfolio" class="text-brand-steel hover:text-brand-orange" title="Leaking here? ->">Portfolio</a>
-        <a href="/pricing" class="text-brand-steel hover:text-brand-orange" title="Leaking here? ->">Pricing</a>
-        <a href="/services" class="text-brand-steel hover:text-brand-orange" title="Leaking here? ->">Services</a>
-        <a href="/process" class="text-brand-steel hover:text-brand-orange" title="Leaking here? ->">Process</a>
-        <a href="/contact" class="text-brand-steel hover:text-brand-orange" title="Leaking here? ->">Contact</a>
-        <a href="/risk-calculator" class="text-brand-steel hover:text-brand-orange" title="Leaking here? ->">Calculator</a>
-      </nav>
-      <div class="flex items-center gap-3">
-        <a href="/contact" class="group inline-block rounded-md bg-brand-orange px-5 py-2 text-white font-semibold shadow hover:opacity-90 transition"><span class="group-hover:hidden">Keep Leaking ▸</span><span class="hidden group-hover:inline">Stop It ✓</span></a>
-      </div>
-    </div>
+  <header class="sticky top-0 z-50 bg-white shadow-sm">
+    <nav class="container flex items-center justify-between py-3">
+      <a href="/" class="text-xl font-bold">Scrapyard Sites</a>
+      <!-- Mobile hamburger (≤ 768 px) -->
+      <button id="menuToggle" class="md:hidden p-2">
+        <svg class="w-6 h-6" viewBox="0 0 24 24" fill="none"><path d="M3 6h18M3 12h18M3 18h18" stroke="currentColor" stroke-width="2"/></svg>
+      </button>
+      <!-- Desktop links -->
+      <ul id="menu" class="hidden md:flex gap-6 text-sm font-medium">
+        <li><a href="/services">Services</a></li>
+        <li><a href="/process">Process</a></li>
+        <li><a href="/portfolio">Portfolio</a></li>
+        <li><a href="/pricing">Pricing</a></li>
+        <li><a href="/risk-calculator">Calculator</a></li>
+        <li><a href="/contact" class="btn-primary">Book Call</a></li>
+      </ul>
+    </nav>
   </header>
+  <script>
+  /* basic mobile toggle */
+  document.getElementById('menuToggle')
+    ?.addEventListener('click', () => document.getElementById('menu').classList.toggle('hidden'));
+  </script>
   <main class="pt-24 pb-32 px-6">
     <h1 class="text-3xl font-bold text-center mb-4">Reputation Risk Calculator</h1>
     <p class="text-center text-brand-steel mb-8">Every missed call is metal on your competitor’s scale. Run the numbers—see what procrastination costs.</p>

--- a/services/index.html
+++ b/services/index.html
@@ -2,11 +2,10 @@
 <html lang="en" class="scroll-smooth overflow-x-hidden">
 <head>
   <meta charset="UTF-8"/>
-  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <link rel="preload" href="/assets/fonts/Inter-Variable.woff2" as="font" type="font/woff2" crossorigin>
   <title>Services | Scrapyard Sites</title>
-  <link rel="icon" href="/assets/logo.png" sizes="any"/>
-  <link rel="mask-icon" href="/assets/logo.svg" color="#D75E02"/>
-  <link rel="apple-touch-icon" href="/assets/logo.png"/>
+  <link rel="icon" href="/favicon.svg"> <!-- prevents 404s on mobile -->
   <script src="https://cdn.tailwindcss.com?plugins=typography"></script>
   <script>
     tailwind.config = {
@@ -79,28 +78,29 @@
   </style>
 </head>
 <body class="font-sans text-brand-charcoal antialiased bg-white overflow-x-hidden">
-  <header class="bg-white fixed top-0 left-0 right-0 w-full z-50 shadow-sm">
-    <div class="mx-auto max-w-7xl relative flex items-center justify-between px-6 py-3">
-      <a href="/" class="flex items-center gap-2">
-        <img src="/assets/logo.svg" alt="ScrapYardSites logo" class="h-6 w-6 md:h-8 md:w-8"/>
-        <span class="site-title text-xl md:text-2xl font-black tracking-tight">
-          <span class="text-brand-orange">Scrapyard</span> Sites
-        </span>
-      </a>
-      <nav class="hidden md:flex absolute left-1/2 -translate-x-1/2 justify-center items-center gap-8 text-sm font-medium">
-        <a href="/#why" class="text-brand-steel hover:text-brand-orange" title="Leaking here? ->">Why Us</a>
-        <a href="/portfolio" class="text-brand-steel hover:text-brand-orange" title="Leaking here? ->">Portfolio</a>
-        <a href="/pricing" class="text-brand-steel hover:text-brand-orange" title="Leaking here? ->">Pricing</a>
-        <a href="/services" class="text-brand-steel hover:text-brand-orange" title="Leaking here? ->">Services</a>
-        <a href="/process" class="text-brand-steel hover:text-brand-orange" title="Leaking here? ->">Process</a>
-        <a href="/contact" class="text-brand-steel hover:text-brand-orange" title="Leaking here? ->">Contact</a>
-        <a href="/risk-calculator" class="text-brand-steel hover:text-brand-orange" title="Leaking here? ->">Calculator</a>
-      </nav>
-      <div class="flex items-center gap-3">
-        <a href="/contact" class="group inline-block rounded-md bg-brand-orange px-5 py-2 text-white font-semibold shadow hover:opacity-90 transition"><span class="group-hover:hidden">Keep Leaking ▸</span><span class="hidden group-hover:inline">Stop It ✓</span></a>
-      </div>
-    </div>
+  <header class="sticky top-0 z-50 bg-white shadow-sm">
+    <nav class="container flex items-center justify-between py-3">
+      <a href="/" class="text-xl font-bold">Scrapyard Sites</a>
+      <!-- Mobile hamburger (≤ 768 px) -->
+      <button id="menuToggle" class="md:hidden p-2">
+        <svg class="w-6 h-6" viewBox="0 0 24 24" fill="none"><path d="M3 6h18M3 12h18M3 18h18" stroke="currentColor" stroke-width="2"/></svg>
+      </button>
+      <!-- Desktop links -->
+      <ul id="menu" class="hidden md:flex gap-6 text-sm font-medium">
+        <li><a href="/services">Services</a></li>
+        <li><a href="/process">Process</a></li>
+        <li><a href="/portfolio">Portfolio</a></li>
+        <li><a href="/pricing">Pricing</a></li>
+        <li><a href="/risk-calculator">Calculator</a></li>
+        <li><a href="/contact" class="btn-primary">Book Call</a></li>
+      </ul>
+    </nav>
   </header>
+  <script>
+  /* basic mobile toggle */
+  document.getElementById('menuToggle')
+    ?.addEventListener('click', () => document.getElementById('menu').classList.toggle('hidden'));
+  </script>
   <main class="pt-24 pb-20 px-6">
     <h1 class="text-3xl font-bold text-center">Four Shields That Stop Revenue Bleed</h1>
     <p class="text-center text-brand-steel mt-2 mb-12">They work together—or not at all—so we bundle them.</p>


### PR DESCRIPTION
## Summary
- use global head snippet with viewport, preloaded font and favicon
- replace headers with mobile-friendly navigation

## Testing
- `grep -n "basic mobile toggle" -R *.html */*.html`


------
https://chatgpt.com/codex/tasks/task_e_686ad3f10afc8329b74a0583dd565d6e