### PR TITLE
Fix bubble background on pricing card

### DIFF
--- a/index.html
+++ b/index.html
@@ -266,7 +266,8 @@
       <!-- Launch -->
       <div class="relative bg-gray-50 border border-brand-steel/10 rounded-xl shadow-sm transition transform hover:-translate-y-1 p-10">
         <span
-          class="absolute -top-4 left-1/2 -translate-x-1/2 transform bg-brand-orange text-white text-xs font-semibold px-3 py-1 rounded-full shadow whitespace-nowrap z-10 pointer-events-none">
+          class="absolute -top-4 left-1/2 -translate-x-1/2 transform bg-brand-orange text-white text-xs font-semibold px-3 py-1 rounded-full shadow whitespace-nowrap z-10 pointer-events-none"
+          style="background-color:#D75E02">
           Most yards start here
         </span>
         <h3 class="text-xl font-semibold mb-4">Standard Launch</h3>


### PR DESCRIPTION
## Summary
- ensure the pricing card badge always has the orange background

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686c2481a0a48329bb65f1591cdfe6b9