### PR TITLE
Center mobile menu icon

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -84,6 +84,14 @@ header.fixed {
   color: #2B2B2B;
 }
 
+/* Center icons inside mobile menu toggle buttons */
+#menuToggle,
+#menuClose {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
 /* Swap hamburger/close icons when menu opens */
 #menuToggle .icon-close { display: none; }
 #menuToggle.open .icon-open { display: none; }


### PR DESCRIPTION
## Summary
- ensure icons inside mobile menu buttons are centered

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68742324f59883298fcd41b48d8e36f5