### PR TITLE
Add Stripe Buy Button

### DIFF
--- a/pricing/index.html
+++ b/pricing/index.html
@@ -108,6 +108,12 @@
               <li>• Google Business Profile tune-up + basic SEO</li>
               <li>• 30 days of free tweaks</li>
             </ul>
+            <script async src="https://js.stripe.com/v3/buy-button.js"></script>
+            <stripe-buy-button
+              buy-button-id="buy_btn_1RkUCaF8fsrvSO5cMrdaQHho"
+              publishable-key="pk_live_51RckynF8fsrvSO5cFqrhaJHMEr8ALuwbutxDjmhOcyHEFx9eRpCCGlPDLmhqHgSgm3vJgU5MoWVTY4MptvQQsJam00l7CjqBwr"
+            >
+            </stripe-buy-button>
           </div>
           <!-- Premium Launch -->
           <div class="bg-gray-50 border border-brand-steel/10 rounded-xl shadow-sm transition transform hover:-translate-y-1 p-10">


### PR DESCRIPTION
## Summary
- add payment button via Stripe to the Standard Launch card on the pricing page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6873f4ac7de88329a89e31e79030078c