### PR TITLE
Fix mobile menu title highlight

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -56,7 +56,7 @@
     </nav>
     <!-- Full-screen mobile menu -->
     <div id="mobileMenu" class="text-brand-charcoal md:hidden fixed inset-0 z-50 flex flex-col items-center justify-center gap-6 text-xl font-medium bg-white hidden">
-      <a href="/" class="absolute left-1/2 top-3 flex items-center gap-2" style="transform:translateX(calc(-50% - 1rem))"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-8 w-8"/><span class="site-title text-2xl text-brand-charcoal relative -top-0.5"><span class="font-bold text-brand-orange">Scrapyard</span> <span class="font-bold">Sites</span></span></a>
+      <a href="/" class="absolute left-1/2 -translate-x-1/2 top-3 flex items-center gap-2 no-highlight"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-8 w-8"/><span class="site-title text-2xl text-brand-charcoal relative -top-0.5"><span class="font-bold text-brand-orange">Scrapyard</span> <span class="font-bold">Sites</span></span></a>
       <button id="menuClose" class="absolute top-4 right-4 p-2">
         <svg class="w-6 h-6" viewBox="0 0 24 24" fill="none"><path d="M6 6l12 12M6 18L18 6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
       </button>
@@ -83,7 +83,7 @@
     const currentPath = location.pathname
       .replace(/\/index.html$/, '')
       .replace(/\/$/, '');
-    document.querySelectorAll('#menu a, #mobileMenu a').forEach(link => {
+    document.querySelectorAll('#menu a:not(.no-highlight), #mobileMenu a:not(.no-highlight)').forEach(link => {
       const linkPath = new URL(link.getAttribute('href'), location.origin).pathname
         .replace(/\/index.html$/, '')
         .replace(/\/$/, '');

--- a/contact/index.html
+++ b/contact/index.html
@@ -46,7 +46,7 @@
     </nav>
     <!-- Full-screen mobile menu -->
     <div id="mobileMenu" class="text-brand-charcoal md:hidden fixed inset-0 z-50 flex flex-col items-center justify-center gap-6 text-xl font-medium bg-white hidden">
-      <a href="/" class="absolute left-1/2 top-3 flex items-center gap-2" style="transform:translateX(calc(-50% - 1rem))"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-8 w-8"/><span class="site-title text-2xl text-brand-charcoal relative -top-0.5"><span class="font-bold text-brand-orange">Scrapyard</span> <span class="font-bold">Sites</span></span></a>
+      <a href="/" class="absolute left-1/2 -translate-x-1/2 top-3 flex items-center gap-2 no-highlight"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-8 w-8"/><span class="site-title text-2xl text-brand-charcoal relative -top-0.5"><span class="font-bold text-brand-orange">Scrapyard</span> <span class="font-bold">Sites</span></span></a>
       <button id="menuClose" class="absolute top-4 right-4 p-2">
         <svg class="w-6 h-6" viewBox="0 0 24 24" fill="none"><path d="M6 6l12 12M6 18L18 6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
       </button>
@@ -73,7 +73,7 @@
     const currentPath = location.pathname
       .replace(/\/index.html$/, '')
       .replace(/\/$/, '');
-    document.querySelectorAll('#menu a, #mobileMenu a').forEach(link => {
+    document.querySelectorAll('#menu a:not(.no-highlight), #mobileMenu a:not(.no-highlight)').forEach(link => {
       const linkPath = new URL(link.getAttribute('href'), location.origin).pathname
         .replace(/\/index.html$/, '')
         .replace(/\/$/, '');

--- a/index.html
+++ b/index.html
@@ -191,7 +191,7 @@
     </nav>
     <!-- Full-screen mobile menu -->
     <div id="mobileMenu" class="text-brand-charcoal md:hidden fixed inset-0 z-50 flex flex-col items-center justify-center gap-6 text-xl font-medium bg-white hidden">
-      <a href="/" class="absolute left-1/2 top-3 flex items-center gap-2" style="transform:translateX(calc(-50% - 1rem))"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-8 w-8"/><span class="site-title text-2xl text-brand-charcoal relative -top-0.5"><span class="font-bold text-brand-orange">Scrapyard</span> <span class="font-bold">Sites</span></span></a>
+      <a href="/" class="absolute left-1/2 -translate-x-1/2 top-3 flex items-center gap-2 no-highlight"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-8 w-8"/><span class="site-title text-2xl text-brand-charcoal relative -top-0.5"><span class="font-bold text-brand-orange">Scrapyard</span> <span class="font-bold">Sites</span></span></a>
       <button id="menuClose" class="absolute top-4 right-4 p-2">
         <svg class="w-6 h-6" viewBox="0 0 24 24" fill="none"><path d="M6 6l12 12M6 18L18 6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
       </button>
@@ -219,7 +219,7 @@
     const currentPath = location.pathname
       .replace(/\/index.html$/, '')
       .replace(/\/$/, '');
-    document.querySelectorAll('#menu a, #mobileMenu a').forEach(link => {
+    document.querySelectorAll('#menu a:not(.no-highlight), #mobileMenu a:not(.no-highlight)').forEach(link => {
       const linkPath = new URL(link.getAttribute('href'), location.origin).pathname
         .replace(/\/index.html$/, '')
         .replace(/\/$/, '');

--- a/portfolio/index.html
+++ b/portfolio/index.html
@@ -46,7 +46,7 @@
     </nav>
     <!-- Full-screen mobile menu -->
     <div id="mobileMenu" class="text-brand-charcoal md:hidden fixed inset-0 z-50 flex flex-col items-center justify-center gap-6 text-xl font-medium bg-white hidden">
-      <a href="/" class="absolute left-1/2 top-3 flex items-center gap-2" style="transform:translateX(calc(-50% - 1rem))"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-8 w-8"/><span class="site-title text-2xl text-brand-charcoal relative -top-0.5"><span class="font-bold text-brand-orange">Scrapyard</span> <span class="font-bold">Sites</span></span></a>
+      <a href="/" class="absolute left-1/2 -translate-x-1/2 top-3 flex items-center gap-2 no-highlight"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-8 w-8"/><span class="site-title text-2xl text-brand-charcoal relative -top-0.5"><span class="font-bold text-brand-orange">Scrapyard</span> <span class="font-bold">Sites</span></span></a>
       <button id="menuClose" class="absolute top-4 right-4 p-2">
         <svg class="w-6 h-6" viewBox="0 0 24 24" fill="none"><path d="M6 6l12 12M6 18L18 6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
       </button>
@@ -73,7 +73,7 @@
     const currentPath = location.pathname
       .replace(/\/index.html$/, '')
       .replace(/\/$/, '');
-    document.querySelectorAll('#menu a, #mobileMenu a').forEach(link => {
+    document.querySelectorAll('#menu a:not(.no-highlight), #mobileMenu a:not(.no-highlight)').forEach(link => {
       const linkPath = new URL(link.getAttribute('href'), location.origin).pathname
         .replace(/\/index.html$/, '')
         .replace(/\/$/, '');

--- a/pricing/index.html
+++ b/pricing/index.html
@@ -50,7 +50,7 @@
     </nav>
     <!-- Full-screen mobile menu -->
     <div id="mobileMenu" class="text-brand-charcoal md:hidden fixed inset-0 z-50 flex flex-col items-center justify-center gap-6 text-xl font-medium bg-white hidden">
-      <a href="/" class="absolute left-1/2 top-3 flex items-center gap-2" style="transform:translateX(calc(-50% - 1rem))"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-8 w-8"/><span class="site-title text-2xl text-brand-charcoal relative -top-0.5"><span class="font-bold text-brand-orange">Scrapyard</span> <span class="font-bold">Sites</span></span></a>
+      <a href="/" class="absolute left-1/2 -translate-x-1/2 top-3 flex items-center gap-2 no-highlight"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-8 w-8"/><span class="site-title text-2xl text-brand-charcoal relative -top-0.5"><span class="font-bold text-brand-orange">Scrapyard</span> <span class="font-bold">Sites</span></span></a>
       <button id="menuClose" class="absolute top-4 right-4 p-2">
         <svg class="w-6 h-6" viewBox="0 0 24 24" fill="none"><path d="M6 6l12 12M6 18L18 6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
       </button>
@@ -77,7 +77,7 @@
     const currentPath = location.pathname
       .replace(/\/index.html$/, '')
       .replace(/\/$/, '');
-    document.querySelectorAll('#menu a, #mobileMenu a').forEach(link => {
+    document.querySelectorAll('#menu a:not(.no-highlight), #mobileMenu a:not(.no-highlight)').forEach(link => {
       const linkPath = new URL(link.getAttribute('href'), location.origin).pathname
         .replace(/\/index.html$/, '')
         .replace(/\/$/, '');

--- a/privacy/index.html
+++ b/privacy/index.html
@@ -111,7 +111,7 @@
     </nav>
     <!-- Full-screen mobile menu -->
     <div id="mobileMenu" class="text-brand-charcoal md:hidden fixed inset-0 z-50 flex flex-col items-center justify-center gap-6 text-xl font-medium bg-white hidden">
-      <a href="/" class="absolute left-1/2 top-3 flex items-center gap-2" style="transform:translateX(calc(-50% - 1rem))"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-8 w-8"/><span class="site-title text-2xl text-brand-charcoal relative -top-0.5"><span class="font-bold text-brand-orange">Scrapyard</span> <span class="font-bold">Sites</span></span></a>
+      <a href="/" class="absolute left-1/2 -translate-x-1/2 top-3 flex items-center gap-2 no-highlight"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-8 w-8"/><span class="site-title text-2xl text-brand-charcoal relative -top-0.5"><span class="font-bold text-brand-orange">Scrapyard</span> <span class="font-bold">Sites</span></span></a>
       <button id="menuClose" class="absolute top-4 right-4 p-2">
         <svg class="w-6 h-6" viewBox="0 0 24 24" fill="none"><path d="M6 6l12 12M6 18L18 6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
       </button>
@@ -138,7 +138,7 @@
     const currentPath = location.pathname
       .replace(/\/index.html$/, '')
       .replace(/\/$/, '');
-    document.querySelectorAll('#menu a, #mobileMenu a').forEach(link => {
+    document.querySelectorAll('#menu a:not(.no-highlight), #mobileMenu a:not(.no-highlight)').forEach(link => {
       const linkPath = new URL(link.getAttribute('href'), location.origin).pathname
         .replace(/\/index.html$/, '')
         .replace(/\/$/, '');

--- a/process/index.html
+++ b/process/index.html
@@ -74,7 +74,7 @@
     </nav>
     <!-- Full-screen mobile menu -->
     <div id="mobileMenu" class="text-brand-charcoal md:hidden fixed inset-0 z-50 flex flex-col items-center justify-center gap-6 text-xl font-medium bg-white hidden">
-      <a href="/" class="absolute left-1/2 top-3 flex items-center gap-2" style="transform:translateX(calc(-50% - 1rem))"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-8 w-8"/><span class="site-title text-2xl text-brand-charcoal relative -top-0.5"><span class="font-bold text-brand-orange">Scrapyard</span> <span class="font-bold">Sites</span></span></a>
+      <a href="/" class="absolute left-1/2 -translate-x-1/2 top-3 flex items-center gap-2 no-highlight"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-8 w-8"/><span class="site-title text-2xl text-brand-charcoal relative -top-0.5"><span class="font-bold text-brand-orange">Scrapyard</span> <span class="font-bold">Sites</span></span></a>
       <button id="menuClose" class="absolute top-4 right-4 p-2">
         <svg class="w-6 h-6" viewBox="0 0 24 24" fill="none"><path d="M6 6l12 12M6 18L18 6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
       </button>
@@ -101,7 +101,7 @@
     const currentPath = location.pathname
       .replace(/\/index.html$/, '')
       .replace(/\/$/, '');
-    document.querySelectorAll('#menu a, #mobileMenu a').forEach(link => {
+    document.querySelectorAll('#menu a:not(.no-highlight), #mobileMenu a:not(.no-highlight)').forEach(link => {
       const linkPath = new URL(link.getAttribute('href'), location.origin).pathname
         .replace(/\/index.html$/, '')
         .replace(/\/$/, '');

--- a/risk-calculator/index.html
+++ b/risk-calculator/index.html
@@ -46,7 +46,7 @@
     </nav>
     <!-- Full-screen mobile menu -->
     <div id="mobileMenu" class="text-brand-charcoal md:hidden fixed inset-0 z-50 flex flex-col items-center justify-center gap-6 text-xl font-medium bg-white hidden">
-      <a href="/" class="absolute left-1/2 top-3 flex items-center gap-2" style="transform:translateX(calc(-50% - 1rem))"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-8 w-8"/><span class="site-title text-2xl text-brand-charcoal relative -top-0.5"><span class="font-bold text-brand-orange">Scrapyard</span> <span class="font-bold">Sites</span></span></a>
+      <a href="/" class="absolute left-1/2 -translate-x-1/2 top-3 flex items-center gap-2 no-highlight"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-8 w-8"/><span class="site-title text-2xl text-brand-charcoal relative -top-0.5"><span class="font-bold text-brand-orange">Scrapyard</span> <span class="font-bold">Sites</span></span></a>
       <button id="menuClose" class="absolute top-4 right-4 p-2">
         <svg class="w-6 h-6" viewBox="0 0 24 24" fill="none"><path d="M6 6l12 12M6 18L18 6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
       </button>
@@ -74,7 +74,7 @@
     const currentPath = location.pathname
       .replace(/\/index.html$/, '')
       .replace(/\/$/, '');
-    document.querySelectorAll('#menu a, #mobileMenu a').forEach(link => {
+    document.querySelectorAll('#menu a:not(.no-highlight), #mobileMenu a:not(.no-highlight)').forEach(link => {
       const linkPath = new URL(link.getAttribute('href'), location.origin).pathname
         .replace(/\/index.html$/, '')
         .replace(/\/$/, '');

--- a/services/index.html
+++ b/services/index.html
@@ -100,7 +100,7 @@
     </nav>
     <!-- Full-screen mobile menu -->
     <div id="mobileMenu" class="text-brand-charcoal md:hidden fixed inset-0 z-50 flex flex-col items-center justify-center gap-6 text-xl font-medium bg-white hidden">
-      <a href="/" class="absolute left-1/2 top-3 flex items-center gap-2" style="transform:translateX(calc(-50% - 1rem))"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-8 w-8"/><span class="site-title text-2xl text-brand-charcoal relative -top-0.5"><span class="font-bold text-brand-orange">Scrapyard</span> <span class="font-bold">Sites</span></span></a>
+      <a href="/" class="absolute left-1/2 -translate-x-1/2 top-3 flex items-center gap-2 no-highlight"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-8 w-8"/><span class="site-title text-2xl text-brand-charcoal relative -top-0.5"><span class="font-bold text-brand-orange">Scrapyard</span> <span class="font-bold">Sites</span></span></a>
       <button id="menuClose" class="absolute top-4 right-4 p-2">
         <svg class="w-6 h-6" viewBox="0 0 24 24" fill="none"><path d="M6 6l12 12M6 18L18 6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
       </button>
@@ -127,7 +127,7 @@
     const currentPath = location.pathname
       .replace(/\/index.html$/, '')
       .replace(/\/$/, '');
-    document.querySelectorAll('#menu a, #mobileMenu a').forEach(link => {
+    document.querySelectorAll('#menu a:not(.no-highlight), #mobileMenu a:not(.no-highlight)').forEach(link => {
       const linkPath = new URL(link.getAttribute('href'), location.origin).pathname
         .replace(/\/index.html$/, '')
         .replace(/\/$/, '');

--- a/terms-of-service/index.html
+++ b/terms-of-service/index.html
@@ -50,7 +50,7 @@
     </nav>
     <!-- Full-screen mobile menu -->
     <div id="mobileMenu" class="text-brand-charcoal md:hidden fixed inset-0 z-50 flex flex-col items-center justify-center gap-6 text-xl font-medium bg-white hidden">
-      <a href="/" class="absolute left-1/2 top-3 flex items-center gap-2" style="transform:translateX(calc(-50% - 1rem))"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-8 w-8"/><span class="site-title text-2xl text-brand-charcoal relative -top-0.5"><span class="font-bold text-brand-orange">Scrapyard</span> <span class="font-bold">Sites</span></span></a>
+      <a href="/" class="absolute left-1/2 -translate-x-1/2 top-3 flex items-center gap-2 no-highlight"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-8 w-8"/><span class="site-title text-2xl text-brand-charcoal relative -top-0.5"><span class="font-bold text-brand-orange">Scrapyard</span> <span class="font-bold">Sites</span></span></a>
       <button id="menuClose" class="absolute top-4 right-4 p-2">
         <svg class="w-6 h-6" viewBox="0 0 24 24" fill="none"><path d="M6 6l12 12M6 18L18 6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
       </button>
@@ -77,7 +77,7 @@
     const currentPath = location.pathname
       .replace(/\/index.html$/, '')
       .replace(/\/$/, '');
-    document.querySelectorAll('#menu a, #mobileMenu a').forEach(link => {
+    document.querySelectorAll('#menu a:not(.no-highlight), #mobileMenu a:not(.no-highlight)').forEach(link => {
       const linkPath = new URL(link.getAttribute('href'), location.origin).pathname
         .replace(/\/index.html$/, '')
         .replace(/\/$/, '');


### PR DESCRIPTION
## Summary
- exclude the site title from menu highlighting
- center title link in full-screen mobile menu

## Testing
- `bash -lc 'git status --short'`

------
https://chatgpt.com/codex/tasks/task_e_68741919459883298b9ea1a10a1c3f9d