### PR TITLE
Remove hero CTA border

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -21,7 +21,7 @@
   justify-content: center;
   padding: 0.75rem 1.25rem;
   background-color: white;
-  border: 2px solid #D75E02;
+  border: none;
   color: #D75E02;
   font-weight: 600;
   line-height: 1;


### PR DESCRIPTION
## Summary
- remove the orange outline from the secondary CTA button

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6873ef49a00c832991fa97cdb3775457