### PR TITLE
Remove case study section from portfolio

### DIFF
--- a/portfolio/index.html
+++ b/portfolio/index.html
@@ -88,56 +88,6 @@
         </a>
       </div>
     </div>
-  <section class="py-16">
-    <div class="max-w-3xl mx-auto text-center px-6">
-      <h2 class="text-3xl font-bold">Loads Recovered—One Yard at a Time</h2>
-    </div>
-
-    <!-- Masonry grid -->
-    <div class="max-w-6xl mx-auto columns-1 sm:columns-2 md:columns-3 px-6 gap-6 mt-10">
-      <!-- Card -->
-      <article class="break-inside-avoid mb-6 shadow-lg rounded overflow-hidden">
-        <img src="/assets/portfolio/demo1.jpg" alt="Demo Yard 1 website screenshot"
-             class="w-full object-cover aspect-video">
-        <div class="p-4 bg-white">
-          <h2 class="font-semibold text-base">+23 Loads/Month — Demo Yard 1</h2>
-          <p class="text-xs mt-1">
-            <strong>Problem:</strong> 9‑sec load time; Google burial.<br>
-            <strong>Fix:</strong> 1.2‑sec rebuild + quote form above fold.<br>
-            <strong>After:</strong> Phones rang next morning.
-          </p>
-        </div>
-      </article>
-      <article class="break-inside-avoid mb-6 shadow-lg rounded overflow-hidden">
-        <img src="/assets/portfolio/demo2.jpg" alt="Demo Yard 2 website screenshot"
-             class="w-full object-cover aspect-video">
-        <div class="p-4 bg-white">
-          <h2 class="font-semibold text-base">+17 Loads/Month — Demo Yard 2</h2>
-          <p class="text-xs mt-1">
-            <strong>Problem:</strong> Phones dead after redesign.<br>
-            <strong>Fix:</strong> Fixed meta titles, CTA buttons.<br>
-            <strong>After:</strong> Back on page 1 within weeks.
-          </p>
-        </div>
-      </article>
-      <article class="break-inside-avoid mb-6 shadow-lg rounded overflow-hidden">
-        <img src="/assets/portfolio/demo3.jpg" alt="Demo Yard 3 website screenshot"
-             class="w-full object-cover aspect-video">
-        <div class="p-4 bg-white">
-          <h2 class="font-semibold text-base">+31 Loads/Month — Demo Yard 3</h2>
-          <p class="text-xs mt-1">
-            <strong>Problem:</strong> 12‑sec load time; outdated design.<br>
-            <strong>Fix:</strong> Fast theme + above‑fold quote form.<br>
-            <strong>After:</strong> New contracts in days.
-          </p>
-        </div>
-      </article>
-    </div>
-
-    <div class="text-center mt-12">
-      <a href="/contact" class="btn-primary">Make My Yard the Next Headline</a>
-    </div>
-  </section>
   </main>
   <footer class="bg-white py-8 text-center text-xs text-gray-400">
     <p>© <span id="year"></span> Scrapyard Sites — All rights reserved.</p>


### PR DESCRIPTION
## Summary
- delete `Loads Recovered—One Yard at a Time` section on the Portfolio page

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686c253caad48329ba487c8e6fa41ce8