### PR TITLE
Add trust stack bullet list to contact forms

### DIFF
--- a/contact/index.html
+++ b/contact/index.html
@@ -48,14 +48,13 @@
     ?.addEventListener('click', () => document.getElementById('menu').classList.toggle('hidden'));
   </script>
   <main class="pt-24 pb-20 px-6">
-    <h1 class="text-3xl font-bold text-center mb-8">Get in Touch</h1>
+    <h1 class="text-3xl font-bold text-center mb-8">Cap the Leak in 15&nbsp;Minutes or Less</h1>
     <div class="mx-auto max-w-4xl text-center">
       <p class="mt-2 text-brand-steel">Fill the form or call <a href="tel:9493568762" class="underline">949‑356‑8762</a>.</p>
-      <ul class="mt-6 text-base md:text-sm text-brand-steel space-y-2 text-left max-w-md mx-auto">
-        <li>• Confidentiality pledge: We never share competitive intel.</li>
-        <li>• No‑pitch promise: 15&nbsp;minutes max. Hang up whenever—no hard feelings.</li>
-        <li>• Owner time guarantee: Elias answers personally or buys you lunch.</li>
-        <li>• Prefer text? SMS <a href="sms:9493568762" class="underline">949‑356‑8762</a> “STOP BLEED”—we’ll reply within 15&nbsp;min.</li>
+      <ul class="mt-6 text-sm space-y-2">
+        <li>🚫 <strong>No spam.</strong> Your email never hits a CRM.</li>
+        <li>🤐 <strong>Confidential.</strong> We don’t share competitive intel.</li>
+        <li>⏱ <strong>15&nbsp;minutes max.</strong> Hang up any time—no hard feelings.</li>
       </ul>
       <form action="https://formspree.io/f/yourID" method="POST" class="mt-10 grid gap-6">
         <input type="text" name="name" required placeholder="Name" class="w-full rounded-md px-4 py-3 bg-white border border-brand-steel/20 text-brand-charcoal" />
@@ -64,6 +63,7 @@
         <textarea name="message" rows="4" placeholder="Tell us what you need…" class="w-full rounded-md px-4 py-3 bg-white border border-brand-steel/20 text-brand-charcoal"></textarea>
         <button type="submit" class="rounded-md bg-brand-orange px-8 py-3 font-semibold text-white shadow hover:opacity-90 transition">Send →</button>
       </form>
+      <p class="text-center text-sm mt-6">Prefer immediate answers? <a href="tel:+19493568762" class="underline">Call 949‑356‑8762</a></p>
       <div class="mt-10">
         <iframe class="w-full h-64" loading="lazy" allowfullscreen src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d10000!2d-97.7431!3d30.2672"></iframe>
       </div>

--- a/index.html
+++ b/index.html
@@ -296,6 +296,11 @@
       <p class="mt-2 text-brand-steel text-base md:text-sm">
         Fill the form below or call <a href="tel:9493568762" class="underline">949‑356‑8762</a>.
       </p>
+      <ul class="mt-6 text-sm space-y-2">
+        <li>🚫 <strong>No spam.</strong> Your email never hits a CRM.</li>
+        <li>🤐 <strong>Confidential.</strong> We don’t share competitive intel.</li>
+        <li>⏱ <strong>15&nbsp;minutes max.</strong> Hang up any time—no hard feelings.</li>
+      </ul>
 
     <form action="https://formspree.io/f/yourID" method="POST"
           class="mt-10 grid gap-6">
@@ -312,6 +317,7 @@
         Send →
       </button>
     </form>
+    <p class="text-center text-sm mt-6">Prefer immediate answers? <a href="tel:+19493568762" class="underline">Call 949‑356‑8762</a></p>
     <p class="mt-4 text-xs text-brand-steel">
         By submitting you agree to our <a href="/privacy" class="underline">privacy policy</a>. No spam—ever.
     </p>


### PR DESCRIPTION
## Summary
- add trust stack bullet list in index contact section
- update contact page heading and trust stack bullets
- provide phone call CTA after form submission

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686ad644c6348329becde4ef647f9ae9