### PR TITLE
Fix pricing card hover clipping

### DIFF
--- a/index.html
+++ b/index.html
@@ -342,7 +342,7 @@
       No hidden fees, no “call for quote”. You’ll know the cost before we write a line of code.
     </p>
 
-    <div id="pricing-carousel" class="carousel-track overflow-x-auto overflow-y-visible mt-14 flex gap-10 px-4 md:grid md:grid-cols-2 lg:grid-cols-3">
+    <div id="pricing-carousel" class="carousel-track overflow-x-auto overflow-visible mt-14 flex gap-10 px-4 md:grid md:grid-cols-2 lg:grid-cols-3">
       <!-- Launch -->
       <div class="carousel-item relative overflow-visible bg-gray-50 border border-brand-steel/10 rounded-xl shadow-sm transition transform hover:-translate-y-1 p-10">
         <span

--- a/pricing/index.html
+++ b/pricing/index.html
@@ -101,7 +101,7 @@
         </p>
 
         <!-- Packages -->
-        <div id="pricing-carousel" class="carousel-track overflow-x-auto overflow-y-visible mt-14 flex gap-10 px-4 md:grid md:grid-cols-2 lg:grid-cols-3">
+        <div id="pricing-carousel" class="carousel-track overflow-x-auto overflow-visible mt-14 flex gap-10 px-4 md:grid md:grid-cols-2 lg:grid-cols-3">
           <!-- Launch -->
           <div class="carousel-item relative overflow-visible bg-gray-50 border border-brand-steel/10 rounded-xl shadow-sm transition transform hover:-translate-y-1 p-10 flex flex-col">
             <span


### PR DESCRIPTION
## Summary
- ensure pricing card hover doesn't clip the bubble badge

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6874206d47748329b13b740e5d26bd87