### PR TITLE
Remove Get Started CTA from pricing

### DIFF
--- a/index.html
+++ b/index.html
@@ -108,9 +108,6 @@
       transform: translateY(0);
       transition: opacity 0.6s ease-out, transform 0.6s ease-out;
     }
-    #cta-final.aos-active {
-      transition-duration: 0.25s;
-    }
 
   </style>
 </head>
@@ -343,9 +340,6 @@
       </div>
     </div>
 
-    <a id="cta-final" href="#contact" class="btn-primary mt-12">
-      Get Started
-    </a>
   </div>
 </section>
 


### PR DESCRIPTION
## Summary
- drop the Get Started button from the Pricing section on the homepage
- clean up unused CSS for the removed button

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6873ff0344588329a7739c522febf11d