### PR TITLE
Add mobile carousel to portfolio page

### DIFF
--- a/portfolio/index.html
+++ b/portfolio/index.html
@@ -22,6 +22,10 @@
     .site-title{position:relative;display:inline-block;}
     .site-title::after{content:'';position:absolute;left:0;bottom:-2px;width:0;height:2px;background-color:var(--color-links);transition:width .3s ease;}
     a:hover .site-title::after{width:100%;}
+    @media (max-width: 767px){.carousel-track{display:flex;overflow-x:auto;scroll-snap-type:x mandatory;-webkit-overflow-scrolling:touch;scroll-behavior:smooth;}.carousel-item{flex:0 0 100%;scroll-snap-align:center;}}
+    .carousel-indicators{display:flex;justify-content:center;gap:.5rem;margin-top:1rem;}
+    .carousel-indicators span{background:#D75E02;border-radius:9999px;width:.5rem;height:.5rem;opacity:.5;transition:width .3s ease,opacity .3s ease;}
+    .carousel-indicators span.active{width:1.5rem;opacity:1;}
   </style>
 </head>
 <body class="font-sans text-brand-charcoal antialiased bg-white overflow-x-hidden">
@@ -90,22 +94,22 @@
   <main class="pt-24 pb-20 px-6">
     <h1 class="text-3xl font-bold text-center mb-12">Our Portfolio</h1>
     <div class="mx-auto max-w-6xl text-center">
-      <div class="grid gap-8 md:grid-cols-3">
-        <a href="demo-yard-1/" class="block bg-gray-50 border border-brand-steel/10 rounded-xl shadow-sm p-10 flex flex-col items-center text-center hover:bg-gray-100 hover:shadow-lg transition transform hover:-translate-y-1">
+      <div id="portfolio-carousel" class="carousel-track flex px-4 md:grid md:grid-cols-3 gap-8">
+        <a href="demo-yard-1/" class="carousel-item block bg-gray-50 border border-brand-steel/10 rounded-xl shadow-sm p-10 flex flex-col items-center text-center hover:bg-gray-100 hover:shadow-lg transition transform hover:-translate-y-1">
           <div class="w-full rounded-xl overflow-hidden border border-brand-steel/10">
             <img class="w-full" src="https://placehold.co/600x400/2B2B2B/FFFFFF?text=Demo+Yard+1" alt="Demo Yard 1">
           </div>
           <h2 class="font-semibold mt-4">Demo Yard 1</h2>
           <p class="text-sm text-brand-steel mt-1">Custom design for a busy metro scrapyard.</p>
         </a>
-        <a href="demo-yard-2/" class="block bg-gray-50 border border-brand-steel/10 rounded-xl shadow-sm p-10 flex flex-col items-center text-center hover:bg-gray-100 hover:shadow-lg transition transform hover:-translate-y-1">
+        <a href="demo-yard-2/" class="carousel-item block bg-gray-50 border border-brand-steel/10 rounded-xl shadow-sm p-10 flex flex-col items-center text-center hover:bg-gray-100 hover:shadow-lg transition transform hover:-translate-y-1">
           <div class="w-full rounded-xl overflow-hidden border border-brand-steel/10">
             <img class="w-full" src="https://placehold.co/600x400/2B2B2B/FFFFFF?text=Demo+Yard+2" alt="Demo Yard 2">
           </div>
           <h2 class="font-semibold mt-4">Demo Yard 2</h2>
           <p class="text-sm text-brand-steel mt-1">Mobile friendly layout with fast quote form.</p>
         </a>
-        <a href="demo-yard-3/" class="block bg-gray-50 border border-brand-steel/10 rounded-xl shadow-sm p-10 flex flex-col items-center text-center hover:bg-gray-100 hover:shadow-lg transition transform hover:-translate-y-1">
+        <a href="demo-yard-3/" class="carousel-item block bg-gray-50 border border-brand-steel/10 rounded-xl shadow-sm p-10 flex flex-col items-center text-center hover:bg-gray-100 hover:shadow-lg transition transform hover:-translate-y-1">
           <div class="w-full rounded-xl overflow-hidden border border-brand-steel/10">
             <img class="w-full" src="https://placehold.co/600x400/2B2B2B/FFFFFF?text=Demo+Yard+3" alt="Demo Yard 3">
           </div>
@@ -119,5 +123,17 @@
     <p>© <span id="year"></span> Scrapyard Sites — All rights reserved.</p>
   </footer>
   <script>document.getElementById('year').textContent=new Date().getFullYear();</script>
+  <script>
+  function initCarousel(id){
+    const track=document.getElementById(id);if(!track)return;const slides=Array.from(track.children);const slideCount=slides.length;
+    const indicators=document.createElement('div');indicators.className='carousel-indicators';
+    for(let i=0;i<slideCount;i++){const dot=document.createElement('span');if(i==0)dot.classList.add('active');indicators.appendChild(dot);}track.after(indicators);
+    let index=0;function updateDots(i){indicators.querySelectorAll('span').forEach((dot,idx)=>{dot.classList.toggle('active',idx===i);});}
+    const slideWidth=slides[1]?slides[1].offsetLeft-slides[0].offsetLeft:track.clientWidth;
+    function goTo(i){index=i;track.scrollTo({left:slideWidth*index,behavior:'smooth'});updateDots(index);}
+    track.addEventListener('scroll',()=>{const i=Math.round(track.scrollLeft/slideWidth);if(i!==index){index=i;updateDots(index);}});
+  }
+  if(window.matchMedia('(max-width: 767px)').matches){initCarousel('portfolio-carousel');}
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add carousel CSS and JS to `portfolio/index.html`
- convert portfolio grid to carousel on mobile

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6874430102508329afa99208581685db