### PR TITLE
Fix mobile menu toggle icon

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -62,3 +62,8 @@ header.sticky {
   color: #2B2B2B;
 }
 
+/* Swap hamburger/close icons when menu opens */
+#menuToggle .icon-close { display: none; }
+#menuToggle.open .icon-open { display: none; }
+#menuToggle.open .icon-close { display: inline; }
+

--- a/contact/index.html
+++ b/contact/index.html
@@ -31,7 +31,7 @@
       <!-- Mobile hamburger (≤ 768 px) -->
       <button id="menuToggle" class="md:hidden p-2">
         <svg class="icon-open w-6 h-6" viewBox="0 0 24 24" fill="none"><path d="M3 6h18M3 12h18M3 18h18" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
-        <svg class="icon-close w-6 h-6 hidden" viewBox="0 0 24 24" fill="none"><path d="M6 6l12 12M6 18L18 6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+        <svg class="icon-close w-6 h-6" viewBox="0 0 24 24" fill="none"><path d="M6 6l12 12M6 18L18 6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
       </button>
       <!-- Desktop links -->
       <ul id="menu" class="hidden md:flex md:absolute md:left-1/2 md:top-1/2 md:-translate-x-1/2 md:-translate-y-1/2 gap-6 text-sm font-medium">
@@ -60,13 +60,11 @@
   /* full-screen mobile toggle */
   document.getElementById('menuToggle')?.addEventListener('click', () => {
     const menu = document.getElementById('mobileMenu');
-    const openIcon = document.querySelector('#menuToggle .icon-open');
-    const closeIcon = document.querySelector('#menuToggle .icon-close');
+    const btn = document.getElementById('menuToggle');
     menu.classList.toggle('hidden');
     const isOpen = !menu.classList.contains('hidden');
     document.body.classList.toggle('overflow-hidden', isOpen);
-    openIcon.classList.toggle('hidden', isOpen);
-    closeIcon.classList.toggle('hidden', !isOpen);
+    btn.classList.toggle('open');
   });
   </script>
   <main class="pt-24 pb-20 px-6">

--- a/index.html
+++ b/index.html
@@ -124,7 +124,7 @@
       <!-- Mobile hamburger (≤ 768 px) -->
       <button id="menuToggle" class="md:hidden p-2">
         <svg class="icon-open w-6 h-6" viewBox="0 0 24 24" fill="none"><path d="M3 6h18M3 12h18M3 18h18" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
-        <svg class="icon-close w-6 h-6 hidden" viewBox="0 0 24 24" fill="none"><path d="M6 6l12 12M6 18L18 6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+        <svg class="icon-close w-6 h-6" viewBox="0 0 24 24" fill="none"><path d="M6 6l12 12M6 18L18 6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
       </button>
       <!-- Desktop links -->
       <ul id="menu" class="hidden md:flex md:absolute md:left-1/2 md:top-1/2 md:-translate-x-1/2 md:-translate-y-1/2 gap-6 text-sm font-medium">
@@ -153,13 +153,11 @@
   /* full-screen mobile toggle */
   document.getElementById('menuToggle')?.addEventListener('click', () => {
     const menu = document.getElementById('mobileMenu');
-    const openIcon = document.querySelector('#menuToggle .icon-open');
-    const closeIcon = document.querySelector('#menuToggle .icon-close');
+    const btn = document.getElementById('menuToggle');
     menu.classList.toggle('hidden');
     const isOpen = !menu.classList.contains('hidden');
     document.body.classList.toggle('overflow-hidden', isOpen);
-    openIcon.classList.toggle('hidden', isOpen);
-    closeIcon.classList.toggle('hidden', !isOpen);
+    btn.classList.toggle('open');
   });
   </script>
 

--- a/portfolio/demo-yard-1/index.html
+++ b/portfolio/demo-yard-1/index.html
@@ -25,7 +25,7 @@
   </style>
 </head>
 <body class="font-sans text-brand-charcoal antialiased bg-white overflow-x-hidden">
-  <header class="bg-white fixed top-0 left-0 right-0 w-full z-50 shadow-sm">
+  <header class="sticky top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
     <div class="mx-auto max-w-7xl relative flex items-center justify-between px-6 py-3">
       <a href="/" class="flex items-center gap-2">
         <img src="/assets/logo.svg" alt="ScrapYardSites logo" class="h-6 w-6 md:h-8 md:w-8"/>

--- a/portfolio/demo-yard-2/index.html
+++ b/portfolio/demo-yard-2/index.html
@@ -25,7 +25,7 @@
   </style>
 </head>
 <body class="font-sans text-brand-charcoal antialiased bg-white overflow-x-hidden">
-  <header class="bg-white fixed top-0 left-0 right-0 w-full z-50 shadow-sm">
+  <header class="sticky top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
     <div class="mx-auto max-w-7xl relative flex items-center justify-between px-6 py-3">
       <a href="/" class="flex items-center gap-2">
         <img src="/assets/logo.svg" alt="ScrapYardSites logo" class="h-6 w-6 md:h-8 md:w-8"/>

--- a/portfolio/demo-yard-3/index.html
+++ b/portfolio/demo-yard-3/index.html
@@ -25,7 +25,7 @@
   </style>
 </head>
 <body class="font-sans text-brand-charcoal antialiased bg-white overflow-x-hidden">
-  <header class="bg-white fixed top-0 left-0 right-0 w-full z-50 shadow-sm">
+  <header class="sticky top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
     <div class="mx-auto max-w-7xl relative flex items-center justify-between px-6 py-3">
       <a href="/" class="flex items-center gap-2">
         <img src="/assets/logo.svg" alt="ScrapYardSites logo" class="h-6 w-6 md:h-8 md:w-8"/>

--- a/portfolio/index.html
+++ b/portfolio/index.html
@@ -31,7 +31,7 @@
       <!-- Mobile hamburger (≤ 768 px) -->
       <button id="menuToggle" class="md:hidden p-2">
         <svg class="icon-open w-6 h-6" viewBox="0 0 24 24" fill="none"><path d="M3 6h18M3 12h18M3 18h18" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
-        <svg class="icon-close w-6 h-6 hidden" viewBox="0 0 24 24" fill="none"><path d="M6 6l12 12M6 18L18 6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+        <svg class="icon-close w-6 h-6" viewBox="0 0 24 24" fill="none"><path d="M6 6l12 12M6 18L18 6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
       </button>
       <!-- Desktop links -->
       <ul id="menu" class="hidden md:flex md:absolute md:left-1/2 md:top-1/2 md:-translate-x-1/2 md:-translate-y-1/2 gap-6 text-sm font-medium">
@@ -60,13 +60,11 @@
   /* full-screen mobile toggle */
   document.getElementById('menuToggle')?.addEventListener('click', () => {
     const menu = document.getElementById('mobileMenu');
-    const openIcon = document.querySelector('#menuToggle .icon-open');
-    const closeIcon = document.querySelector('#menuToggle .icon-close');
+    const btn = document.getElementById('menuToggle');
     menu.classList.toggle('hidden');
     const isOpen = !menu.classList.contains('hidden');
     document.body.classList.toggle('overflow-hidden', isOpen);
-    openIcon.classList.toggle('hidden', isOpen);
-    closeIcon.classList.toggle('hidden', !isOpen);
+    btn.classList.toggle('open');
   });
   </script>
   <main class="pt-24 pb-20 px-6">

--- a/pricing/index.html
+++ b/pricing/index.html
@@ -31,7 +31,7 @@
       <!-- Mobile hamburger (≤ 768 px) -->
       <button id="menuToggle" class="md:hidden p-2">
         <svg class="icon-open w-6 h-6" viewBox="0 0 24 24" fill="none"><path d="M3 6h18M3 12h18M3 18h18" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
-        <svg class="icon-close w-6 h-6 hidden" viewBox="0 0 24 24" fill="none"><path d="M6 6l12 12M6 18L18 6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+        <svg class="icon-close w-6 h-6" viewBox="0 0 24 24" fill="none"><path d="M6 6l12 12M6 18L18 6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
       </button>
       <!-- Desktop links -->
       <ul id="menu" class="hidden md:flex md:absolute md:left-1/2 md:top-1/2 md:-translate-x-1/2 md:-translate-y-1/2 gap-6 text-sm font-medium">
@@ -60,13 +60,11 @@
   /* full-screen mobile toggle */
   document.getElementById('menuToggle')?.addEventListener('click', () => {
     const menu = document.getElementById('mobileMenu');
-    const openIcon = document.querySelector('#menuToggle .icon-open');
-    const closeIcon = document.querySelector('#menuToggle .icon-close');
+    const btn = document.getElementById('menuToggle');
     menu.classList.toggle('hidden');
     const isOpen = !menu.classList.contains('hidden');
     document.body.classList.toggle('overflow-hidden', isOpen);
-    openIcon.classList.toggle('hidden', isOpen);
-    closeIcon.classList.toggle('hidden', !isOpen);
+    btn.classList.toggle('open');
   });
   </script>
   <main class="pt-24 pb-20 px-6">

--- a/privacy/index.html
+++ b/privacy/index.html
@@ -96,7 +96,7 @@
       <!-- Mobile hamburger (≤ 768 px) -->
       <button id="menuToggle" class="md:hidden p-2">
         <svg class="icon-open w-6 h-6" viewBox="0 0 24 24" fill="none"><path d="M3 6h18M3 12h18M3 18h18" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
-        <svg class="icon-close w-6 h-6 hidden" viewBox="0 0 24 24" fill="none"><path d="M6 6l12 12M6 18L18 6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+        <svg class="icon-close w-6 h-6" viewBox="0 0 24 24" fill="none"><path d="M6 6l12 12M6 18L18 6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
       </button>
       <!-- Desktop links -->
       <ul id="menu" class="hidden md:flex md:absolute md:left-1/2 md:top-1/2 md:-translate-x-1/2 md:-translate-y-1/2 gap-6 text-sm font-medium">
@@ -125,13 +125,11 @@
   /* full-screen mobile toggle */
   document.getElementById('menuToggle')?.addEventListener('click', () => {
     const menu = document.getElementById('mobileMenu');
-    const openIcon = document.querySelector('#menuToggle .icon-open');
-    const closeIcon = document.querySelector('#menuToggle .icon-close');
+    const btn = document.getElementById('menuToggle');
     menu.classList.toggle('hidden');
     const isOpen = !menu.classList.contains('hidden');
     document.body.classList.toggle('overflow-hidden', isOpen);
-    openIcon.classList.toggle('hidden', isOpen);
-    closeIcon.classList.toggle('hidden', !isOpen);
+    btn.classList.toggle('open');
   });
   </script>
   <main class="max-w-3xl mx-auto pt-24 pb-20 px-6 prose prose-a:text-brand-orange">

--- a/process/index.html
+++ b/process/index.html
@@ -64,7 +64,7 @@
       <!-- Mobile hamburger (≤ 768 px) -->
       <button id="menuToggle" class="md:hidden p-2">
         <svg class="icon-open w-6 h-6" viewBox="0 0 24 24" fill="none"><path d="M3 6h18M3 12h18M3 18h18" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
-        <svg class="icon-close w-6 h-6 hidden" viewBox="0 0 24 24" fill="none"><path d="M6 6l12 12M6 18L18 6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+        <svg class="icon-close w-6 h-6" viewBox="0 0 24 24" fill="none"><path d="M6 6l12 12M6 18L18 6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
       </button>
       <!-- Desktop links -->
       <ul id="menu" class="hidden md:flex md:absolute md:left-1/2 md:top-1/2 md:-translate-x-1/2 md:-translate-y-1/2 gap-6 text-sm font-medium">
@@ -93,13 +93,11 @@
   /* full-screen mobile toggle */
   document.getElementById('menuToggle')?.addEventListener('click', () => {
     const menu = document.getElementById('mobileMenu');
-    const openIcon = document.querySelector('#menuToggle .icon-open');
-    const closeIcon = document.querySelector('#menuToggle .icon-close');
+    const btn = document.getElementById('menuToggle');
     menu.classList.toggle('hidden');
     const isOpen = !menu.classList.contains('hidden');
     document.body.classList.toggle('overflow-hidden', isOpen);
-    openIcon.classList.toggle('hidden', isOpen);
-    closeIcon.classList.toggle('hidden', !isOpen);
+    btn.classList.toggle('open');
   });
   </script>
   <main class="pt-24 pb-20 px-6">

--- a/risk-calculator/index.html
+++ b/risk-calculator/index.html
@@ -31,7 +31,7 @@
       <!-- Mobile hamburger (≤ 768 px) -->
       <button id="menuToggle" class="md:hidden p-2">
         <svg class="icon-open w-6 h-6" viewBox="0 0 24 24" fill="none"><path d="M3 6h18M3 12h18M3 18h18" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
-        <svg class="icon-close w-6 h-6 hidden" viewBox="0 0 24 24" fill="none"><path d="M6 6l12 12M6 18L18 6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+        <svg class="icon-close w-6 h-6" viewBox="0 0 24 24" fill="none"><path d="M6 6l12 12M6 18L18 6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
       </button>
       <!-- Desktop links -->
       <ul id="menu" class="hidden md:flex md:absolute md:left-1/2 md:top-1/2 md:-translate-x-1/2 md:-translate-y-1/2 gap-6 text-sm font-medium">
@@ -60,13 +60,11 @@
   /* full-screen mobile toggle */
   document.getElementById('menuToggle')?.addEventListener('click', () => {
     const menu = document.getElementById('mobileMenu');
-    const openIcon = document.querySelector('#menuToggle .icon-open');
-    const closeIcon = document.querySelector('#menuToggle .icon-close');
+    const btn = document.getElementById('menuToggle');
     menu.classList.toggle('hidden');
     const isOpen = !menu.classList.contains('hidden');
     document.body.classList.toggle('overflow-hidden', isOpen);
-    openIcon.classList.toggle('hidden', isOpen);
-    closeIcon.classList.toggle('hidden', !isOpen);
+    btn.classList.toggle('open');
   });
   </script>
   <main class="pt-24 pb-32 px-6">

--- a/services/index.html
+++ b/services/index.html
@@ -85,7 +85,7 @@
       <!-- Mobile hamburger (≤ 768 px) -->
       <button id="menuToggle" class="md:hidden p-2">
         <svg class="icon-open w-6 h-6" viewBox="0 0 24 24" fill="none"><path d="M3 6h18M3 12h18M3 18h18" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
-        <svg class="icon-close w-6 h-6 hidden" viewBox="0 0 24 24" fill="none"><path d="M6 6l12 12M6 18L18 6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+        <svg class="icon-close w-6 h-6" viewBox="0 0 24 24" fill="none"><path d="M6 6l12 12M6 18L18 6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
       </button>
       <!-- Desktop links -->
       <ul id="menu" class="hidden md:flex md:absolute md:left-1/2 md:top-1/2 md:-translate-x-1/2 md:-translate-y-1/2 gap-6 text-sm font-medium">
@@ -114,13 +114,11 @@
   /* full-screen mobile toggle */
   document.getElementById('menuToggle')?.addEventListener('click', () => {
     const menu = document.getElementById('mobileMenu');
-    const openIcon = document.querySelector('#menuToggle .icon-open');
-    const closeIcon = document.querySelector('#menuToggle .icon-close');
+    const btn = document.getElementById('menuToggle');
     menu.classList.toggle('hidden');
     const isOpen = !menu.classList.contains('hidden');
     document.body.classList.toggle('overflow-hidden', isOpen);
-    openIcon.classList.toggle('hidden', isOpen);
-    closeIcon.classList.toggle('hidden', !isOpen);
+    btn.classList.toggle('open');
   });
   </script>
   <main class="pt-24 pb-20">


### PR DESCRIPTION
## Summary
- show close icon via CSS instead of JS toggles
- update header scripts to toggle an `open` class on the button

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686d82ab1f6c83299199e652f32415ae