### PR TITLE
Fix mobile carousel and animations

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -44,6 +44,7 @@
 /* Large numbers in the "How We Work" section */
 .process-step-number {
   color: #D75E02;
+  margin-bottom: 0.5rem;
 }
 
 

--- a/index.html
+++ b/index.html
@@ -111,12 +111,18 @@
     [data-aos="whoosh"] {
       transform: translateY(60px);
     }
+    .aos-active[data-aos="whoosh"] {
+      transform: translateY(0);
+    }
 @media (max-width: 767px) {
   [data-aos] {
     transform: translateY(40px);
   }
   [data-aos="whoosh"] {
     transform: translateY(80px);
+  }
+  .aos-active[data-aos="whoosh"] {
+    transform: translateY(0);
   }
   .aos-active {
     transition-duration: 0.4s;
@@ -310,17 +316,17 @@
     <h2 class="text-3xl font-bold mb-8">How We Work</h2>
     <div id="process-carousel" class="grid gap-10 md:grid-cols-3">
       <div>
-        <div class="process-step-number text-6xl font-black" data-aos="fade-up" data-aos-delay="0">1</div>
+        <div class="process-step-number text-6xl font-black mb-2" data-aos="fade-up" data-aos-delay="0">1</div>
         <h3 class="font-semibold text-lg mt-3">Discovery Call</h3>
         <p class="text-base md:text-sm text-brand-steel mt-1">15 minutes to learn your yard, materials & amp draw area.</p>
       </div>
       <div>
-        <div class="process-step-number text-6xl font-black" data-aos="fade-up" data-aos-delay="100">2</div>
+        <div class="process-step-number text-6xl font-black mb-2" data-aos="fade-up" data-aos-delay="100">2</div>
         <h3 class="font-semibold text-lg mt-3">Build Week</h3>
         <p class="text-base md:text-sm text-brand-steel mt-1">We design, write and code. You review once—done.</p>
       </div>
       <div>
-        <div class="process-step-number text-6xl font-black" data-aos="fade-up" data-aos-delay="200">3</div>
+        <div class="process-step-number text-6xl font-black mb-2" data-aos="fade-up" data-aos-delay="200">3</div>
         <h3 class="font-semibold text-lg mt-3">Launch & Maintain</h3>
         <p class="text-base md:text-sm text-brand-steel mt-1">Site goes live, Google Business updated, $99/mo care plan kicks in.</p>
       </div>
@@ -336,7 +342,7 @@
       No hidden fees, no “call for quote”. You’ll know the cost before we write a line of code.
     </p>
 
-    <div id="pricing-carousel" class="carousel-track overflow-visible mt-14 flex gap-10 md:grid md:grid-cols-2 lg:grid-cols-3">
+    <div id="pricing-carousel" class="carousel-track overflow-x-auto mt-14 flex gap-10 md:grid md:grid-cols-2 lg:grid-cols-3">
       <!-- Launch -->
       <div class="carousel-item relative overflow-visible bg-gray-50 border border-brand-steel/10 rounded-xl shadow-sm transition transform hover:-translate-y-1 p-10">
         <span
@@ -541,7 +547,8 @@
   function initCarousel(id) {
     const track = document.getElementById(id);
     if (!track) return;
-    const slideCount = track.children.length;
+    const slides = Array.from(track.children);
+    const slideCount = slides.length;
 
     const indicators = document.createElement('div');
     indicators.className = 'carousel-indicators';
@@ -561,9 +568,11 @@
       });
     }
 
+    const slideWidth = slides[1] ? slides[1].offsetLeft - slides[0].offsetLeft : track.clientWidth;
+
     function goTo(i) {
       index = i;
-      track.scrollTo({ left: track.clientWidth * index, behavior: 'smooth' });
+      track.scrollTo({ left: slideWidth * index, behavior: 'smooth' });
       updateDots(index);
     }
 
@@ -597,7 +606,7 @@
     visibility.observe(track.parentElement || track);
 
     track.addEventListener('scroll', () => {
-      const i = Math.round(track.scrollLeft / track.clientWidth);
+      const i = Math.round(track.scrollLeft / slideWidth);
       if (i !== index) {
         index = i;
         updateDots(index);

--- a/pricing/index.html
+++ b/pricing/index.html
@@ -101,7 +101,7 @@
         </p>
 
         <!-- Packages -->
-        <div id="pricing-carousel" class="carousel-track overflow-visible mt-14 flex gap-10 md:grid md:grid-cols-2 lg:grid-cols-3">
+        <div id="pricing-carousel" class="carousel-track overflow-x-auto mt-14 flex gap-10 md:grid md:grid-cols-2 lg:grid-cols-3">
           <!-- Launch -->
           <div class="carousel-item relative overflow-visible bg-gray-50 border border-brand-steel/10 rounded-xl shadow-sm transition transform hover:-translate-y-1 p-10 flex flex-col">
             <span
@@ -184,16 +184,17 @@
   <script>document.getElementById('year').textContent=new Date().getFullYear();</script>
   <script>
   function initCarousel(id){
-    const track=document.getElementById(id);if(!track)return;const slideCount=track.children.length;
+    const track=document.getElementById(id);if(!track)return;const slides=Array.from(track.children);const slideCount=slides.length;
     const indicators=document.createElement('div');indicators.className='carousel-indicators';
     for(let i=0;i<slideCount;i++){const dot=document.createElement('span');if(i===0)dot.classList.add('active');indicators.appendChild(dot);}track.after(indicators);
     let index=0;let interval;function updateDots(i){indicators.querySelectorAll('span').forEach((dot,idx)=>{dot.classList.toggle('active',idx===i);});}
-    function goTo(i){index=i;track.scrollTo({left:track.clientWidth*index,behavior:'smooth'});updateDots(index);} 
+    const slideWidth=slides[1]?slides[1].offsetLeft-slides[0].offsetLeft:track.clientWidth;
+    function goTo(i){index=i;track.scrollTo({left:slideWidth*index,behavior:'smooth'});updateDots(index);}
     function start(){if(!interval)interval=setInterval(()=>{goTo((index+1)%slideCount);},4000);} 
     function stop(){if(interval){clearInterval(interval);interval=null;}}
     const visibility=new IntersectionObserver(entries=>{entries.forEach(entry=>{const fully=entry.isIntersecting&&entry.intersectionRect.height>=entry.boundingClientRect.height&&entry.intersectionRect.top>=0&&entry.intersectionRect.bottom<=window.innerHeight;if(fully){start();}else{stop();}});},{threshold:[0,1]});
     visibility.observe(track.parentElement||track);
-    track.addEventListener('scroll',()=>{const i=Math.round(track.scrollLeft/track.clientWidth);if(i!==index){index=i;updateDots(index);}});
+    track.addEventListener('scroll',()=>{const i=Math.round(track.scrollLeft/slideWidth);if(i!==index){index=i;updateDots(index);}});
   }
   if(window.matchMedia('(max-width: 767px)').matches){initCarousel('pricing-carousel');}
   </script>


### PR DESCRIPTION
## Summary
- make pricing carousel scrollable on mobile
- adjust AOS whoosh animation so it triggers correctly
- add bottom margin to process step numbers
- improve mobile carousel script in pricing page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68741432bb8883298bb15ea7fc8a0d7a