### PR TITLE
Fix sticky nav bar

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -48,6 +48,7 @@
 
 /* Ensure header remains sticky across browsers */
 header.sticky {
+  position: -webkit-sticky;
   position: sticky;
   top: 0;
   z-index: 50;


### PR DESCRIPTION
## Summary
- ensure the nav header works in Safari by adding `-webkit-sticky`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686d7ea626088329a5065b787dc9fef2