### PR TITLE
Fix about page hero layout and card style

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -98,10 +98,10 @@
   document.getElementById('menuClose')?.addEventListener('click', toggleMobileMenu);
 
   </script>
-  <main class="pt-24 pb-20 px-0">
+  <main class="pt-0 pb-20 px-0">
 <section class="relative text-center flex items-center justify-center min-h-[60vh]">
   <img src="/assets/hero.jpg" alt="Scrapyard hero" class="absolute inset-0 w-full h-full object-cover" />
-  <div class="absolute inset-0 bg-black/70"></div>
+  <div class="absolute inset-0 bg-black/80"></div>
   <div class="relative z-10 px-6">
     <p class="uppercase tracking-widest text-white text-sm mb-2">Websites that ship scrap to your scale.</p>
     <h1 class="text-4xl md:text-5xl font-extrabold text-white">From the Melt Shop to the Keyboard</h1>
@@ -130,22 +130,22 @@
 <section class="mt-16 max-w-4xl mx-auto">
   <h2 class="text-2xl font-bold text-center mb-8">Shields</h2>
   <div class="grid gap-6 md:grid-cols-2 px-6">
-    <article class="card-hover p-6 bg-white rounded-md text-center" data-aos="fade-up" data-aos-delay="0">
+    <article class="bg-gray-50 border border-brand-steel/10 rounded-xl shadow-sm p-6 text-center transition transform hover:-translate-y-1" data-aos="fade-up" data-aos-delay="0">
       <i class="fa-solid fa-shield-alt text-5xl card-icon mb-4" data-icon></i>
       <h3 class="font-semibold mb-1">Credibility Shield</h3>
       <p class="text-sm">Sub‑2‑second load times, SSL, and real yard photos build instant trust.</p>
     </article>
-    <article class="card-hover p-6 bg-white rounded-md text-center" data-aos="fade-up" data-aos-delay="100">
+    <article class="bg-gray-50 border border-brand-steel/10 rounded-xl shadow-sm p-6 text-center transition transform hover:-translate-y-1" data-aos="fade-up" data-aos-delay="100">
       <i class="fa-solid fa-comment-slash text-5xl card-icon mb-4" data-icon></i>
       <h3 class="font-semibold mb-1">Objection Shield</h3>
       <p class="text-sm">Copy written around the questions sellers actually ask—grades, pricing cadence, pick‑up radius.</p>
     </article>
-    <article class="card-hover p-6 bg-white rounded-md text-center" data-aos="fade-up" data-aos-delay="200">
+    <article class="bg-gray-50 border border-brand-steel/10 rounded-xl shadow-sm p-6 text-center transition transform hover:-translate-y-1" data-aos="fade-up" data-aos-delay="200">
       <i class="fa-solid fa-eye text-5xl card-icon mb-4" data-icon></i>
       <h3 class="font-semibold mb-1">Visibility Shield</h3>
       <p class="text-sm">Local SEO schema and keyword research so you appear above chain recyclers in the map pack.</p>
     </article>
-    <article class="card-hover p-6 bg-white rounded-md text-center" data-aos="fade-up" data-aos-delay="300">
+    <article class="bg-gray-50 border border-brand-steel/10 rounded-xl shadow-sm p-6 text-center transition transform hover:-translate-y-1" data-aos="fade-up" data-aos-delay="300">
       <i class="fa-solid fa-screwdriver-wrench text-5xl card-icon mb-4" data-icon></i>
       <h3 class="font-semibold mb-1">Reliability Shield</h3>
       <p class="text-sm">Ongoing care plan with uptime monitoring, backups, and content edits—so the site never rusts.</p>


### PR DESCRIPTION
## Summary
- remove top padding so about page hero touches navbar
- match about hero overlay shade to index
- copy card hover style from home page "Why Generalist" section

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68740a4467a483299287ac2e55db9a14