### PR TITLE
Fix homepage sections not displaying due to JS error

### DIFF
--- a/index.html
+++ b/index.html
@@ -464,6 +464,7 @@
           entry.target.classList.add('aos-active');
           obs.unobserve(entry.target);
         }
+      });
     }, { threshold: 0.1 });
     aosEls.forEach(el => aosObserver.observe(el));
   } else if (prefersReduced) {


### PR DESCRIPTION
## Summary
- close a missing bracket in the AOS IntersectionObserver script

## Testing
- `tidy -q -e index.html` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e93d74b0c8329b0ba573d45dd4fc4