### PR TITLE
Fix mobile overlap of How We Work numbers

### DIFF
--- a/index.html
+++ b/index.html
@@ -315,18 +315,18 @@
   <div class="mx-auto max-w-6xl px-0 sm:px-6 text-center">
     <h2 class="text-3xl font-bold mb-8">How We Work</h2>
     <div id="process-carousel" class="grid gap-10 md:grid-cols-3">
-      <div class="flex flex-col items-center">
-        <div class="step-badge flex items-center justify-center w-10 h-10 rounded-full bg-brand-orange text-white font-bold mb-2 flex-shrink-0" data-aos="fade-up" data-aos-delay="0">1</div>
+      <div class="flex flex-col items-center" data-aos="fade-up" data-aos-delay="0">
+        <div class="step-badge flex items-center justify-center w-10 h-10 rounded-full bg-brand-orange text-white font-bold mb-2 flex-shrink-0">1</div>
         <h3 class="font-semibold text-lg mt-3">Discovery Call</h3>
         <p class="text-base md:text-sm text-brand-steel mt-1">15 minutes to learn your yard, materials & amp draw area.</p>
       </div>
-      <div class="flex flex-col items-center">
-        <div class="step-badge flex items-center justify-center w-10 h-10 rounded-full bg-brand-orange text-white font-bold mb-2 flex-shrink-0" data-aos="fade-up" data-aos-delay="100">2</div>
+      <div class="flex flex-col items-center" data-aos="fade-up" data-aos-delay="100">
+        <div class="step-badge flex items-center justify-center w-10 h-10 rounded-full bg-brand-orange text-white font-bold mb-2 flex-shrink-0">2</div>
         <h3 class="font-semibold text-lg mt-3">Build Week</h3>
         <p class="text-base md:text-sm text-brand-steel mt-1">We design, write and code. You review once—done.</p>
       </div>
-      <div class="flex flex-col items-center">
-        <div class="step-badge flex items-center justify-center w-10 h-10 rounded-full bg-brand-orange text-white font-bold mb-2 flex-shrink-0" data-aos="fade-up" data-aos-delay="200">3</div>
+      <div class="flex flex-col items-center" data-aos="fade-up" data-aos-delay="200">
+        <div class="step-badge flex items-center justify-center w-10 h-10 rounded-full bg-brand-orange text-white font-bold mb-2 flex-shrink-0">3</div>
         <h3 class="font-semibold text-lg mt-3">Launch & Maintain</h3>
         <p class="text-base md:text-sm text-brand-steel mt-1">Site goes live, Google Business updated, $99/mo care plan kicks in.</p>
       </div>


### PR DESCRIPTION
## Summary
- move AOS attributes from badges to parent steps so the numbers animate together with the text

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687420ad102c8329b1bba437f975678f