### PR TITLE
Fix icon colors on home page

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -34,3 +34,8 @@
   background-color: #D75E02;
   color: white;
 }
+
+/* Consistent icon color for feature cards */
+.card-icon {
+  color: #D75E02;
+}

--- a/index.html
+++ b/index.html
@@ -169,17 +169,17 @@
 
   <div class="grid md:grid-cols-3 gap-8 text-sm">
     <article class="bg-gray-50 border border-brand-steel/10 rounded-xl shadow-sm p-6 text-center">
-      <i class="fa-solid fa-phone-slash text-3xl text-brand-orange mb-4"></i>
+      <i class="fa-solid fa-phone-slash text-3xl card-icon mb-4"></i>
       <h3 class="font-semibold text-base">Missed‑Call Plug</h3>
       <p>Quote forms drop hot leads straight into your inbox—no trucks lost in voicemail hell.</p>
     </article>
     <article class="bg-gray-50 border border-brand-steel/10 rounded-xl shadow-sm p-6 text-center">
-      <i class="fa-solid fa-tags text-3xl text-brand-orange mb-4"></i>
+      <i class="fa-solid fa-tags text-3xl card-icon mb-4"></i>
       <h3 class="font-semibold text-base">Price‑Shopper Filter</h3>
       <p>Copy answers margin, materials & pickup times so tyre‑kickers don’t tie up your phone lines.</p>
     </article>
     <article class="bg-gray-50 border border-brand-steel/10 rounded-xl shadow-sm p-6 text-center">
-      <i class="fa-solid fa-shield-alt text-3xl text-brand-orange mb-4"></i>
+      <i class="fa-solid fa-shield-alt text-3xl card-icon mb-4"></i>
       <h3 class="font-semibold text-base">Credibility Shield</h3>
       <p>Industrial‑grade design signals trust to brokers, suppliers and walk‑ins.</p>
     </article>


### PR DESCRIPTION
## Summary
- ensure feature card icons use the brand orange
- define a `.card-icon` helper class for consistent color styling

## Testing
- `npm test` *(fails: could not read `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_686bfe9f95d4832999895992c04a4e4d