### PR TITLE
Fix navbar title styling

### DIFF
--- a/contact/index.html
+++ b/contact/index.html
@@ -27,7 +27,7 @@
 <body class="font-sans text-brand-charcoal antialiased bg-white overflow-x-hidden">
   <header class="fixed top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
     <nav class="max-w-7xl mx-auto relative flex items-center justify-between py-3 px-6">
-      <a href="/" class="flex items-center gap-2"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-8 w-8"/><span class="site-title text-xl text-brand-charcoal"><span class="font-bold text-brand-orange">Scrapyard</span> Sites</span></a>
+      <a href="/" class="flex items-center gap-2"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-8 w-8"/><span class="site-title text-xl text-brand-charcoal"><span class="font-bold text-brand-orange">Scrapyard</span> <span class="font-bold">Sites</span></span></a>
       <!-- Mobile hamburger (≤ 768 px) -->
       <button id="menuToggle" class="md:hidden p-2">
         <svg class="icon-open w-6 h-6" viewBox="0 0 24 24" fill="none"><path d="M3 6h18M3 12h18M3 18h18" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>

--- a/index.html
+++ b/index.html
@@ -120,7 +120,7 @@
 <!-- ── Header ─────────────────────────────────────────────── -->
   <header class="fixed top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
     <nav class="max-w-7xl mx-auto relative flex items-center justify-between py-3 px-6">
-      <a href="/" class="flex items-center gap-2"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-8 w-8"/><span class="site-title text-xl text-brand-charcoal"><span class="font-bold text-brand-orange">Scrapyard</span> Sites</span></a>
+      <a href="/" class="flex items-center gap-2"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-8 w-8"/><span class="site-title text-xl text-brand-charcoal"><span class="font-bold text-brand-orange">Scrapyard</span> <span class="font-bold">Sites</span></span></a>
       <!-- Mobile hamburger (≤ 768 px) -->
       <button id="menuToggle" class="md:hidden p-2">
         <svg class="icon-open w-6 h-6" viewBox="0 0 24 24" fill="none"><path d="M3 6h18M3 12h18M3 18h18" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>

--- a/portfolio/demo-yard-1/index.html
+++ b/portfolio/demo-yard-1/index.html
@@ -29,7 +29,7 @@
     <div class="mx-auto max-w-7xl relative flex items-center justify-between px-6 py-3">
       <a href="/" class="flex items-center gap-2">
         <img src="/assets/logo.svg" alt="ScrapYardSites logo" class="h-6 w-6 md:h-8 md:w-8"/>
-        <span class="site-title text-xl md:text-2xl tracking-tight"><span class="font-bold text-brand-orange">Scrapyard</span> Sites</span>
+        <span class="site-title text-xl md:text-2xl tracking-tight"><span class="font-bold text-brand-orange">Scrapyard</span> <span class="font-bold">Sites</span></span>
       </a>
       <nav class="hidden md:flex absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 justify-center items-center gap-8 text-sm font-medium">
         <a href="/#why" class="text-brand-charcoal hover:text-brand-orange" title="Leaking here? ->">Why Us</a>

--- a/portfolio/demo-yard-2/index.html
+++ b/portfolio/demo-yard-2/index.html
@@ -29,7 +29,7 @@
     <div class="mx-auto max-w-7xl relative flex items-center justify-between px-6 py-3">
       <a href="/" class="flex items-center gap-2">
         <img src="/assets/logo.svg" alt="ScrapYardSites logo" class="h-6 w-6 md:h-8 md:w-8"/>
-        <span class="site-title text-xl md:text-2xl tracking-tight"><span class="font-bold text-brand-orange">Scrapyard</span> Sites</span>
+        <span class="site-title text-xl md:text-2xl tracking-tight"><span class="font-bold text-brand-orange">Scrapyard</span> <span class="font-bold">Sites</span></span>
       </a>
       <nav class="hidden md:flex absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 justify-center items-center gap-8 text-sm font-medium">
         <a href="/#why" class="text-brand-charcoal hover:text-brand-orange" title="Leaking here? ->">Why Us</a>

--- a/portfolio/demo-yard-3/index.html
+++ b/portfolio/demo-yard-3/index.html
@@ -29,7 +29,7 @@
     <div class="mx-auto max-w-7xl relative flex items-center justify-between px-6 py-3">
       <a href="/" class="flex items-center gap-2">
         <img src="/assets/logo.svg" alt="ScrapYardSites logo" class="h-6 w-6 md:h-8 md:w-8"/>
-        <span class="site-title text-xl md:text-2xl tracking-tight"><span class="font-bold text-brand-orange">Scrapyard</span> Sites</span>
+        <span class="site-title text-xl md:text-2xl tracking-tight"><span class="font-bold text-brand-orange">Scrapyard</span> <span class="font-bold">Sites</span></span>
       </a>
       <nav class="hidden md:flex absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 justify-center items-center gap-8 text-sm font-medium">
         <a href="/#why" class="text-brand-charcoal hover:text-brand-orange" title="Leaking here? ->">Why Us</a>

--- a/portfolio/index.html
+++ b/portfolio/index.html
@@ -27,7 +27,7 @@
 <body class="font-sans text-brand-charcoal antialiased bg-white overflow-x-hidden">
   <header class="fixed top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
     <nav class="max-w-7xl mx-auto relative flex items-center justify-between py-3 px-6">
-      <a href="/" class="flex items-center gap-2"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-8 w-8"/><span class="site-title text-xl text-brand-charcoal"><span class="font-bold text-brand-orange">Scrapyard</span> Sites</span></a>
+      <a href="/" class="flex items-center gap-2"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-8 w-8"/><span class="site-title text-xl text-brand-charcoal"><span class="font-bold text-brand-orange">Scrapyard</span> <span class="font-bold">Sites</span></span></a>
       <!-- Mobile hamburger (≤ 768 px) -->
       <button id="menuToggle" class="md:hidden p-2">
         <svg class="icon-open w-6 h-6" viewBox="0 0 24 24" fill="none"><path d="M3 6h18M3 12h18M3 18h18" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>

--- a/pricing/index.html
+++ b/pricing/index.html
@@ -27,7 +27,7 @@
 <body class="font-sans text-brand-charcoal antialiased bg-white overflow-x-hidden">
   <header class="fixed top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
     <nav class="max-w-7xl mx-auto relative flex items-center justify-between py-3 px-6">
-      <a href="/" class="flex items-center gap-2"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-8 w-8"/><span class="site-title text-xl text-brand-charcoal"><span class="font-bold text-brand-orange">Scrapyard</span> Sites</span></a>
+      <a href="/" class="flex items-center gap-2"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-8 w-8"/><span class="site-title text-xl text-brand-charcoal"><span class="font-bold text-brand-orange">Scrapyard</span> <span class="font-bold">Sites</span></span></a>
       <!-- Mobile hamburger (≤ 768 px) -->
       <button id="menuToggle" class="md:hidden p-2">
         <svg class="icon-open w-6 h-6" viewBox="0 0 24 24" fill="none"><path d="M3 6h18M3 12h18M3 18h18" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>

--- a/privacy/index.html
+++ b/privacy/index.html
@@ -92,7 +92,7 @@
 <body class="font-sans text-brand-charcoal antialiased bg-white overflow-x-hidden">
   <header class="fixed top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
     <nav class="max-w-7xl mx-auto relative flex items-center justify-between py-3 px-6">
-      <a href="/" class="flex items-center gap-2"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-8 w-8"/><span class="site-title text-xl text-brand-charcoal"><span class="font-bold text-brand-orange">Scrapyard</span> Sites</span></a>
+      <a href="/" class="flex items-center gap-2"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-8 w-8"/><span class="site-title text-xl text-brand-charcoal"><span class="font-bold text-brand-orange">Scrapyard</span> <span class="font-bold">Sites</span></span></a>
       <!-- Mobile hamburger (≤ 768 px) -->
       <button id="menuToggle" class="md:hidden p-2">
         <svg class="icon-open w-6 h-6" viewBox="0 0 24 24" fill="none"><path d="M3 6h18M3 12h18M3 18h18" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>

--- a/process/index.html
+++ b/process/index.html
@@ -55,7 +55,7 @@
 <body class="font-sans text-brand-charcoal antialiased bg-white overflow-x-hidden">
   <header class="fixed top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
     <nav class="max-w-7xl mx-auto relative flex items-center justify-between py-3 px-6">
-      <a href="/" class="flex items-center gap-2"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-8 w-8"/><span class="site-title text-xl text-brand-charcoal"><span class="font-bold text-brand-orange">Scrapyard</span> Sites</span></a>
+      <a href="/" class="flex items-center gap-2"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-8 w-8"/><span class="site-title text-xl text-brand-charcoal"><span class="font-bold text-brand-orange">Scrapyard</span> <span class="font-bold">Sites</span></span></a>
       <!-- Mobile hamburger (≤ 768 px) -->
       <button id="menuToggle" class="md:hidden p-2">
         <svg class="icon-open w-6 h-6" viewBox="0 0 24 24" fill="none"><path d="M3 6h18M3 12h18M3 18h18" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>

--- a/risk-calculator/index.html
+++ b/risk-calculator/index.html
@@ -27,7 +27,7 @@
 <body class="font-sans text-brand-charcoal antialiased bg-white overflow-x-hidden">
   <header class="fixed top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
     <nav class="max-w-7xl mx-auto relative flex items-center justify-between py-3 px-6">
-      <a href="/" class="flex items-center gap-2"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-8 w-8"/><span class="site-title text-xl text-brand-charcoal"><span class="font-bold text-brand-orange">Scrapyard</span> Sites</span></a>
+      <a href="/" class="flex items-center gap-2"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-8 w-8"/><span class="site-title text-xl text-brand-charcoal"><span class="font-bold text-brand-orange">Scrapyard</span> <span class="font-bold">Sites</span></span></a>
       <!-- Mobile hamburger (≤ 768 px) -->
       <button id="menuToggle" class="md:hidden p-2">
         <svg class="icon-open w-6 h-6" viewBox="0 0 24 24" fill="none"><path d="M3 6h18M3 12h18M3 18h18" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>

--- a/services/index.html
+++ b/services/index.html
@@ -81,7 +81,7 @@
 <body class="font-sans text-brand-charcoal antialiased bg-white overflow-x-hidden">
   <header class="fixed top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
     <nav class="max-w-7xl mx-auto relative flex items-center justify-between py-3 px-6">
-      <a href="/" class="flex items-center gap-2"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-8 w-8"/><span class="site-title text-xl text-brand-charcoal"><span class="font-bold text-brand-orange">Scrapyard</span> Sites</span></a>
+      <a href="/" class="flex items-center gap-2"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-8 w-8"/><span class="site-title text-xl text-brand-charcoal"><span class="font-bold text-brand-orange">Scrapyard</span> <span class="font-bold">Sites</span></span></a>
       <!-- Mobile hamburger (≤ 768 px) -->
       <button id="menuToggle" class="md:hidden p-2">
         <svg class="icon-open w-6 h-6" viewBox="0 0 24 24" fill="none"><path d="M3 6h18M3 12h18M3 18h18" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>


### PR DESCRIPTION
## Summary
- make `Scrapyard` orange and keep both words bold in the navbar on every page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686d8ceaf3988329958d1615fd10afe3