### PR TITLE
Fix card text and pricing section layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -255,9 +255,9 @@
 </section>
 
 <!-- ── Why Us ──────────────────────────────────────────────── -->
-<section class="py-16 bg-brand-orange text-white" style="background-color:#D75E02">
+<section class="py-16 bg-brand-orange" style="background-color:#D75E02">
   <div class="max-w-6xl mx-auto px-6">
-  <h2 class="text-2xl font-bold mb-10 text-center">Why Generalist Agencies Leave You Exposed</h2>
+  <h2 class="text-2xl font-bold mb-10 text-center text-white">Why Generalist Agencies Leave You Exposed</h2>
 
   <div id="why-carousel" class="grid gap-8 md:grid-cols-3 text-sm text-brand-charcoal">
     <article class="bg-gray-50 border border-brand-steel/10 rounded-xl shadow-sm p-6 text-center transition hover:-translate-y-1" data-aos="fade-up" data-aos-delay="0">
@@ -342,7 +342,7 @@
       No hidden fees, no “call for quote”. You’ll know the cost before we write a line of code.
     </p>
 
-    <div id="pricing-carousel" class="carousel-track overflow-x-auto mt-14 flex gap-10 md:grid md:grid-cols-2 lg:grid-cols-3">
+    <div id="pricing-carousel" class="carousel-track overflow-x-auto overflow-y-visible mt-14 flex gap-10 md:grid md:grid-cols-2 lg:grid-cols-3">
       <!-- Launch -->
       <div class="carousel-item relative overflow-visible bg-gray-50 border border-brand-steel/10 rounded-xl shadow-sm transition transform hover:-translate-y-1 p-10">
         <span


### PR DESCRIPTION
## Summary
- update Why Us section so card text renders dark
- allow pricing cards to rise without clipping

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6874183a8c68832984f0d2efc043a15b