### PR TITLE
Fix process page card layout

### DIFF
--- a/process/index.html
+++ b/process/index.html
@@ -41,11 +41,12 @@
       font-weight: 700;
       flex-shrink: 0;
     }
-    @media (max-width:480px) {
-      .process-step {
-        flex-direction: column;
-        align-items: flex-start;
-      }
+    .process-step {
+      flex-direction: column;
+      align-items: flex-start;
+    }
+    .process-step h2 {
+      word-wrap: break-word;
     }
   </style>
 </head>
@@ -100,7 +101,7 @@
           <li class="process-step flex gap-6 bg-gray-50 border border-brand-steel/10 rounded-xl shadow-sm p-6">
             <span class="step-badge">1</span>
             <div class="text-left">
-              <h2 class="font-semibold">Leak&nbsp;Detection&nbsp;(Discovery&nbsp;Call)</h2>
+              <h2 class="font-semibold">Leak Detection (Discovery Call)</h2>
               <ul class="text-sm list-disc list-inside">
                 <li>15‑min screen‑share</li>
                 <li>Identify phone‑call leaks &amp; Google gaps</li>
@@ -112,7 +113,7 @@
           <li class="process-step flex gap-6 bg-gray-50 border border-brand-steel/10 rounded-xl shadow-sm p-6">
             <span class="step-badge">2</span>
             <div class="text-left">
-              <h2 class="font-semibold">Controlled&nbsp;Fix&nbsp;(Build&nbsp;Week)</h2>
+              <h2 class="font-semibold">Controlled Fix (Build Week)</h2>
               <ul class="text-sm list-disc list-inside">
                 <li>Design, copy &amp; code in staging sandbox</li>
                 <li>Your 1‑time review—no endless loops</li>
@@ -124,11 +125,11 @@
           <li class="process-step flex gap-6 bg-gray-50 border border-brand-steel/10 rounded-xl shadow-sm p-6">
             <span class="step-badge">3</span>
             <div class="text-left">
-              <h2 class="font-semibold">Safe&nbsp;Launch&nbsp;+&nbsp;30‑Day&nbsp;Watch</h2>
+              <h2 class="font-semibold">Safe Launch + 30-Day Watch</h2>
               <ul class="text-sm list-disc list-inside">
                 <li>SSL &amp; backups enabled</li>
                 <li>Google Business synced</li>
-                <li>Weekly speed &amp; bug checks for 30&nbsp;days</li>
+                <li>Weekly speed &amp; bug checks for 30 days</li>
               </ul>
             </div>
           </li>


### PR DESCRIPTION
## Summary
- keep process steps vertical for all screen sizes
- wrap step headings so text stays within cards

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c27cb1030832991435b0cb97fa3ec