### PR TITLE
Disable nav bar animations on mobile

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -102,3 +102,15 @@ header nav ul a,
 }
 
 
+@media (max-width: 767px) {
+  header nav ul a::after,
+  #mobileMenu a:not(.bg-yellow-500)::after,
+  .site-title::after {
+    transition: none !important;
+  }
+  header nav ul a:hover::after,
+  #mobileMenu a:not(.bg-yellow-500):hover::after,
+  a:hover .site-title::after {
+    width: 0 !important;
+  }
+}


### PR DESCRIPTION
## Summary
- turn off nav bar underline effects on small screens

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687404f5ad2c8329af2207a64f7ff58b