### PR TITLE
Fix pricing card width on mobile

### DIFF
--- a/pricing/index.html
+++ b/pricing/index.html
@@ -91,7 +91,7 @@
   });
 
   </script>
-  <main class="pt-24 pb-20 px-6">
+  <main class="pt-24 pb-20">
     <section class="py-20 bg-white">
       <div class="mx-auto max-w-6xl px-6 text-center">
         <h1 class="text-3xl font-bold">Straight‑Shooter Pricing</h1>


### PR DESCRIPTION
## Summary
- remove horizontal padding from pricing page `<main>` element

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6874432a10e8832981226a6e6e89cf4b