### PR TITLE
Fix mobile header overflow on process page

### DIFF
--- a/process/index.html
+++ b/process/index.html
@@ -54,7 +54,7 @@
 </head>
 <body class="font-sans text-brand-charcoal antialiased bg-white overflow-x-hidden">
   <header class="fixed top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
-    <nav class="max-w-7xl mx-auto relative flex items-center justify-between py-3 px-6">
+    <nav class="max-w-7xl w-full mx-auto relative flex items-center justify-between py-3 px-6">
       <a href="/" class="flex items-center gap-2"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-8 w-8"/><span class="site-title text-xl text-brand-charcoal"><span class="font-bold text-brand-orange">Scrapyard</span> <span class="font-bold">Sites</span></span></a>
       <!-- Mobile hamburger (≤ 768 px) -->
       <button id="menuToggle" class="md:hidden p-2">


### PR DESCRIPTION
## Summary
- ensure nav fills the header width to stop overflow on small screens

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6874194029e883298b088cce2ec47bfa