### PR TITLE
Fix about page CTA color

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -160,7 +160,7 @@
   </div>
 </section>
 <section class="mt-16 bg-brand-charcoal text-white py-12 text-center">
-  <h2 class="text-2xl font-bold text-brand-orange">Ready to Plug the Revenue Leak?</h2>
+  <h2 class="text-2xl font-bold" style="color:#D75E02">Ready to Plug the Revenue Leak?</h2>
   <div class="mt-6 flex flex-col sm:flex-row gap-4 justify-center">
     <a href="/risk-calculator" class="btn-primary">Calculator</a>
     <a href="/contact" class="btn-primary">Book Call</a>


### PR DESCRIPTION
## Summary
- ensure "Ready to Plug the Revenue Leak?" displays in brand orange

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_687412bad8008329a3a0ad81623f82b8