### PR TITLE
Fix pricing card layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -244,13 +244,13 @@
 
 <!-- ── Pricing ─────────────────────────────────────────────── -->
 <section id="pricing" class="scroll-mt-16 bg-white py-20">
-  <div class="mx-auto max-w-4xl px-6 text-center">
+  <div class="mx-auto max-w-6xl px-6 text-center">
     <h2 class="text-3xl font-bold">Straight‑Shooter Pricing</h2>
     <p class="mt-2 text-brand-steel max-w-xl mx-auto">
       No hidden fees, no “call for quote”. You’ll know the cost before we write a line of code.
     </p>
 
-    <div class="mt-14 grid gap-10 md:grid-cols-3">
+    <div class="mt-14 grid gap-10 md:grid-cols-2 lg:grid-cols-3">
       <!-- Launch -->
       <div class="relative bg-gray-50 border border-brand-steel/10 rounded-xl shadow-sm transition transform hover:-translate-y-1 p-10">
         <span


### PR DESCRIPTION
## Summary
- widen the pricing section
- show three pricing cards only on large screens

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686bfe8752448329aa7ada820df683d6