### PR TITLE
Adjust carousel card width

### DIFF
--- a/index.html
+++ b/index.html
@@ -281,7 +281,7 @@
 
 <!-- ── Work / Demo ─────────────────────────────────────────── -->
 <section id="work" class="scroll-mt-16 bg-white py-20">
-  <div class="mx-auto max-w-6xl px-0 sm:px-6 text-center">
+  <div class="mx-auto max-w-6xl px-6 text-center">
     <h2 class="text-3xl font-bold mb-10">Our Portfolio</h2>
     <div id="portfolio-carousel" class="carousel-track flex px-4 md:grid md:grid-cols-3 gap-8">
       <!-- Demo project cards -->
@@ -336,7 +336,7 @@
 
 <!-- ── Pricing ─────────────────────────────────────────────── -->
 <section id="pricing" class="scroll-mt-16 bg-white py-20">
-  <div class="mx-auto max-w-6xl px-0 sm:px-6 text-center">
+  <div class="mx-auto max-w-6xl px-6 text-center">
     <h2 class="text-3xl font-bold">Straight‑Shooter Pricing</h2>
     <p class="mt-2 text-brand-steel max-w-xl mx-auto">
       No hidden fees, no “call for quote”. You’ll know the cost before we write a line of code.

--- a/pricing/index.html
+++ b/pricing/index.html
@@ -93,7 +93,7 @@
   </script>
   <main class="pt-24 pb-20 px-6">
     <section class="py-20 bg-white">
-      <div class="max-w-6xl -mx-6 sm:mx-auto px-0 sm:px-6 text-center">
+      <div class="mx-auto max-w-6xl px-6 text-center">
         <h1 class="text-3xl font-bold">Straight‑Shooter Pricing</h1>
         <p class="mt-2 text-sm">
           One missed roll‑off a month (~<strong>$8 k</strong>) costs more than our Standard Launch.


### PR DESCRIPTION
## Summary
- set padding for carousel sections to match other cards

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68741e3c85bc8329b77b1bbceb345435