### PR TITLE
Make carousel cards use full viewport width

### DIFF
--- a/index.html
+++ b/index.html
@@ -281,7 +281,7 @@
 
 <!-- ── Work / Demo ─────────────────────────────────────────── -->
 <section id="work" class="scroll-mt-16 bg-white py-20">
-  <div class="mx-auto max-w-6xl px-6 text-center">
+  <div class="mx-auto max-w-6xl px-0 sm:px-6 text-center">
     <h2 class="text-3xl font-bold mb-10">Our Portfolio</h2>
     <div id="portfolio-carousel" class="carousel-track flex md:grid md:grid-cols-3 gap-8">
       <!-- Demo project cards -->
@@ -312,7 +312,7 @@
 
 <!-- ── Process ─────────────────────────────────────────────── -->
 <section class="py-20 bg-gray-100">
-  <div class="mx-auto max-w-6xl px-6 text-center">
+  <div class="mx-auto max-w-6xl px-0 sm:px-6 text-center">
     <h2 class="text-3xl font-bold mb-8">How We Work</h2>
     <div id="process-carousel" class="grid gap-10 md:grid-cols-3">
       <div>

--- a/pricing/index.html
+++ b/pricing/index.html
@@ -93,7 +93,7 @@
   </script>
   <main class="pt-24 pb-20 px-6">
     <section class="py-20 bg-white">
-      <div class="mx-auto max-w-6xl px-6 text-center">
+      <div class="mx-auto max-w-6xl px-0 sm:px-6 text-center">
         <h1 class="text-3xl font-bold">Straight‑Shooter Pricing</h1>
         <p class="mt-2 text-sm">
           One missed roll‑off a month (~<strong>$8 k</strong>) costs more than our Standard Launch.


### PR DESCRIPTION
## Summary
- allow portfolio and pricing carousels to use the full viewport width on mobile

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687419af84208329bdae2676c89d2c25