### PR TITLE
Fix risk calculator form styling

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -45,15 +45,6 @@
   color: #D75E02;
 }
 
-/* Form fields on the Risk Calculator page */
-.calc-field {
-  width: 100%;
-  padding: 0.75rem 1rem; /* px-4 py-3 */
-  border-radius: 0.375rem; /* rounded-md */
-  background-color: #fff;
-  border: 1px solid rgba(94, 99, 103, 0.2); /* brand-steel/20 */
-  color: #2B2B2B; /* brand-charcoal */
-}
 
 /* Ensure header remains sticky across browsers */
 header.sticky {

--- a/risk-calculator/index.html
+++ b/risk-calculator/index.html
@@ -73,18 +73,15 @@
       </p>
 
       <form id="calcForm" class="mt-10 grid gap-6 max-w-md mx-auto">
-        <label class="block">
-          <span class="text-xs font-medium">Average load weight (tons)</span>
-          <input type="number" step="0.1" class="calc-field" name="tons" inputmode="decimal" required>
-        </label>
-        <label class="block">
-          <span class="text-xs font-medium">Average margin ($/ton)</span>
-          <input type="number" step="0.1" class="calc-field" name="margin" inputmode="decimal" required>
-        </label>
-        <label class="block">
-          <span class="text-xs font-medium">Loads missed per month</span>
-          <input type="number" class="calc-field" name="missed" inputmode="numeric" required>
-        </label>
+        <input type="number" step="0.1" name="tons" inputmode="decimal" required
+               placeholder="Average load weight (tons)"
+               class="w-full rounded-md px-4 py-3 bg-white border border-brand-steel/20 text-brand-charcoal" />
+        <input type="number" step="0.1" name="margin" inputmode="decimal" required
+               placeholder="Average margin ($/ton)"
+               class="w-full rounded-md px-4 py-3 bg-white border border-brand-steel/20 text-brand-charcoal" />
+        <input type="number" name="missed" inputmode="numeric" required
+               placeholder="Loads missed per month"
+               class="w-full rounded-md px-4 py-3 bg-white border border-brand-steel/20 text-brand-charcoal" />
         <button class="btn-primary w-full" type="submit">Calculate</button>
       </form>
 


### PR DESCRIPTION
## Summary
- switch risk calculator fields to use same placeholder-based styling as other forms
- remove unused `.calc-field` rule

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686c28d1ffe083298e430d265ddcaaa0