### PR TITLE
Remove Calendly from contact page

### DIFF
--- a/contact/index.html
+++ b/contact/index.html
@@ -101,9 +101,6 @@
         <button type="submit" class="btn-primary">Send →</button>
       </form>
       <p class="text-center text-sm mt-6">Prefer immediate answers? <a href="tel:+19493568762" class="underline">Call 949‑356‑8762</a></p>
-      <div class="mt-10">
-        <iframe src="https://calendly.com/your-calendar" class="w-full h-[630px]"></iframe>
-      </div>
     </div>
     <section class="mt-20 max-w-4xl mx-auto" id="faq">
       <h2 class="text-3xl font-bold text-center mb-10">FAQ</h2>


### PR DESCRIPTION
## Summary
- remove Calendly iframe embed from `contact/index.html`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68740c195fdc83298e4161d50028731d