### PR TITLE
Add robots.txt and sitemap

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -1,1 +1,3 @@
+/robots.txt   /robots.txt   200
+/sitemap.xml  /sitemap.xml  200
 /*   /index.html   200

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://scrapyardsites.com/sitemap.xml

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>https://scrapyardsites.com/</loc></url>
+  <url><loc>https://scrapyardsites.com/about/</loc></url>
+  <url><loc>https://scrapyardsites.com/services/</loc></url>
+  <url><loc>https://scrapyardsites.com/pricing/</loc></url>
+  <url><loc>https://scrapyardsites.com/process/</loc></url>
+  <url><loc>https://scrapyardsites.com/risk-calculator/</loc></url>
+  <url><loc>https://scrapyardsites.com/portfolio/</loc></url>
+  <url><loc>https://scrapyardsites.com/portfolio/demo-yard-1/</loc></url>
+  <url><loc>https://scrapyardsites.com/portfolio/demo-yard-2/</loc></url>
+  <url><loc>https://scrapyardsites.com/portfolio/demo-yard-3/</loc></url>
+  <url><loc>https://scrapyardsites.com/contact/</loc></url>
+  <url><loc>https://scrapyardsites.com/privacy/</loc></url>
+</urlset>


### PR DESCRIPTION
## Summary
- add `/robots.txt` with link to sitemap
- create `/sitemap.xml`
- adjust Netlify `_redirects` so robots and sitemap are served directly

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68715e602bb48329a1524af1a032a840