### PR TITLE
Fix mobile padding for How We Work section

### DIFF
--- a/index.html
+++ b/index.html
@@ -311,8 +311,8 @@
 </section>
 
 <!-- ── Process ─────────────────────────────────────────────── -->
-<section class="py-20 bg-gray-100">
-  <div class="mx-auto max-w-6xl px-0 sm:px-6 text-center">
+  <section class="py-20 bg-gray-100">
+  <div class="mx-auto max-w-6xl px-6 text-center">
     <h2 class="text-3xl font-bold mb-8">How We Work</h2>
     <div id="process-carousel" class="grid gap-10 md:grid-cols-3">
       <div class="flex flex-col items-center" data-aos="fade-up" data-aos-delay="0">


### PR DESCRIPTION
## Summary
- add left/right padding to the How We Work section so mobile text isn't flush to the edges

## Testing
- `grep -n "px-0 sm:px-6" -n index.html`

------
https://chatgpt.com/codex/tasks/task_e_68742349e6e883298282941f0661c342