### PR TITLE
Grid layout for pricing carousel

### DIFF
--- a/index.html
+++ b/index.html
@@ -342,7 +342,7 @@
       No hidden fees, no “call for quote”. You’ll know the cost before we write a line of code.
     </p>
 
-    <div id="pricing-carousel" class="relative z-[60] carousel-track overflow-x-auto overflow-visible mt-14 flex gap-10 px-4 md:grid md:grid-cols-2 lg:grid-cols-3">
+    <div id="pricing-carousel" class="carousel-track grid gap-10 px-4 mt-14 md:grid-cols-2 lg:grid-cols-3 relative z-[60]">
       <!-- Launch -->
       <div class="carousel-item relative z-[70] overflow-visible bg-gray-50 border border-brand-steel/10 rounded-xl shadow-sm transition transform hover:-translate-y-1 px-6 py-10 md:p-10">
         <span

--- a/pricing/index.html
+++ b/pricing/index.html
@@ -101,7 +101,7 @@
         </p>
 
         <!-- Packages -->
-        <div id="pricing-carousel" class="relative z-[60] carousel-track overflow-x-auto overflow-visible mt-14 flex gap-10 px-4 md:grid md:grid-cols-2 lg:grid-cols-3">
+        <div id="pricing-carousel" class="carousel-track grid gap-10 px-4 mt-14 md:grid-cols-2 lg:grid-cols-3 relative z-[60]">
           <!-- Launch -->
           <div class="carousel-item relative z-[70] overflow-visible bg-gray-50 border border-brand-steel/10 rounded-xl shadow-sm transition transform hover:-translate-y-1 px-6 py-10 md:p-10 flex flex-col">
             <span


### PR DESCRIPTION
## Summary
- set pricing carousel container to use grid layout like the portfolio carousel on both the homepage and the pricing page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687437b2bd188329a3e58713ee13ab53