### PR TITLE
Fix overflow clipping for pricing carousel

### DIFF
--- a/pricing/index.html
+++ b/pricing/index.html
@@ -101,7 +101,7 @@
         </p>
 
         <!-- Packages -->
-        <div id="pricing-carousel" class="carousel-track overflow-x-auto mt-14 flex gap-10 px-4 md:grid md:grid-cols-2 lg:grid-cols-3">
+        <div id="pricing-carousel" class="carousel-track overflow-x-auto overflow-y-visible mt-14 flex gap-10 px-4 md:grid md:grid-cols-2 lg:grid-cols-3">
           <!-- Launch -->
           <div class="carousel-item relative overflow-visible bg-gray-50 border border-brand-steel/10 rounded-xl shadow-sm transition transform hover:-translate-y-1 p-10 flex flex-col">
             <span


### PR DESCRIPTION
## Summary
- avoid clipping pricing cards in pricing page carousel

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68741cbc65748329824599af927b612d