### PR TITLE
Fix pricing card overlap

### DIFF
--- a/index.html
+++ b/index.html
@@ -342,9 +342,9 @@
       No hidden fees, no “call for quote”. You’ll know the cost before we write a line of code.
     </p>
 
-    <div id="pricing-carousel" class="carousel-track flex gap-10 px-4 mt-14 md:grid md:grid-cols-2 lg:grid-cols-3 relative z-[60]">
+    <div id="pricing-carousel" class="carousel-track flex gap-10 px-4 mt-14 md:grid md:grid-cols-2 lg:grid-cols-3 relative z-40">
       <!-- Launch -->
-      <div class="carousel-item relative z-[70] overflow-visible bg-gray-50 border border-brand-steel/10 rounded-xl shadow-sm transition transform hover:-translate-y-1 px-6 py-10 md:p-10">
+      <div class="carousel-item relative z-30 overflow-visible bg-gray-50 border border-brand-steel/10 rounded-xl shadow-sm transition transform hover:-translate-y-1 px-6 py-10 md:p-10">
         <span
           class="absolute -top-3 left-1/2 -translate-x-1/2 transform bg-brand-orange text-white text-xs font-semibold px-3 py-1 rounded-full shadow whitespace-nowrap z-10 pointer-events-none"
           style="background-color:#D75E02">
@@ -369,7 +369,7 @@
         </div>
       </div>
       <!-- Premium Launch -->
-      <div class="carousel-item z-[70] bg-gray-50 border border-brand-steel/10 rounded-xl shadow-sm transition transform hover:-translate-y-1 px-6 py-10 md:p-10">
+      <div class="carousel-item z-30 bg-gray-50 border border-brand-steel/10 rounded-xl shadow-sm transition transform hover:-translate-y-1 px-6 py-10 md:p-10">
         <h3 class="text-xl font-semibold mb-4">Premium Launch</h3>
         <p class="text-5xl font-extrabold tracking-tight">$5,499</p>
         <ul class="text-base md:text-sm text-brand-steel mt-6 space-y-2 text-left">
@@ -389,7 +389,7 @@
         </div>
       </div>
       <!-- Care Plan -->
-      <div class="carousel-item z-[70] bg-gray-50 border border-brand-steel/10 rounded-xl shadow-sm transition transform hover:-translate-y-1 px-6 py-10 md:p-10">
+      <div class="carousel-item z-30 bg-gray-50 border border-brand-steel/10 rounded-xl shadow-sm transition transform hover:-translate-y-1 px-6 py-10 md:p-10">
         <h3 class="text-xl font-semibold mb-4">Care Plan</h3>
         <p class="text-5xl font-extrabold tracking-tight">$99<span class="text-2xl font-bold">/mo</span></p>
         <ul class="text-base md:text-sm text-brand-steel mt-6 space-y-2 text-left">

--- a/pricing/index.html
+++ b/pricing/index.html
@@ -101,9 +101,9 @@
         </p>
 
         <!-- Packages -->
-        <div id="pricing-carousel" class="carousel-track flex gap-10 px-4 mt-14 md:grid md:grid-cols-2 lg:grid-cols-3 relative z-[60]">
+        <div id="pricing-carousel" class="carousel-track flex gap-10 px-4 mt-14 md:grid md:grid-cols-2 lg:grid-cols-3 relative z-40">
           <!-- Launch -->
-          <div class="carousel-item relative z-[70] overflow-visible bg-gray-50 border border-brand-steel/10 rounded-xl shadow-sm transition transform hover:-translate-y-1 px-6 py-10 md:p-10 flex flex-col">
+          <div class="carousel-item relative z-30 overflow-visible bg-gray-50 border border-brand-steel/10 rounded-xl shadow-sm transition transform hover:-translate-y-1 px-6 py-10 md:p-10 flex flex-col">
             <span
               class="absolute -top-3 left-1/2 -translate-x-1/2 transform bg-brand-orange text-white text-xs font-semibold px-3 py-1 rounded-full shadow whitespace-nowrap z-10 pointer-events-none"
               style="background-color:#D75E02">
@@ -128,7 +128,7 @@
             </div>
           </div>
           <!-- Premium Launch -->
-          <div class="carousel-item z-[70] bg-gray-50 border border-brand-steel/10 rounded-xl shadow-sm transition transform hover:-translate-y-1 px-6 py-10 md:p-10 flex flex-col">
+          <div class="carousel-item z-30 bg-gray-50 border border-brand-steel/10 rounded-xl shadow-sm transition transform hover:-translate-y-1 px-6 py-10 md:p-10 flex flex-col">
             <h3 class="text-xl font-semibold mb-4">Premium Launch</h3>
             <p class="text-5xl font-extrabold tracking-tight">$5,499</p>
           <ul class="text-base md:text-sm text-brand-steel mt-6 space-y-2 text-left">
@@ -148,7 +148,7 @@
           </div>
         </div>
           <!-- Care Plan -->
-          <div class="carousel-item z-[70] bg-gray-50 border border-brand-steel/10 rounded-xl shadow-sm transition transform hover:-translate-y-1 px-6 py-10 md:p-10">
+          <div class="carousel-item z-30 bg-gray-50 border border-brand-steel/10 rounded-xl shadow-sm transition transform hover:-translate-y-1 px-6 py-10 md:p-10">
             <h3 class="text-xl font-semibold mb-4">Care Plan</h3>
             <p class="text-5xl font-extrabold tracking-tight">$99<span class="text-2xl font-bold">/mo</span></p>
             <ul class="text-base md:text-sm text-brand-steel mt-6 space-y-2 text-left">


### PR DESCRIPTION
## Summary
- lower z-index on the pricing carousel and cards so the header stays on top

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687439f1fd688329a38edcbb874f3b8b