### PR TITLE
Fix homepage CTA text

### DIFF
--- a/index.html
+++ b/index.html
@@ -248,7 +248,7 @@
       We plug that hole—in <em>7 days</em>—or your build is free.
     </p>
     <div class="mt-8 flex flex-col sm:flex-row gap-4 justify-center">
-      <a href="/pricing" class="btn-primary">See Cost →</a>
+      <a href="/pricing" class="btn-primary">See Pricing →</a>
       <a href="/risk-calculator" class="btn-secondary">Calculate My Leak</a>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- update the hero button text on the homepage to say "See Pricing" instead of "See Cost"

## Testing
- `grep -n "See Pricing" -n index.html`


------
https://chatgpt.com/codex/tasks/task_e_68744407e88c83299b6be0eadc598be7