### PR TITLE
Remove carousel auto scrolling

### DIFF
--- a/index.html
+++ b/index.html
@@ -574,7 +574,6 @@
     track.after(indicators);
 
     let index = 0;
-    let interval;
 
     function updateDots(i) {
       indicators.querySelectorAll('span').forEach((dot, idx) => {
@@ -590,34 +589,7 @@
       updateDots(index);
     }
 
-    function start() {
-      if (!interval) interval = setInterval(() => {
-        goTo((index + 1) % slideCount);
-      }, 4000);
-    }
-
-    function stop() {
-      if (interval) {
-        clearInterval(interval);
-        interval = null;
-      }
-    }
-
-    const visibility = new IntersectionObserver(entries => {
-      entries.forEach(entry => {
-        const fully = entry.isIntersecting &&
-                      entry.intersectionRect.height >= entry.boundingClientRect.height &&
-                      entry.intersectionRect.top >= 0 &&
-                      entry.intersectionRect.bottom <= window.innerHeight;
-        if (fully) {
-          start();
-        } else {
-          stop();
-        }
-      });
-    }, { threshold: [0, 1] });
-
-    visibility.observe(track.parentElement || track);
+    // Auto-scrolling removed
 
     track.addEventListener('scroll', () => {
       const i = Math.round(track.scrollLeft / slideWidth);

--- a/pricing/index.html
+++ b/pricing/index.html
@@ -187,13 +187,10 @@
     const track=document.getElementById(id);if(!track)return;const slides=Array.from(track.children);const slideCount=slides.length;
     const indicators=document.createElement('div');indicators.className='carousel-indicators';
     for(let i=0;i<slideCount;i++){const dot=document.createElement('span');if(i===0)dot.classList.add('active');indicators.appendChild(dot);}track.after(indicators);
-    let index=0;let interval;function updateDots(i){indicators.querySelectorAll('span').forEach((dot,idx)=>{dot.classList.toggle('active',idx===i);});}
+    let index=0;function updateDots(i){indicators.querySelectorAll('span').forEach((dot,idx)=>{dot.classList.toggle('active',idx===i);});}
     const slideWidth=slides[1]?slides[1].offsetLeft-slides[0].offsetLeft:track.clientWidth;
     function goTo(i){index=i;track.scrollTo({left:slideWidth*index,behavior:'smooth'});updateDots(index);}
-    function start(){if(!interval)interval=setInterval(()=>{goTo((index+1)%slideCount);},4000);} 
-    function stop(){if(interval){clearInterval(interval);interval=null;}}
-    const visibility=new IntersectionObserver(entries=>{entries.forEach(entry=>{const fully=entry.isIntersecting&&entry.intersectionRect.height>=entry.boundingClientRect.height&&entry.intersectionRect.top>=0&&entry.intersectionRect.bottom<=window.innerHeight;if(fully){start();}else{stop();}});},{threshold:[0,1]});
-    visibility.observe(track.parentElement||track);
+    // Auto-scrolling removed
     track.addEventListener('scroll',()=>{const i=Math.round(track.scrollLeft/slideWidth);if(i!==index){index=i;updateDots(index);}});
   }
   if(window.matchMedia('(max-width: 767px)').matches){initCarousel('pricing-carousel');}


### PR DESCRIPTION
## Summary
- disable automatic rotation on portfolio and pricing carousels

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68743e759f24832983de7bfeaf7b0bfa