### PR TITLE
Fix color gap on services page

### DIFF
--- a/services/index.html
+++ b/services/index.html
@@ -141,7 +141,7 @@
   });
 
   </script>
-  <main class="pt-24 pb-20 px-6">
+  <main class="pt-24 pb-20 px-6 bg-gray-50">
     <section class="bg-gray-50 py-16">
       <div class="max-w-3xl mx-auto text-center px-6">
         <h1 class="text-3xl font-bold">Four Shields That Stop Revenue&nbsp;Bleed</h1>


### PR DESCRIPTION
## Summary
- remove white gap above the hero section by matching the background color

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6874320e48048329935b8f0b8721d18c