### PR TITLE
Remove card styling in How We Work section

### DIFF
--- a/index.html
+++ b/index.html
@@ -258,17 +258,17 @@
   <div class="mx-auto max-w-6xl px-6 text-center">
     <h2 class="text-3xl font-bold mb-8">How We Work</h2>
     <div class="grid gap-10 md:grid-cols-3">
-      <div class="bg-gray-50 border border-brand-steel/10 rounded-xl shadow-sm p-6 transition transform hover:-translate-y-1">
+      <div>
         <div class="process-step-number text-6xl font-black" data-aos="fade-up" data-aos-delay="0">1</div>
         <h3 class="font-semibold text-lg mt-3">Discovery Call</h3>
         <p class="text-base md:text-sm text-brand-steel mt-1">15 minutes to learn your yard, materials & amp draw area.</p>
       </div>
-      <div class="bg-gray-50 border border-brand-steel/10 rounded-xl shadow-sm p-6 transition transform hover:-translate-y-1">
+      <div>
         <div class="process-step-number text-6xl font-black" data-aos="fade-up" data-aos-delay="100">2</div>
         <h3 class="font-semibold text-lg mt-3">Build Week</h3>
         <p class="text-base md:text-sm text-brand-steel mt-1">We design, write and code. You review once—done.</p>
       </div>
-      <div class="bg-gray-50 border border-brand-steel/10 rounded-xl shadow-sm p-6 transition transform hover:-translate-y-1">
+      <div>
         <div class="process-step-number text-6xl font-black" data-aos="fade-up" data-aos-delay="200">3</div>
         <h3 class="font-semibold text-lg mt-3">Launch & Maintain</h3>
         <p class="text-base md:text-sm text-brand-steel mt-1">Site goes live, Google Business updated, $99/mo care plan kicks in.</p>


### PR DESCRIPTION
## Summary
- simplify "How We Work" section by removing card containers

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686e8cec7690832994aca517a407bd9b