### PR TITLE
Update pricing page

### DIFF
--- a/pricing/index.html
+++ b/pricing/index.html
@@ -48,73 +48,43 @@
     ?.addEventListener('click', () => document.getElementById('menu').classList.toggle('hidden'));
   </script>
   <main class="pt-24 pb-20 px-6">
-    <section class="max-w-4xl mx-auto text-center">
-      <h1 class="text-3xl font-bold">Straight‑Shooter Pricing</h1>
-      <p class="mt-2 text-brand-steel max-w-xl mx-auto">No hidden fees, no “call for quote”. You’ll know the cost before we write a line of code.</p>
-      <div class="mt-6 bg-brand-orange text-white font-semibold px-4 py-3 rounded-md">
-        One missed roll-off a month (~$8k margin) &gt; Standard Launch fee. Doing nothing is the most expensive option.
+    <section class="py-16 bg-gray-50">
+      <div class="container text-center">
+        <h1 class="text-3xl font-bold">Straight‑Shooter Pricing</h1>
+        <p class="mt-2 text-sm">
+          One missed roll‑off a month (~<strong>$8 k</strong>) costs more than our Standard Launch.
+          Doing nothing is the most expensive option.
+        </p>
       </div>
-      <div class="mt-14 grid gap-10 md:grid-cols-3">
-        <div class="relative bg-gray-50 border border-brand-steel/10 rounded-xl shadow-sm p-10">
-          <span class="absolute -top-4 left-1/2 -translate-x-1/2 bg-brand-orange text-white text-xs font-semibold px-3 py-1 rounded-full shadow">Most yards start here</span>
-          <h2 class="text-xl font-semibold mb-4">Standard Launch</h2>
-          <p class="text-5xl font-extrabold tracking-tight">$2,499</p>
-          <ul class="text-base md:text-sm text-brand-steel mt-6 space-y-2 text-left">
-            <li>&bull; Quick fix that stops missed-call bleed—for yards losing business right now.</li>
-            <li>&bull; Contact form straight to your inbox</li>
-            <li>&bull; Google Maps embed</li>
-            <li>&bull; Google Business Profile tune-up + basic SEO</li>
-            <li>&bull; 30 days of free tweaks</li>
+
+      <!-- Packages -->
+      <div class="container grid md:grid-cols-2 gap-8 mt-12">
+        <!-- Standard -->
+        <article class="pricing-card">
+          <h2 class="pricing-title">Standard Launch</h2>
+          <p class="pricing-price">$2,499</p>
+          <ul class="pricing-list">
+            <li>3‑page build & quick quote form</li>
+            <li>Google Maps embed + GBP tune‑up</li>
+            <li>30‑day fine‑tune window</li>
           </ul>
-          <p class="mt-4 text-xs font-semibold text-brand-orange">If inbound calls don’t rise in 90 days, we rebuild free until they do.</p>
-        </div>
-        <div class="bg-gray-50 border border-brand-steel/10 rounded-xl shadow-sm p-10">
-          <h2 class="text-xl font-semibold mb-4">Premium Launch</h2>
-          <p class="text-5xl font-extrabold tracking-tight">$5,499</p>
-          <ul class="text-base md:text-sm text-brand-steel mt-6 space-y-2 text-left">
-            <li>&bull; Full insurance policy: multi-page muscle so Google never buries you again.</li>
-            <li>&bull; Contact forms on every key page</li>
-            <li>&bull; Location pages with Google Maps</li>
-            <li>&bull; Structured-data SEO + GBP cleanup</li>
-            <li>&bull; 60 days of fine-tuning after go-live</li>
+          <a href="/contact" class="btn-primary">Stop the Bleed →</a>
+        </article>
+
+        <!-- Premium -->
+        <article class="pricing-card">
+          <h2 class="pricing-title">Premium Launch</h2>
+          <p class="pricing-price">$5,499</p>
+          <ul class="pricing-list">
+            <li>Multi‑page muscle + location pages</li>
+            <li>Structured data & advanced SEO</li>
+            <li>60‑day fine‑tune window</li>
           </ul>
-          <p class="mt-4 text-xs font-semibold text-brand-orange">If inbound calls don’t rise in 90 days, we rebuild free until they do.</p>
-        </div>
-        <div class="bg-gray-50 border border-brand-steel/10 rounded-xl shadow-sm p-10">
-          <h2 class="text-xl font-semibold mb-4">Care Plan</h2>
-          <p class="text-5xl font-extrabold tracking-tight">$99<span class="text-2xl font-bold">/mo</span></p>
-          <ul class="text-base md:text-sm text-brand-steel mt-6 space-y-2 text-left">
-            <li>&bull; Unlimited text & photo updates (24 hour turnaround)</li>
-            <li>&bull; Security patches, backups, uptime checks</li>
-            <li>&bull; Quarterly performance report</li>
-            <li>&bull; Priority email support</li>
-          </ul>
-          <p class="mt-4 text-xs font-semibold text-brand-orange">If inbound calls don’t rise in 90 days, we rebuild free until they do.</p>
-        </div>
+          <a href="/contact" class="btn-primary">Own the Market →</a>
+        </article>
       </div>
-      <div class="mt-10">
-        <table class="w-full text-sm text-center border-collapse">
-          <thead>
-            <tr>
-              <th class="py-2"></th>
-              <th class="py-2 font-semibold">Standard Launch</th>
-              <th class="py-2 font-semibold">Do Nothing</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr class="border-t">
-              <td class="py-2 font-semibold text-left">12-month cash flow</td>
-              <td class="py-2 text-green-700 font-bold">+$93,501</td>
-              <td class="py-2 text-red-600 font-bold">-$96,000</td>
-            </tr>
-            <tr class="border-t">
-              <td class="py-2 font-semibold text-left">Site ownership</td>
-              <td class="py-2">100% yours</td>
-              <td class="py-2">Competitor owns your customers</td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
+
+      <!-- FAQ stays below packages -->
     </section>
     <section class="mt-20 max-w-4xl mx-auto" id="faq">
       <h2 class="text-3xl font-bold text-center mb-10">FAQ</h2>


### PR DESCRIPTION
## Summary
- replace Pricing page header
- add cost-of-inaction pricing section with standard and premium packages

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686ad606f14c8329880b2291a097a574