### PR TITLE
Add Stripe buy button to Premium Launch

### DIFF
--- a/pricing/index.html
+++ b/pricing/index.html
@@ -113,14 +113,16 @@
           <div class="bg-gray-50 border border-brand-steel/10 rounded-xl shadow-sm transition transform hover:-translate-y-1 p-10">
             <h3 class="text-xl font-semibold mb-4">Premium Launch</h3>
             <p class="text-5xl font-extrabold tracking-tight">$5,499</p>
-            <ul class="text-base md:text-sm text-brand-steel mt-6 space-y-2 text-left">
-              <li>• Full insurance policy: multi-page muscle so Google never buries you again.</li>
-              <li>• Contact forms on every key page</li>
-              <li>• Location pages with Google Maps</li>
-              <li>• Structured-data SEO + GBP cleanup</li>
-              <li>• 60 days of fine-tuning after go-live</li>
-            </ul>
-          </div>
+          <ul class="text-base md:text-sm text-brand-steel mt-6 space-y-2 text-left">
+            <li>• Full insurance policy: multi-page muscle so Google never buries you again.</li>
+            <li>• Contact forms on every key page</li>
+            <li>• Location pages with Google Maps</li>
+            <li>• Structured-data SEO + GBP cleanup</li>
+            <li>• 60 days of fine-tuning after go-live</li>
+          </ul>
+          <script async src="https://js.stripe.com/v3/buy-button.js"></script>
+          <stripe-buy-button buy-button-id="buy_btn_1RkUG2F8fsrvSO5cgPQ5HFg1" publishable-key="pk_live_51RckynF8fsrvSO5cFqrhaJHMEr8ALuwbutxDjmhOcyHEFx9eRpCCGlPDLmhqHgSgm3vJgU5MoWVTY4MptvQQsJam00l7CjqBwr"></stripe-buy-button>
+        </div>
           <!-- Care Plan -->
           <div class="bg-gray-50 border border-brand-steel/10 rounded-xl shadow-sm transition transform hover:-translate-y-1 p-10">
             <h3 class="text-xl font-semibold mb-4">Care Plan</h3>


### PR DESCRIPTION
## Summary
- embed Stripe payment button in Premium Launch card on the pricing page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6873f537b3948329b4033bc556bfbb1a