### PR TITLE
Fix bubble layout on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -346,7 +346,7 @@
       <!-- Launch -->
       <div class="carousel-item relative z-30 overflow-visible bg-gray-50 border border-brand-steel/10 rounded-xl shadow-sm transition transform hover:-translate-y-1 px-6 py-10 md:p-10">
         <span
-          class="absolute -top-3 left-1/2 -translate-x-1/2 transform bg-brand-orange text-white text-xs font-semibold px-3 py-1 rounded-full shadow whitespace-nowrap z-10 pointer-events-none"
+          class="block mx-auto mb-4 md:absolute md:mb-0 md:-top-3 md:left-1/2 md:-translate-x-1/2 transform bg-brand-orange text-white text-xs font-semibold px-3 py-1 rounded-full shadow whitespace-nowrap z-10 pointer-events-none"
           style="background-color:#D75E02">
           Most yards start here
         </span>

--- a/pricing/index.html
+++ b/pricing/index.html
@@ -105,7 +105,7 @@
           <!-- Launch -->
           <div class="carousel-item relative z-30 overflow-visible bg-gray-50 border border-brand-steel/10 rounded-xl shadow-sm transition transform hover:-translate-y-1 px-6 py-10 md:p-10 flex flex-col">
             <span
-              class="absolute -top-3 left-1/2 -translate-x-1/2 transform bg-brand-orange text-white text-xs font-semibold px-3 py-1 rounded-full shadow whitespace-nowrap z-10 pointer-events-none"
+              class="block mx-auto mb-4 md:absolute md:mb-0 md:-top-3 md:left-1/2 md:-translate-x-1/2 transform bg-brand-orange text-white text-xs font-semibold px-3 py-1 rounded-full shadow whitespace-nowrap z-10 pointer-events-none"
               style="background-color:#D75E02">
               Most yards start here
             </span>


### PR DESCRIPTION
## Summary
- tweak the "Most yards start here" bubble so it's placed inside the Standard Launch card on small screens

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68743ee49d688329a9f330174f3e839e