### PR TITLE
Add inverted hover for pricing CTA

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -15,6 +15,16 @@
 }
 .btn-primary:hover { opacity: 0.9; }
 
+/* Inverted hover style for the homepage pricing CTA */
+.btn-invert-hover {
+  transition: background-color 0.2s, color 0.2s;
+}
+.btn-invert-hover:hover {
+  background-color: white;
+  color: #D75E02;
+  opacity: 1;
+}
+
 .btn-secondary {
   display: inline-flex;
   align-items: center;

--- a/index.html
+++ b/index.html
@@ -248,7 +248,7 @@
       We plug that hole—in <em>7 days</em>—or your build is free.
     </p>
     <div class="mt-8 flex flex-col sm:flex-row gap-4 justify-center">
-      <a href="/pricing" class="btn-primary">See Pricing →</a>
+      <a href="/pricing" class="btn-primary btn-invert-hover">See Pricing →</a>
       <a href="/risk-calculator" class="btn-secondary">Calculate My Leak</a>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- add `btn-invert-hover` style for custom hover behavior
- apply the new style to the homepage "See Pricing" CTA

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68755a8117ec8329bf2428708c69e9ba