### PR TITLE
Fix pricing text margins on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -336,11 +336,13 @@
 
 <!-- ── Pricing ─────────────────────────────────────────────── -->
 <section id="pricing" class="scroll-mt-16 bg-white py-20">
-  <div class="mx-auto max-w-6xl px-0 sm:px-6 text-center">
-    <h2 class="text-3xl font-bold">Straight‑Shooter Pricing</h2>
-    <p class="mt-2 text-brand-steel max-w-xl mx-auto">
-      No hidden fees, no “call for quote”. You’ll know the cost before we write a line of code.
-    </p>
+  <div class="mx-auto max-w-6xl sm:px-6 text-center">
+    <div class="px-4 sm:px-0">
+      <h2 class="text-3xl font-bold">Straight‑Shooter Pricing</h2>
+      <p class="mt-2 text-brand-steel max-w-xl mx-auto">
+        No hidden fees, no “call for quote”. You’ll know the cost before we write a line of code.
+      </p>
+    </div>
 
     <div id="pricing-carousel" class="carousel-track overflow-x-auto overflow-y-visible mt-14 flex gap-10 px-4 md:grid md:grid-cols-2 lg:grid-cols-3">
       <!-- Launch -->


### PR DESCRIPTION
## Summary
- adjust mobile padding for pricing section heading text

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68741e6751088329ae526f3934fd4c42