### PR TITLE
Fix color of How We Work numbers

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -39,3 +39,8 @@
 .card-icon {
   color: #D75E02;
 }
+
+/* Large numbers in the "How We Work" section */
+.process-step-number {
+  color: #D75E02;
+}

--- a/index.html
+++ b/index.html
@@ -224,17 +224,17 @@
     <h2 class="text-3xl font-bold mb-8">How We Work</h2>
     <div class="grid gap-10 md:grid-cols-3">
       <div>
-        <div class="text-brand-orange text-6xl font-black" data-aos="fade-up" data-aos-delay="0">1</div>
+        <div class="process-step-number text-6xl font-black" data-aos="fade-up" data-aos-delay="0">1</div>
         <h3 class="font-semibold text-lg mt-3">Discovery Call</h3>
         <p class="text-base md:text-sm text-brand-steel mt-1">15 minutes to learn your yard, materials & amp draw area.</p>
       </div>
       <div>
-        <div class="text-brand-orange text-6xl font-black" data-aos="fade-up" data-aos-delay="100">2</div>
+        <div class="process-step-number text-6xl font-black" data-aos="fade-up" data-aos-delay="100">2</div>
         <h3 class="font-semibold text-lg mt-3">Build Week</h3>
         <p class="text-base md:text-sm text-brand-steel mt-1">We design, write and code. You review once—done.</p>
       </div>
       <div>
-        <div class="text-brand-orange text-6xl font-black" data-aos="fade-up" data-aos-delay="200">3</div>
+        <div class="process-step-number text-6xl font-black" data-aos="fade-up" data-aos-delay="200">3</div>
         <h3 class="font-semibold text-lg mt-3">Launch & Maintain</h3>
         <p class="text-base md:text-sm text-brand-steel mt-1">Site goes live, Google Business updated, $99/mo care plan kicks in.</p>
       </div>


### PR DESCRIPTION
## Summary
- ensure the "How We Work" numbers use brand orange

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686c02f405f08329820936ba33c47f6a