### PR TITLE
Adjust hero layout and button style

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -20,6 +20,7 @@
   align-items: center;
   justify-content: center;
   padding: 0.75rem 1.25rem;
+  background-color: white;
   border: 2px solid #D75E02;
   color: #D75E02;
   font-weight: 600;

--- a/index.html
+++ b/index.html
@@ -177,21 +177,21 @@
   </script>
 
 <!-- ── Hero ───────────────────────────────────────────────── -->
-<section class="relative text-center mt-24">
+<section class="relative text-center mt-24 flex items-center justify-center min-h-[80vh]">
   <img src="/assets/hero.jpg" alt="Scrapyard hero" class="absolute inset-0 w-full h-full object-cover"/>
   <div class="absolute inset-0 bg-black/80"></div>
-  <div class="relative z-10 py-24 md:py-32 px-6 max-w-4xl mx-auto text-white">
-    <h1 class="text-4xl md:text-5xl font-extrabold leading-tight">
+  <div class="relative z-10 py-32 md:py-40 px-6 max-w-4xl mx-auto text-white">
+    <h1 class="text-5xl md:text-6xl font-extrabold leading-tight">
       Your Outdated Site Is <span class="text-orange-600">Leaking Loads</span>
     </h1>
-    <p class="mt-4 max-w-xl mx-auto text-lg">
+    <p class="mt-4 max-w-xl mx-auto text-xl">
       An average roll‑off nets <strong>$2‑3 k</strong>.
       Let even two trucks a week drive past and you bleed <strong>$250 k +/yr</strong>.
       We plug that hole—in <em>7 days</em>—or your build is free.
     </p>
     <div class="mt-8 flex flex-col sm:flex-row gap-4 justify-center">
       <a href="/pricing" class="btn-primary">See Cost →</a>
-      <a href="/risk-calculator" class="btn-primary">Calculate My Leak</a>
+      <a href="/risk-calculator" class="btn-secondary">Calculate My Leak</a>
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Summary
- expand hero section and center text vertically
- enlarge hero typography for better readability
- make the "Calculate My Leak" button white with orange text

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68716da11d54832987c68fa0938a69fc