### PR TITLE
Fix risk calculator title alignment

### DIFF
--- a/risk-calculator/index.html
+++ b/risk-calculator/index.html
@@ -89,7 +89,7 @@
   <main class="pt-24 pb-32 px-6">
     <section class="py-16">
       <div class="max-w-xl mx-auto px-6 text-center">
-      <h1 class="text-3xl font-bold text-center">Reputation Risk Calculator</h1>
+      <h1 class="text-3xl font-bold text-center mx-auto w-max">Reputation Risk Calculator</h1>
       <p class="text-sm max-w-md mx-auto text-center mt-2">
         Every missed call is material on your competitor’s scale.
         Run the numbers—see what procrastination costs.


### PR DESCRIPTION
## Summary
- ensure the risk calculator page title is centered on mobile

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68740bff5cd88329a131382c5bd6b8bb