### PR TITLE
Update mobile menu logo

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -56,7 +56,7 @@
     </nav>
     <!-- Full-screen mobile menu -->
     <div id="mobileMenu" class="text-brand-charcoal md:hidden fixed inset-0 z-50 flex flex-col items-center justify-center gap-6 text-xl font-medium bg-white hidden">
-      <a href="/" class="absolute left-1/2 -translate-x-1/2 top-3 flex items-center gap-2 no-highlight"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-8 w-8"/><span class="site-title text-2xl text-brand-charcoal relative -top-0.5"><span class="font-bold text-brand-orange">Scrapyard</span> <span class="font-bold">Sites</span></span></a>
+      <a href="/" class="absolute left-1/2 -translate-x-1/2 top-3 flex items-center no-highlight"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-16 w-16"/></a>
       <button id="menuClose" class="absolute top-4 right-4 p-2">
         <svg class="w-6 h-6" viewBox="0 0 24 24" fill="none"><path d="M6 6l12 12M6 18L18 6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
       </button>

--- a/contact/index.html
+++ b/contact/index.html
@@ -46,7 +46,7 @@
     </nav>
     <!-- Full-screen mobile menu -->
     <div id="mobileMenu" class="text-brand-charcoal md:hidden fixed inset-0 z-50 flex flex-col items-center justify-center gap-6 text-xl font-medium bg-white hidden">
-      <a href="/" class="absolute left-1/2 -translate-x-1/2 top-3 flex items-center gap-2 no-highlight"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-8 w-8"/><span class="site-title text-2xl text-brand-charcoal relative -top-0.5"><span class="font-bold text-brand-orange">Scrapyard</span> <span class="font-bold">Sites</span></span></a>
+      <a href="/" class="absolute left-1/2 -translate-x-1/2 top-3 flex items-center no-highlight"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-16 w-16"/></a>
       <button id="menuClose" class="absolute top-4 right-4 p-2">
         <svg class="w-6 h-6" viewBox="0 0 24 24" fill="none"><path d="M6 6l12 12M6 18L18 6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
       </button>

--- a/index.html
+++ b/index.html
@@ -191,7 +191,7 @@
     </nav>
     <!-- Full-screen mobile menu -->
     <div id="mobileMenu" class="text-brand-charcoal md:hidden fixed inset-0 z-50 flex flex-col items-center justify-center gap-6 text-xl font-medium bg-white hidden">
-      <a href="/" class="absolute left-1/2 -translate-x-1/2 top-3 flex items-center gap-2 no-highlight"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-8 w-8"/><span class="site-title text-2xl text-brand-charcoal relative -top-0.5"><span class="font-bold text-brand-orange">Scrapyard</span> <span class="font-bold">Sites</span></span></a>
+      <a href="/" class="absolute left-1/2 -translate-x-1/2 top-3 flex items-center no-highlight"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-16 w-16"/></a>
       <button id="menuClose" class="absolute top-4 right-4 p-2">
         <svg class="w-6 h-6" viewBox="0 0 24 24" fill="none"><path d="M6 6l12 12M6 18L18 6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
       </button>

--- a/portfolio/index.html
+++ b/portfolio/index.html
@@ -46,7 +46,7 @@
     </nav>
     <!-- Full-screen mobile menu -->
     <div id="mobileMenu" class="text-brand-charcoal md:hidden fixed inset-0 z-50 flex flex-col items-center justify-center gap-6 text-xl font-medium bg-white hidden">
-      <a href="/" class="absolute left-1/2 -translate-x-1/2 top-3 flex items-center gap-2 no-highlight"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-8 w-8"/><span class="site-title text-2xl text-brand-charcoal relative -top-0.5"><span class="font-bold text-brand-orange">Scrapyard</span> <span class="font-bold">Sites</span></span></a>
+      <a href="/" class="absolute left-1/2 -translate-x-1/2 top-3 flex items-center no-highlight"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-16 w-16"/></a>
       <button id="menuClose" class="absolute top-4 right-4 p-2">
         <svg class="w-6 h-6" viewBox="0 0 24 24" fill="none"><path d="M6 6l12 12M6 18L18 6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
       </button>

--- a/pricing/index.html
+++ b/pricing/index.html
@@ -50,7 +50,7 @@
     </nav>
     <!-- Full-screen mobile menu -->
     <div id="mobileMenu" class="text-brand-charcoal md:hidden fixed inset-0 z-50 flex flex-col items-center justify-center gap-6 text-xl font-medium bg-white hidden">
-      <a href="/" class="absolute left-1/2 -translate-x-1/2 top-3 flex items-center gap-2 no-highlight"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-8 w-8"/><span class="site-title text-2xl text-brand-charcoal relative -top-0.5"><span class="font-bold text-brand-orange">Scrapyard</span> <span class="font-bold">Sites</span></span></a>
+      <a href="/" class="absolute left-1/2 -translate-x-1/2 top-3 flex items-center no-highlight"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-16 w-16"/></a>
       <button id="menuClose" class="absolute top-4 right-4 p-2">
         <svg class="w-6 h-6" viewBox="0 0 24 24" fill="none"><path d="M6 6l12 12M6 18L18 6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
       </button>

--- a/privacy/index.html
+++ b/privacy/index.html
@@ -111,7 +111,7 @@
     </nav>
     <!-- Full-screen mobile menu -->
     <div id="mobileMenu" class="text-brand-charcoal md:hidden fixed inset-0 z-50 flex flex-col items-center justify-center gap-6 text-xl font-medium bg-white hidden">
-      <a href="/" class="absolute left-1/2 -translate-x-1/2 top-3 flex items-center gap-2 no-highlight"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-8 w-8"/><span class="site-title text-2xl text-brand-charcoal relative -top-0.5"><span class="font-bold text-brand-orange">Scrapyard</span> <span class="font-bold">Sites</span></span></a>
+      <a href="/" class="absolute left-1/2 -translate-x-1/2 top-3 flex items-center no-highlight"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-16 w-16"/></a>
       <button id="menuClose" class="absolute top-4 right-4 p-2">
         <svg class="w-6 h-6" viewBox="0 0 24 24" fill="none"><path d="M6 6l12 12M6 18L18 6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
       </button>

--- a/process/index.html
+++ b/process/index.html
@@ -74,7 +74,7 @@
     </nav>
     <!-- Full-screen mobile menu -->
     <div id="mobileMenu" class="text-brand-charcoal md:hidden fixed inset-0 z-50 flex flex-col items-center justify-center gap-6 text-xl font-medium bg-white hidden">
-      <a href="/" class="absolute left-1/2 -translate-x-1/2 top-3 flex items-center gap-2 no-highlight"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-8 w-8"/><span class="site-title text-2xl text-brand-charcoal relative -top-0.5"><span class="font-bold text-brand-orange">Scrapyard</span> <span class="font-bold">Sites</span></span></a>
+      <a href="/" class="absolute left-1/2 -translate-x-1/2 top-3 flex items-center no-highlight"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-16 w-16"/></a>
       <button id="menuClose" class="absolute top-4 right-4 p-2">
         <svg class="w-6 h-6" viewBox="0 0 24 24" fill="none"><path d="M6 6l12 12M6 18L18 6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
       </button>

--- a/risk-calculator/index.html
+++ b/risk-calculator/index.html
@@ -46,7 +46,7 @@
     </nav>
     <!-- Full-screen mobile menu -->
     <div id="mobileMenu" class="text-brand-charcoal md:hidden fixed inset-0 z-50 flex flex-col items-center justify-center gap-6 text-xl font-medium bg-white hidden">
-      <a href="/" class="absolute left-1/2 -translate-x-1/2 top-3 flex items-center gap-2 no-highlight"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-8 w-8"/><span class="site-title text-2xl text-brand-charcoal relative -top-0.5"><span class="font-bold text-brand-orange">Scrapyard</span> <span class="font-bold">Sites</span></span></a>
+      <a href="/" class="absolute left-1/2 -translate-x-1/2 top-3 flex items-center no-highlight"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-16 w-16"/></a>
       <button id="menuClose" class="absolute top-4 right-4 p-2">
         <svg class="w-6 h-6" viewBox="0 0 24 24" fill="none"><path d="M6 6l12 12M6 18L18 6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
       </button>

--- a/services/index.html
+++ b/services/index.html
@@ -100,7 +100,7 @@
     </nav>
     <!-- Full-screen mobile menu -->
     <div id="mobileMenu" class="text-brand-charcoal md:hidden fixed inset-0 z-50 flex flex-col items-center justify-center gap-6 text-xl font-medium bg-white hidden">
-      <a href="/" class="absolute left-1/2 -translate-x-1/2 top-3 flex items-center gap-2 no-highlight"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-8 w-8"/><span class="site-title text-2xl text-brand-charcoal relative -top-0.5"><span class="font-bold text-brand-orange">Scrapyard</span> <span class="font-bold">Sites</span></span></a>
+      <a href="/" class="absolute left-1/2 -translate-x-1/2 top-3 flex items-center no-highlight"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-16 w-16"/></a>
       <button id="menuClose" class="absolute top-4 right-4 p-2">
         <svg class="w-6 h-6" viewBox="0 0 24 24" fill="none"><path d="M6 6l12 12M6 18L18 6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
       </button>

--- a/terms-of-service/index.html
+++ b/terms-of-service/index.html
@@ -50,7 +50,7 @@
     </nav>
     <!-- Full-screen mobile menu -->
     <div id="mobileMenu" class="text-brand-charcoal md:hidden fixed inset-0 z-50 flex flex-col items-center justify-center gap-6 text-xl font-medium bg-white hidden">
-      <a href="/" class="absolute left-1/2 -translate-x-1/2 top-3 flex items-center gap-2 no-highlight"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-8 w-8"/><span class="site-title text-2xl text-brand-charcoal relative -top-0.5"><span class="font-bold text-brand-orange">Scrapyard</span> <span class="font-bold">Sites</span></span></a>
+      <a href="/" class="absolute left-1/2 -translate-x-1/2 top-3 flex items-center no-highlight"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-16 w-16"/></a>
       <button id="menuClose" class="absolute top-4 right-4 p-2">
         <svg class="w-6 h-6" viewBox="0 0 24 24" fill="none"><path d="M6 6l12 12M6 18L18 6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
       </button>


### PR DESCRIPTION
## Summary
- remove "Scrapyard Sites" text from the mobile menu overlay
- enlarge the logo there to stand out

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68741a9735808329b940ed2088379f82