### PR TITLE
Remove map embed from contact page

### DIFF
--- a/contact/index.html
+++ b/contact/index.html
@@ -79,9 +79,6 @@
       </form>
       <p class="text-center text-sm mt-6">Prefer immediate answers? <a href="tel:+19493568762" class="underline">Call 949‑356‑8762</a></p>
       <div class="mt-10">
-        <iframe class="w-full h-64" loading="lazy" allowfullscreen src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d10000!2d-97.7431!3d30.2672"></iframe>
-      </div>
-      <div class="mt-10">
         <iframe src="https://calendly.com/your-calendar" class="w-full h-[630px]"></iframe>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- remove Google Maps iframe from the contact page

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686c2747ecf08329978946d114fb5f67