### PR TITLE
Update pricing deposit buttons

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -83,16 +83,4 @@ header nav ul a,
   color: #D75E02 !important;
 }
 
-/* Stripe deposit buttons */
-.deposit-btn {
-  display: inline-block;
-  transition: opacity 0.2s;
-}
-.deposit-btn:hover {
-  opacity: 0.9;
-}
-.deposit-btn iframe {
-  width: 9rem !important;
-  margin: 0 auto;
-}
 

--- a/pricing/index.html
+++ b/pricing/index.html
@@ -109,13 +109,12 @@
               <li>• 30 days of free tweaks</li>
             </ul>
             <div class="mt-auto text-center">
-              <script async src="https://js.stripe.com/v3/buy-button.js"></script>
-              <stripe-buy-button
-                buy-button-id="buy_btn_1RkUCaF8fsrvSO5cMrdaQHho"
-                publishable-key="pk_live_51RckynF8fsrvSO5cFqrhaJHMEr8ALuwbutxDjmhOcyHEFx9eRpCCGlPDLmhqHgSgm3vJgU5MoWVTY4MptvQQsJam00l7CjqBwr"
-                class="deposit-btn"
+              <a
+                href="https://book.stripe.com/eVqeVd8Vi9U45RbdJy73G00"
+                class="btn-primary"
               >
-              </stripe-buy-button>
+                Pay Deposit
+              </a>
             </div>
           </div>
           <!-- Premium Launch -->
@@ -130,12 +129,12 @@
             <li>• 60 days of fine-tuning after go-live</li>
           </ul>
           <div class="mt-auto text-center">
-            <script async src="https://js.stripe.com/v3/buy-button.js"></script>
-            <stripe-buy-button
-              buy-button-id="buy_btn_1RkUG2F8fsrvSO5cgPQ5HFg1"
-              publishable-key="pk_live_51RckynF8fsrvSO5cFqrhaJHMEr8ALuwbutxDjmhOcyHEFx9eRpCCGlPDLmhqHgSgm3vJgU5MoWVTY4MptvQQsJam00l7CjqBwr"
-              class="deposit-btn"
-            ></stripe-buy-button>
+            <a
+              href="https://book.stripe.com/4gM28r2wU7LW3J36h673G01"
+              class="btn-primary"
+            >
+              Pay Deposit
+            </a>
           </div>
         </div>
           <!-- Care Plan -->


### PR DESCRIPTION
## Summary
- replace Stripe deposit buttons with direct payment links
- remove unused deposit button CSS

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6873fa518a148329af5d30598fa53364