### PR TITLE
Fix mobile menu closing

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -66,3 +66,13 @@ header.fixed {
 #menuToggle.open .icon-open { display: none; }
 #menuToggle.open .icon-close { display: inline; }
 
+/* Close button for full-screen mobile menu */
+#mobileMenu .close-btn {
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+  background: transparent;
+  border: none;
+  color: #2B2B2B;
+}
+

--- a/contact/index.html
+++ b/contact/index.html
@@ -47,6 +47,9 @@
     </nav>
     <!-- Full-screen mobile menu -->
     <div id="mobileMenu" class="md:hidden fixed inset-0 z-40 flex flex-col items-center justify-center gap-6 text-xl font-medium bg-white hidden">
+      <button id="menuClose" class="close-btn" aria-label="Close menu">
+        <svg class="w-6 h-6" viewBox="0 0 24 24" fill="none"><path d="M6 6l12 12M6 18L18 6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+      </button>
       <a href="/services">Services</a>
       <a href="/process">Process</a>
       <a href="/portfolio">Portfolio</a>
@@ -58,14 +61,16 @@
   </header>
   <script>
   /* full-screen mobile toggle */
-  document.getElementById('menuToggle')?.addEventListener('click', () => {
+  const toggleMenu = () => {
     const menu = document.getElementById('mobileMenu');
     const btn = document.getElementById('menuToggle');
     menu.classList.toggle('hidden');
     const isOpen = !menu.classList.contains('hidden');
     document.body.classList.toggle('overflow-hidden', isOpen);
     btn.classList.toggle('open');
-  });
+  };
+  document.getElementById('menuToggle')?.addEventListener('click', toggleMenu);
+  document.getElementById('menuClose')?.addEventListener('click', toggleMenu);
   </script>
   <main class="pt-24 pb-20 px-6">
     <h1 class="text-3xl font-bold text-center mb-8">Cap the Leak in 15&nbsp;Minutes or Less</h1>

--- a/index.html
+++ b/index.html
@@ -140,6 +140,9 @@
     </nav>
     <!-- Full-screen mobile menu -->
     <div id="mobileMenu" class="md:hidden fixed inset-0 z-40 flex flex-col items-center justify-center gap-6 text-xl font-medium bg-white hidden">
+      <button id="menuClose" class="close-btn" aria-label="Close menu">
+        <svg class="w-6 h-6" viewBox="0 0 24 24" fill="none"><path d="M6 6l12 12M6 18L18 6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+      </button>
       <a href="/services">Services</a>
       <a href="/process">Process</a>
       <a href="/portfolio">Portfolio</a>
@@ -151,14 +154,16 @@
   </header>
   <script>
   /* full-screen mobile toggle */
-  document.getElementById('menuToggle')?.addEventListener('click', () => {
+  const toggleMenu = () => {
     const menu = document.getElementById('mobileMenu');
     const btn = document.getElementById('menuToggle');
     menu.classList.toggle('hidden');
     const isOpen = !menu.classList.contains('hidden');
     document.body.classList.toggle('overflow-hidden', isOpen);
     btn.classList.toggle('open');
-  });
+  };
+  document.getElementById('menuToggle')?.addEventListener('click', toggleMenu);
+  document.getElementById('menuClose')?.addEventListener('click', toggleMenu);
   </script>
 
 <!-- ── Hero ───────────────────────────────────────────────── -->

--- a/portfolio/index.html
+++ b/portfolio/index.html
@@ -47,6 +47,9 @@
     </nav>
     <!-- Full-screen mobile menu -->
     <div id="mobileMenu" class="md:hidden fixed inset-0 z-40 flex flex-col items-center justify-center gap-6 text-xl font-medium bg-white hidden">
+      <button id="menuClose" class="close-btn" aria-label="Close menu">
+        <svg class="w-6 h-6" viewBox="0 0 24 24" fill="none"><path d="M6 6l12 12M6 18L18 6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+      </button>
       <a href="/services">Services</a>
       <a href="/process">Process</a>
       <a href="/portfolio">Portfolio</a>
@@ -58,14 +61,16 @@
   </header>
   <script>
   /* full-screen mobile toggle */
-  document.getElementById('menuToggle')?.addEventListener('click', () => {
+  const toggleMenu = () => {
     const menu = document.getElementById('mobileMenu');
     const btn = document.getElementById('menuToggle');
     menu.classList.toggle('hidden');
     const isOpen = !menu.classList.contains('hidden');
     document.body.classList.toggle('overflow-hidden', isOpen);
     btn.classList.toggle('open');
-  });
+  };
+  document.getElementById('menuToggle')?.addEventListener('click', toggleMenu);
+  document.getElementById('menuClose')?.addEventListener('click', toggleMenu);
   </script>
   <main class="pt-24 pb-20 px-6">
     <h1 class="text-3xl font-bold text-center mb-12">Our Portfolio</h1>

--- a/pricing/index.html
+++ b/pricing/index.html
@@ -47,6 +47,9 @@
     </nav>
     <!-- Full-screen mobile menu -->
     <div id="mobileMenu" class="md:hidden fixed inset-0 z-40 flex flex-col items-center justify-center gap-6 text-xl font-medium bg-white hidden">
+      <button id="menuClose" class="close-btn" aria-label="Close menu">
+        <svg class="w-6 h-6" viewBox="0 0 24 24" fill="none"><path d="M6 6l12 12M6 18L18 6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+      </button>
       <a href="/services">Services</a>
       <a href="/process">Process</a>
       <a href="/portfolio">Portfolio</a>
@@ -58,14 +61,16 @@
   </header>
   <script>
   /* full-screen mobile toggle */
-  document.getElementById('menuToggle')?.addEventListener('click', () => {
+  const toggleMenu = () => {
     const menu = document.getElementById('mobileMenu');
     const btn = document.getElementById('menuToggle');
     menu.classList.toggle('hidden');
     const isOpen = !menu.classList.contains('hidden');
     document.body.classList.toggle('overflow-hidden', isOpen);
     btn.classList.toggle('open');
-  });
+  };
+  document.getElementById('menuToggle')?.addEventListener('click', toggleMenu);
+  document.getElementById('menuClose')?.addEventListener('click', toggleMenu);
   </script>
   <main class="pt-24 pb-20 px-6">
     <section class="py-20 bg-white">

--- a/privacy/index.html
+++ b/privacy/index.html
@@ -112,6 +112,9 @@
     </nav>
     <!-- Full-screen mobile menu -->
     <div id="mobileMenu" class="md:hidden fixed inset-0 z-40 flex flex-col items-center justify-center gap-6 text-xl font-medium bg-white hidden">
+      <button id="menuClose" class="close-btn" aria-label="Close menu">
+        <svg class="w-6 h-6" viewBox="0 0 24 24" fill="none"><path d="M6 6l12 12M6 18L18 6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+      </button>
       <a href="/services">Services</a>
       <a href="/process">Process</a>
       <a href="/portfolio">Portfolio</a>
@@ -123,14 +126,16 @@
   </header>
   <script>
   /* full-screen mobile toggle */
-  document.getElementById('menuToggle')?.addEventListener('click', () => {
+  const toggleMenu = () => {
     const menu = document.getElementById('mobileMenu');
     const btn = document.getElementById('menuToggle');
     menu.classList.toggle('hidden');
     const isOpen = !menu.classList.contains('hidden');
     document.body.classList.toggle('overflow-hidden', isOpen);
     btn.classList.toggle('open');
-  });
+  };
+  document.getElementById('menuToggle')?.addEventListener('click', toggleMenu);
+  document.getElementById('menuClose')?.addEventListener('click', toggleMenu);
   </script>
   <main class="max-w-3xl mx-auto pt-24 pb-20 px-6 prose prose-a:text-brand-orange">
     <h1 class="text-3xl font-bold mb-4">Privacy Policy</h1>

--- a/process/index.html
+++ b/process/index.html
@@ -75,6 +75,9 @@
     </nav>
     <!-- Full-screen mobile menu -->
     <div id="mobileMenu" class="md:hidden fixed inset-0 z-40 flex flex-col items-center justify-center gap-6 text-xl font-medium bg-white hidden">
+      <button id="menuClose" class="close-btn" aria-label="Close menu">
+        <svg class="w-6 h-6" viewBox="0 0 24 24" fill="none"><path d="M6 6l12 12M6 18L18 6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+      </button>
       <a href="/services">Services</a>
       <a href="/process">Process</a>
       <a href="/portfolio">Portfolio</a>
@@ -86,14 +89,16 @@
   </header>
   <script>
   /* full-screen mobile toggle */
-  document.getElementById('menuToggle')?.addEventListener('click', () => {
+  const toggleMenu = () => {
     const menu = document.getElementById('mobileMenu');
     const btn = document.getElementById('menuToggle');
     menu.classList.toggle('hidden');
     const isOpen = !menu.classList.contains('hidden');
     document.body.classList.toggle('overflow-hidden', isOpen);
     btn.classList.toggle('open');
-  });
+  };
+  document.getElementById('menuToggle')?.addEventListener('click', toggleMenu);
+  document.getElementById('menuClose')?.addEventListener('click', toggleMenu);
   </script>
   <main class="pt-24 pb-20 px-6">
     <section class="py-16">

--- a/risk-calculator/index.html
+++ b/risk-calculator/index.html
@@ -47,6 +47,9 @@
     </nav>
     <!-- Full-screen mobile menu -->
     <div id="mobileMenu" class="md:hidden fixed inset-0 z-40 flex flex-col items-center justify-center gap-6 text-xl font-medium bg-white hidden">
+      <button id="menuClose" class="close-btn" aria-label="Close menu">
+        <svg class="w-6 h-6" viewBox="0 0 24 24" fill="none"><path d="M6 6l12 12M6 18L18 6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+      </button>
       <a href="/services">Services</a>
       <a href="/process">Process</a>
       <a href="/portfolio">Portfolio</a>
@@ -58,14 +61,16 @@
   </header>
   <script>
   /* full-screen mobile toggle */
-  document.getElementById('menuToggle')?.addEventListener('click', () => {
+  const toggleMenu = () => {
     const menu = document.getElementById('mobileMenu');
     const btn = document.getElementById('menuToggle');
     menu.classList.toggle('hidden');
     const isOpen = !menu.classList.contains('hidden');
     document.body.classList.toggle('overflow-hidden', isOpen);
     btn.classList.toggle('open');
-  });
+  };
+  document.getElementById('menuToggle')?.addEventListener('click', toggleMenu);
+  document.getElementById('menuClose')?.addEventListener('click', toggleMenu);
   </script>
   <main class="pt-24 pb-32 px-6">
     <section class="py-16">

--- a/services/index.html
+++ b/services/index.html
@@ -101,6 +101,9 @@
     </nav>
     <!-- Full-screen mobile menu -->
     <div id="mobileMenu" class="md:hidden fixed inset-0 z-40 flex flex-col items-center justify-center gap-6 text-xl font-medium bg-white hidden">
+      <button id="menuClose" class="close-btn" aria-label="Close menu">
+        <svg class="w-6 h-6" viewBox="0 0 24 24" fill="none"><path d="M6 6l12 12M6 18L18 6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+      </button>
       <a href="/services">Services</a>
       <a href="/process">Process</a>
       <a href="/portfolio">Portfolio</a>
@@ -112,14 +115,16 @@
   </header>
   <script>
   /* full-screen mobile toggle */
-  document.getElementById('menuToggle')?.addEventListener('click', () => {
+  const toggleMenu = () => {
     const menu = document.getElementById('mobileMenu');
     const btn = document.getElementById('menuToggle');
     menu.classList.toggle('hidden');
     const isOpen = !menu.classList.contains('hidden');
     document.body.classList.toggle('overflow-hidden', isOpen);
     btn.classList.toggle('open');
-  });
+  };
+  document.getElementById('menuToggle')?.addEventListener('click', toggleMenu);
+  document.getElementById('menuClose')?.addEventListener('click', toggleMenu);
   </script>
   <main class="pt-24">
     <section class="py-16 bg-gray-50">


### PR DESCRIPTION
## Summary
- add a close button to the mobile overlay
- handle closing the overlay from the new button
- style the close button in CSS

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686d89ce5a7483299a6300c020594f95