### PR TITLE
Fix mobile pricing carousel

### DIFF
--- a/index.html
+++ b/index.html
@@ -342,7 +342,7 @@
       No hidden fees, no “call for quote”. You’ll know the cost before we write a line of code.
     </p>
 
-    <div id="pricing-carousel" class="carousel-track grid gap-10 px-4 mt-14 md:grid-cols-2 lg:grid-cols-3 relative z-[60]">
+    <div id="pricing-carousel" class="carousel-track flex gap-10 px-4 mt-14 md:grid md:grid-cols-2 lg:grid-cols-3 relative z-[60]">
       <!-- Launch -->
       <div class="carousel-item relative z-[70] overflow-visible bg-gray-50 border border-brand-steel/10 rounded-xl shadow-sm transition transform hover:-translate-y-1 px-6 py-10 md:p-10">
         <span

--- a/pricing/index.html
+++ b/pricing/index.html
@@ -101,7 +101,7 @@
         </p>
 
         <!-- Packages -->
-        <div id="pricing-carousel" class="carousel-track grid gap-10 px-4 mt-14 md:grid-cols-2 lg:grid-cols-3 relative z-[60]">
+        <div id="pricing-carousel" class="carousel-track flex gap-10 px-4 mt-14 md:grid md:grid-cols-2 lg:grid-cols-3 relative z-[60]">
           <!-- Launch -->
           <div class="carousel-item relative z-[70] overflow-visible bg-gray-50 border border-brand-steel/10 rounded-xl shadow-sm transition transform hover:-translate-y-1 px-6 py-10 md:p-10 flex flex-col">
             <span


### PR DESCRIPTION
## Summary
- make pricing carousel flex-based on small screens

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68743906894083299e8cb7dab2055c53