### PR TITLE
Center mobile menu logo

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -56,8 +56,8 @@
     </nav>
     <!-- Full-screen mobile menu -->
     <div id="mobileMenu" class="text-brand-charcoal md:hidden fixed inset-0 z-50 flex flex-col items-center justify-center gap-6 text-xl font-medium bg-white hidden">
-      <a href="/" class="absolute left-1/2 top-3 -translate-x-1/2 transform flex items-center no-highlight"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-16 w-16"/></a>
-      <button id="menuClose" class="absolute top-4 right-4 p-2">
+      <a href="/" class="absolute inset-x-0 top-3 flex justify-center items-center no-highlight"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-16 w-16"/></a>
+      <button id="menuClose" class="absolute top-4 left-1/2 -translate-x-1/2 transform p-2">
         <svg class="w-6 h-6" viewBox="0 0 24 24" fill="none"><path d="M6 6l12 12M6 18L18 6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
       </button>
       <a href="/services">Services</a>

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -85,7 +85,7 @@ header.fixed {
 }
 
 /* Position the close button using Tailwind classes */
-/* (top-4 right-4) from markup will keep it in the corner */
+/* (top-4 left-1/2 -translate-x-1/2 transform) to center it horizontally */
 
 
 /* Center icons inside mobile menu toggle buttons */

--- a/contact/index.html
+++ b/contact/index.html
@@ -46,8 +46,8 @@
     </nav>
     <!-- Full-screen mobile menu -->
     <div id="mobileMenu" class="text-brand-charcoal md:hidden fixed inset-0 z-50 flex flex-col items-center justify-center gap-6 text-xl font-medium bg-white hidden">
-      <a href="/" class="absolute left-1/2 top-3 -translate-x-1/2 transform flex items-center no-highlight"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-16 w-16"/></a>
-      <button id="menuClose" class="absolute top-4 right-4 p-2">
+      <a href="/" class="absolute inset-x-0 top-3 flex justify-center items-center no-highlight"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-16 w-16"/></a>
+      <button id="menuClose" class="absolute top-4 left-1/2 -translate-x-1/2 transform p-2">
         <svg class="w-6 h-6" viewBox="0 0 24 24" fill="none"><path d="M6 6l12 12M6 18L18 6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
       </button>
       <a href="/services">Services</a>

--- a/index.html
+++ b/index.html
@@ -191,8 +191,8 @@
     </nav>
     <!-- Full-screen mobile menu -->
     <div id="mobileMenu" class="text-brand-charcoal md:hidden fixed inset-0 z-50 flex flex-col items-center justify-center gap-6 text-xl font-medium bg-white hidden">
-      <a href="/" class="absolute left-1/2 top-3 -translate-x-1/2 transform flex items-center no-highlight"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-16 w-16"/></a>
-      <button id="menuClose" class="absolute top-4 right-4 p-2">
+      <a href="/" class="absolute inset-x-0 top-3 flex justify-center items-center no-highlight"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-16 w-16"/></a>
+      <button id="menuClose" class="absolute top-4 left-1/2 -translate-x-1/2 transform p-2">
         <svg class="w-6 h-6" viewBox="0 0 24 24" fill="none"><path d="M6 6l12 12M6 18L18 6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
       </button>
       <a href="/services">Services</a>

--- a/portfolio/index.html
+++ b/portfolio/index.html
@@ -46,8 +46,8 @@
     </nav>
     <!-- Full-screen mobile menu -->
     <div id="mobileMenu" class="text-brand-charcoal md:hidden fixed inset-0 z-50 flex flex-col items-center justify-center gap-6 text-xl font-medium bg-white hidden">
-      <a href="/" class="absolute left-1/2 top-3 -translate-x-1/2 transform flex items-center no-highlight"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-16 w-16"/></a>
-      <button id="menuClose" class="absolute top-4 right-4 p-2">
+      <a href="/" class="absolute inset-x-0 top-3 flex justify-center items-center no-highlight"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-16 w-16"/></a>
+      <button id="menuClose" class="absolute top-4 left-1/2 -translate-x-1/2 transform p-2">
         <svg class="w-6 h-6" viewBox="0 0 24 24" fill="none"><path d="M6 6l12 12M6 18L18 6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
       </button>
       <a href="/services">Services</a>

--- a/pricing/index.html
+++ b/pricing/index.html
@@ -50,8 +50,8 @@
     </nav>
     <!-- Full-screen mobile menu -->
     <div id="mobileMenu" class="text-brand-charcoal md:hidden fixed inset-0 z-50 flex flex-col items-center justify-center gap-6 text-xl font-medium bg-white hidden">
-      <a href="/" class="absolute left-1/2 top-3 -translate-x-1/2 transform flex items-center no-highlight"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-16 w-16"/></a>
-      <button id="menuClose" class="absolute top-4 right-4 p-2">
+      <a href="/" class="absolute inset-x-0 top-3 flex justify-center items-center no-highlight"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-16 w-16"/></a>
+      <button id="menuClose" class="absolute top-4 left-1/2 -translate-x-1/2 transform p-2">
         <svg class="w-6 h-6" viewBox="0 0 24 24" fill="none"><path d="M6 6l12 12M6 18L18 6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
       </button>
       <a href="/services">Services</a>

--- a/privacy/index.html
+++ b/privacy/index.html
@@ -111,8 +111,8 @@
     </nav>
     <!-- Full-screen mobile menu -->
     <div id="mobileMenu" class="text-brand-charcoal md:hidden fixed inset-0 z-50 flex flex-col items-center justify-center gap-6 text-xl font-medium bg-white hidden">
-      <a href="/" class="absolute left-1/2 top-3 -translate-x-1/2 transform flex items-center no-highlight"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-16 w-16"/></a>
-      <button id="menuClose" class="absolute top-4 right-4 p-2">
+      <a href="/" class="absolute inset-x-0 top-3 flex justify-center items-center no-highlight"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-16 w-16"/></a>
+      <button id="menuClose" class="absolute top-4 left-1/2 -translate-x-1/2 transform p-2">
         <svg class="w-6 h-6" viewBox="0 0 24 24" fill="none"><path d="M6 6l12 12M6 18L18 6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
       </button>
       <a href="/services">Services</a>

--- a/process/index.html
+++ b/process/index.html
@@ -74,8 +74,8 @@
     </nav>
     <!-- Full-screen mobile menu -->
     <div id="mobileMenu" class="text-brand-charcoal md:hidden fixed inset-0 z-50 flex flex-col items-center justify-center gap-6 text-xl font-medium bg-white hidden">
-      <a href="/" class="absolute left-1/2 top-3 -translate-x-1/2 transform flex items-center no-highlight"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-16 w-16"/></a>
-      <button id="menuClose" class="absolute top-4 right-4 p-2">
+      <a href="/" class="absolute inset-x-0 top-3 flex justify-center items-center no-highlight"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-16 w-16"/></a>
+      <button id="menuClose" class="absolute top-4 left-1/2 -translate-x-1/2 transform p-2">
         <svg class="w-6 h-6" viewBox="0 0 24 24" fill="none"><path d="M6 6l12 12M6 18L18 6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
       </button>
       <a href="/services">Services</a>

--- a/risk-calculator/index.html
+++ b/risk-calculator/index.html
@@ -46,8 +46,8 @@
     </nav>
     <!-- Full-screen mobile menu -->
     <div id="mobileMenu" class="text-brand-charcoal md:hidden fixed inset-0 z-50 flex flex-col items-center justify-center gap-6 text-xl font-medium bg-white hidden">
-      <a href="/" class="absolute left-1/2 top-3 -translate-x-1/2 transform flex items-center no-highlight"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-16 w-16"/></a>
-      <button id="menuClose" class="absolute top-4 right-4 p-2">
+      <a href="/" class="absolute inset-x-0 top-3 flex justify-center items-center no-highlight"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-16 w-16"/></a>
+      <button id="menuClose" class="absolute top-4 left-1/2 -translate-x-1/2 transform p-2">
         <svg class="w-6 h-6" viewBox="0 0 24 24" fill="none"><path d="M6 6l12 12M6 18L18 6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
       </button>
       <a href="/services">Services</a>

--- a/services/index.html
+++ b/services/index.html
@@ -100,8 +100,8 @@
     </nav>
     <!-- Full-screen mobile menu -->
     <div id="mobileMenu" class="text-brand-charcoal md:hidden fixed inset-0 z-50 flex flex-col items-center justify-center gap-6 text-xl font-medium bg-white hidden">
-      <a href="/" class="absolute left-1/2 top-3 -translate-x-1/2 transform flex items-center no-highlight"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-16 w-16"/></a>
-      <button id="menuClose" class="absolute top-4 right-4 p-2">
+      <a href="/" class="absolute inset-x-0 top-3 flex justify-center items-center no-highlight"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-16 w-16"/></a>
+      <button id="menuClose" class="absolute top-4 left-1/2 -translate-x-1/2 transform p-2">
         <svg class="w-6 h-6" viewBox="0 0 24 24" fill="none"><path d="M6 6l12 12M6 18L18 6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
       </button>
       <a href="/services">Services</a>

--- a/terms-of-service/index.html
+++ b/terms-of-service/index.html
@@ -50,8 +50,8 @@
     </nav>
     <!-- Full-screen mobile menu -->
     <div id="mobileMenu" class="text-brand-charcoal md:hidden fixed inset-0 z-50 flex flex-col items-center justify-center gap-6 text-xl font-medium bg-white hidden">
-      <a href="/" class="absolute left-1/2 top-3 -translate-x-1/2 transform flex items-center no-highlight"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-16 w-16"/></a>
-      <button id="menuClose" class="absolute top-4 right-4 p-2">
+      <a href="/" class="absolute inset-x-0 top-3 flex justify-center items-center no-highlight"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-16 w-16"/></a>
+      <button id="menuClose" class="absolute top-4 left-1/2 -translate-x-1/2 transform p-2">
         <svg class="w-6 h-6" viewBox="0 0 24 24" fill="none"><path d="M6 6l12 12M6 18L18 6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
       </button>
       <a href="/services">Services</a>


### PR DESCRIPTION
## Summary
- center the logo within the expanded mobile menu

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68742816dc9c83299e4b853476936d93