### PR TITLE
Fix hero calculator button style

### DIFF
--- a/index.html
+++ b/index.html
@@ -191,7 +191,7 @@
     </p>
     <div class="mt-8 flex flex-col sm:flex-row gap-4 justify-center">
       <a href="/pricing" class="btn-primary">See Cost →</a>
-      <a href="/risk-calculator" class="inline-flex items-center justify-center px-5 py-3 font-semibold rounded-md bg-white text-brand-orange shadow hover:bg-gray-200">Calculate My Leak</a>
+      <a href="/risk-calculator" class="btn-primary">Calculate My Leak</a>
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Summary
- make hero's 'Calculate My Leak' button use the orange primary style

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68716b8cd09083298cbda76f6cc22f48