### PR TITLE
Apply fade-up animation to Why Generalist cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -260,17 +260,17 @@
   <h2 class="text-2xl font-bold mb-10 text-center text-white">Why Generalist Agencies Leave You Exposed</h2>
 
   <div id="why-carousel" class="grid gap-8 md:grid-cols-3 text-sm text-brand-charcoal">
-    <article class="bg-gray-50 border border-brand-steel/10 rounded-xl shadow-sm p-6 text-center transition-transform duration-150 hover:-translate-y-1">
+    <article class="bg-gray-50 border border-brand-steel/10 rounded-xl shadow-sm p-6 text-center transition-transform duration-150 hover:-translate-y-1" data-aos="fade-up" data-aos-delay="0">
       <i class="fa-solid fa-phone-slash text-3xl card-icon mb-4"></i>
       <h3 class="font-semibold text-base">Missed‑Call Plug</h3>
       <p>Quote forms drop hot leads straight into your inbox—no trucks lost in voicemail hell.</p>
     </article>
-    <article class="bg-gray-50 border border-brand-steel/10 rounded-xl shadow-sm p-6 text-center transition-transform duration-150 hover:-translate-y-1">
+    <article class="bg-gray-50 border border-brand-steel/10 rounded-xl shadow-sm p-6 text-center transition-transform duration-150 hover:-translate-y-1" data-aos="fade-up" data-aos-delay="100">
       <i class="fa-solid fa-tags text-3xl card-icon mb-4"></i>
       <h3 class="font-semibold text-base">Price‑Shopper Filter</h3>
       <p>Copy answers margin, materials & pickup times so tyre‑kickers don’t tie up your phone lines.</p>
     </article>
-    <article class="bg-gray-50 border border-brand-steel/10 rounded-xl shadow-sm p-6 text-center transition-transform duration-150 hover:-translate-y-1">
+    <article class="bg-gray-50 border border-brand-steel/10 rounded-xl shadow-sm p-6 text-center transition-transform duration-150 hover:-translate-y-1" data-aos="fade-up" data-aos-delay="200">
       <i class="fa-solid fa-shield-alt text-3xl card-icon mb-4"></i>
       <h3 class="font-semibold text-base">Credibility Shield</h3>
       <p>Industrial‑grade design signals trust to brokers, suppliers and walk‑ins.</p>


### PR DESCRIPTION
## Summary
- animate the Why Generalist cards using the same fade-up effect as the How We Work section

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68742ce0ff98832986448a169013fc5b