### PR TITLE
Fix mobile menu icon alignment

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -84,18 +84,21 @@ header.fixed {
   color: #2B2B2B;
 }
 
-/* Vertically center the close button in the mobile menu */
-#mobileMenu #menuClose {
-  top: 50%;
-  transform: translateY(-50%);
-}
+/* Position the close button using Tailwind classes */
+/* (top-4 right-4) from markup will keep it in the corner */
+
 
 /* Center icons inside mobile menu toggle buttons */
 #menuToggle,
 #menuClose {
-  display: inline-flex;
   align-items: center;
   justify-content: center;
+  display: inline-flex;
+}
+
+@media (min-width: 768px) {
+  /* Hide hamburger on desktop */
+  #menuToggle { display: none; }
 }
 
 /* Swap hamburger/close icons when menu opens */


### PR DESCRIPTION
## Summary
- remove rule that forced the close icon to the middle of the screen
- don't override Tailwind's `md:hidden` for the hamburger button

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687425fc2f7483299cefc0d11f7cf255