### PR TITLE
Fix launch badge z-index

### DIFF
--- a/index.html
+++ b/index.html
@@ -254,7 +254,7 @@
       <!-- Launch -->
       <div class="relative bg-gray-50 border border-brand-steel/10 rounded-xl shadow-sm transition transform hover:-translate-y-1 p-10">
         <span
-          class="absolute -top-4 left-1/2 -translate-x-1/2 transform bg-brand-orange text-white text-xs font-semibold px-3 py-1 rounded-full shadow whitespace-nowrap">
+          class="absolute -top-4 left-1/2 -translate-x-1/2 transform bg-brand-orange text-white text-xs font-semibold px-3 py-1 rounded-full shadow whitespace-nowrap z-10 pointer-events-none">
           Most yards start here
         </span>
         <h3 class="text-xl font-semibold mb-4">Standard Launch</h3>


### PR DESCRIPTION
## Summary
- keep the "Most yards start here" badge above the Standard Launch card

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686c1aaf9a608329b43633d1ee1137e2