### PR TITLE
Fix mobile carousel padding

### DIFF
--- a/index.html
+++ b/index.html
@@ -283,7 +283,7 @@
 <section id="work" class="scroll-mt-16 bg-white py-20">
   <div class="mx-auto max-w-6xl px-0 sm:px-6 text-center">
     <h2 class="text-3xl font-bold mb-10">Our Portfolio</h2>
-    <div id="portfolio-carousel" class="carousel-track flex md:grid md:grid-cols-3 gap-8">
+    <div id="portfolio-carousel" class="carousel-track flex px-4 md:grid md:grid-cols-3 gap-8">
       <!-- Demo project cards -->
       <a href="#contact" class="carousel-item block bg-gray-50 border border-brand-steel/10 rounded-xl shadow-sm p-10 flex flex-col items-center text-center hover:bg-gray-100 hover:shadow-lg transition transform hover:-translate-y-1 hover:cursor-pointer">
         <div class="w-full rounded-xl overflow-hidden border border-brand-steel/10">
@@ -336,13 +336,13 @@
 
 <!-- ── Pricing ─────────────────────────────────────────────── -->
 <section id="pricing" class="scroll-mt-16 bg-white py-20">
-  <div class="mx-auto max-w-6xl px-6 text-center">
+  <div class="mx-auto max-w-6xl px-0 sm:px-6 text-center">
     <h2 class="text-3xl font-bold">Straight‑Shooter Pricing</h2>
     <p class="mt-2 text-brand-steel max-w-xl mx-auto">
       No hidden fees, no “call for quote”. You’ll know the cost before we write a line of code.
     </p>
 
-    <div id="pricing-carousel" class="carousel-track overflow-x-auto overflow-y-visible mt-14 flex gap-10 md:grid md:grid-cols-2 lg:grid-cols-3">
+    <div id="pricing-carousel" class="carousel-track overflow-x-auto overflow-y-visible mt-14 flex gap-10 px-4 md:grid md:grid-cols-2 lg:grid-cols-3">
       <!-- Launch -->
       <div class="carousel-item relative overflow-visible bg-gray-50 border border-brand-steel/10 rounded-xl shadow-sm transition transform hover:-translate-y-1 p-10">
         <span

--- a/pricing/index.html
+++ b/pricing/index.html
@@ -93,7 +93,7 @@
   </script>
   <main class="pt-24 pb-20 px-6">
     <section class="py-20 bg-white">
-      <div class="mx-auto max-w-6xl px-0 sm:px-6 text-center">
+      <div class="max-w-6xl -mx-6 sm:mx-auto px-0 sm:px-6 text-center">
         <h1 class="text-3xl font-bold">Straight‑Shooter Pricing</h1>
         <p class="mt-2 text-sm">
           One missed roll‑off a month (~<strong>$8 k</strong>) costs more than our Standard Launch.
@@ -101,7 +101,7 @@
         </p>
 
         <!-- Packages -->
-        <div id="pricing-carousel" class="carousel-track overflow-x-auto mt-14 flex gap-10 md:grid md:grid-cols-2 lg:grid-cols-3">
+        <div id="pricing-carousel" class="carousel-track overflow-x-auto mt-14 flex gap-10 px-4 md:grid md:grid-cols-2 lg:grid-cols-3">
           <!-- Launch -->
           <div class="carousel-item relative overflow-visible bg-gray-50 border border-brand-steel/10 rounded-xl shadow-sm transition transform hover:-translate-y-1 p-10 flex flex-col">
             <span


### PR DESCRIPTION
## Summary
- adjust home pricing container padding
- pad the portfolio and pricing carousels on mobile
- offset main padding on the pricing page so carousel touches viewport edges

## Testing
- `npx -y prettier -c index.html pricing/index.html`

------
https://chatgpt.com/codex/tasks/task_e_68741bbec93083298b334e26d0fd58e4