### PR TITLE
Fix orange background on home page

### DIFF
--- a/index.html
+++ b/index.html
@@ -249,7 +249,7 @@
 </section>
 
 <!-- ── Why Us ──────────────────────────────────────────────── -->
-<section class="py-16 bg-brand-orange text-white">
+<section class="py-16 bg-brand-orange text-white" style="background-color:#D75E02">
   <div class="max-w-6xl mx-auto px-6">
   <h2 class="text-2xl font-bold mb-10 text-center">Why Generalist Agencies Leave You Exposed</h2>
 


### PR DESCRIPTION
## Summary
- ensure the "Why Generalist Agencies Leave You Exposed" section uses inline orange background

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6874146d76f08329b60b70ff2c913e9c