### PR TITLE
Remove sticky CTA from process page

### DIFF
--- a/process/index.html
+++ b/process/index.html
@@ -162,9 +162,6 @@
           </li>
         </ol>
 
-        <!-- Sticky CTA only shows ≤ 640 px -->
-        <a href="/risk-calculator"
-           class="md:hidden fixed bottom-4 left-1/2 -translate-x-1/2 w-11/12 text-center btn-primary">Know Your Leak in 60 s</a>
       </div>
     </section>
     <section class="py-12">


### PR DESCRIPTION
## Summary
- remove the mobile-only sticky CTA from `process/index.html`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68740be534b4832994b0dde8fc2ace3e