### PR TITLE
Fix nav title color

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -76,3 +76,9 @@ header nav ul a,
   color: #2B2B2B;
 }
 
+
+/* Force "Scrapyard" word to appear orange */
+.site-title span:first-child {
+  color: #D75E02 !important;
+}
+


### PR DESCRIPTION
## Summary
- ensure the "Scrapyard" part of the site title is always orange

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686e8ed6ce5c8329aad13b90e9ae7813