### PR TITLE
Fix close icon vertical position

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -84,6 +84,12 @@ header.fixed {
   color: #2B2B2B;
 }
 
+/* Vertically center the close button in the mobile menu */
+#mobileMenu #menuClose {
+  top: 50%;
+  transform: translateY(-50%);
+}
+
 /* Center icons inside mobile menu toggle buttons */
 #menuToggle,
 #menuClose {


### PR DESCRIPTION
## Summary
- ensure the mobile menu close icon is vertically centered

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6874248608d88329a571c6b07cbe5ace