### PR TITLE
Fix hero gap

### DIFF
--- a/index.html
+++ b/index.html
@@ -177,7 +177,7 @@
   </script>
 
 <!-- ── Hero ───────────────────────────────────────────────── -->
-<section class="relative text-center mt-24 flex items-center justify-center min-h-[80vh]">
+<section class="relative text-center flex items-center justify-center min-h-[80vh]">
   <img src="/assets/hero.jpg" alt="Scrapyard hero" class="absolute inset-0 w-full h-full object-cover"/>
   <div class="absolute inset-0 bg-black/80"></div>
   <div class="relative z-10 py-32 md:py-40 px-6 max-w-4xl mx-auto text-white">


### PR DESCRIPTION
## Summary
- remove top margin from hero section so the hero image sits directly beneath the fixed navbar

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6873ef18ff2c8329ba9e6b58c5b1626e