### PR TITLE
Fix portfolio carousel spacing

### DIFF
--- a/portfolio/index.html
+++ b/portfolio/index.html
@@ -23,7 +23,7 @@
     .site-title::after{content:'';position:absolute;left:0;bottom:-2px;width:0;height:2px;background-color:var(--color-links);transition:width .3s ease;}
     a:hover .site-title::after{width:100%;}
     @media (max-width: 767px){.carousel-track{display:flex;overflow-x:auto;scroll-snap-type:x mandatory;-webkit-overflow-scrolling:touch;scroll-behavior:smooth;}.carousel-item{flex:0 0 100%;scroll-snap-align:center;}}
-    .carousel-indicators{display:flex;justify-content:center;gap:.5rem;margin-top:1rem;}
+    .carousel-indicators{display:flex;justify-content:center;gap:.5rem;margin-top:1.5rem;}
     .carousel-indicators span{background:#D75E02;border-radius:9999px;width:.5rem;height:.5rem;opacity:.5;transition:width .3s ease,opacity .3s ease;}
     .carousel-indicators span.active{width:1.5rem;opacity:1;}
   </style>


### PR DESCRIPTION
## Summary
- bump margin-top for portfolio carousel indicators to 1.5rem

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6874451c33288329a7b839e1358c342a