### PR TITLE
Fix CTA color and hero spacing on About page

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -106,7 +106,7 @@
     <a href="/contact" class="btn-primary mt-6 inline-block">Book a Call</a>
   </div>
 </section>
-<section class="mt-16 bg-gray-50 py-16">
+<section class="bg-gray-50 py-16">
   <div class="max-w-6xl mx-auto grid md:grid-cols-2 gap-10 items-center px-6">
     <img src="/assets/hero.jpg" alt="Elias Burlison" class="rounded-lg shadow" />
     <div>
@@ -160,7 +160,7 @@
   </div>
 </section>
 <section class="mt-16 bg-brand-charcoal text-white py-12 text-center">
-  <h2 class="text-2xl font-bold">Ready to Plug the Revenue Leak?</h2>
+  <h2 class="text-2xl font-bold text-brand-orange">Ready to Plug the Revenue Leak?</h2>
   <div class="mt-6 flex flex-col sm:flex-row gap-4 justify-center">
     <a href="/risk-calculator" class="btn-primary">Calculator</a>
     <a href="/contact" class="btn-primary">Book Call</a>


### PR DESCRIPTION
## Summary
- remove unwanted margin after hero section
- make CTA heading text orange

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687410c941c48329951cab907d6b6356