### PR TITLE
Fix AOS fade-in on home cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -537,6 +537,8 @@
     const aosObserver = new IntersectionObserver((entries, obs) => {
       entries.forEach(entry => {
         if (entry.isIntersecting) {
+          entry.target.style.transition =
+            'opacity 1s ease-out, transform 1s ease-out';
           entry.target.classList.add('aos-active');
           entry.target.addEventListener(
             'transitionend',


### PR DESCRIPTION
## Summary
- ensure `aos-active` fade uses opacity transition by applying the desired transition inline

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68742e87e184832980c5811d20e3e7af