### PR TITLE
Revamp pricing page with ROI details

### DIFF
--- a/pricing/index.html
+++ b/pricing/index.html
@@ -94,72 +94,65 @@
   <main class="pt-24 pb-20">
     <section class="py-20 bg-white">
       <div class="mx-auto max-w-6xl px-6 text-center">
-        <h1 class="text-3xl font-bold">Straight‑Shooter Pricing</h1>
+        <h1 class="text-3xl font-bold">Straight‑Shooter Pricing—with ROI Math</h1>
         <p class="mt-2 text-sm">
-          One missed roll‑off a month (~<strong>$8 k</strong>) costs more than our Standard Launch.
-          Doing nothing is the most expensive option.
+          Every missed roll‑off equals $2–3 k. One per month costs $30 k—more than our Premium build.
         </p>
 
-        <!-- Packages -->
-        <div id="pricing-carousel" class="carousel-track flex gap-10 px-4 mt-14 md:grid md:grid-cols-2 lg:grid-cols-3 relative z-40">
-          <!-- Launch -->
-          <div class="carousel-item relative z-30 overflow-visible bg-gray-50 border border-brand-steel/10 rounded-xl shadow-sm transition transform hover:-translate-y-1 px-6 py-10 md:p-10 flex flex-col">
-            <span
-              class="hidden md:block mx-auto mb-4 md:absolute md:mb-0 md:-top-3 md:left-1/2 md:-translate-x-1/2 transform bg-brand-orange text-white text-xs font-semibold px-3 py-1 rounded-full shadow whitespace-nowrap z-10 pointer-events-none"
-              style="background-color:#D75E02">
-              Most yards start here
-            </span>
-            <h3 class="text-xl font-semibold mb-4">Standard Launch</h3>
-            <p class="text-5xl font-extrabold tracking-tight">$2,499</p>
-            <ul class="text-base md:text-sm text-brand-steel mt-6 space-y-2 text-left">
-              <li>• Quick fix that stops missed-call bleed—for yards losing business right now.</li>
-              <li>• Contact form straight to your inbox</li>
-              <li>• Google Maps embed</li>
-              <li>• Google Business Profile tune-up + basic SEO</li>
-              <li>• 30 days of free tweaks</li>
-            </ul>
-            <div class="mt-auto pt-6 text-center">
-              <a
-                href="https://book.stripe.com/eVqeVd8Vi9U45RbdJy73G00"
-                class="btn-primary"
-              >
-                Pay Deposit
-              </a>
-            </div>
-          </div>
-          <!-- Premium Launch -->
-          <div class="carousel-item z-30 bg-gray-50 border border-brand-steel/10 rounded-xl shadow-sm transition transform hover:-translate-y-1 px-6 py-10 md:p-10 flex flex-col">
-            <h3 class="text-xl font-semibold mb-4">Premium Launch</h3>
-            <p class="text-5xl font-extrabold tracking-tight">$5,499</p>
-          <ul class="text-base md:text-sm text-brand-steel mt-6 space-y-2 text-left">
-            <li>• Full insurance policy: multi-page muscle so Google never buries you again.</li>
-            <li>• Contact forms on every key page</li>
-            <li>• Location pages with Google Maps</li>
-            <li>• Structured-data SEO + GBP cleanup</li>
-            <li>• 60 days of fine-tuning after go-live</li>
-          </ul>
-          <div class="mt-auto pt-6 text-center">
-            <a
-              href="https://book.stripe.com/4gM28r2wU7LW3J36h673G01"
-              class="btn-primary"
-            >
-              Pay Deposit
-            </a>
-          </div>
+        <div class="overflow-x-auto mt-8">
+          <table class="min-w-full text-sm border">
+            <thead class="bg-gray-100">
+              <tr>
+                <th class="border px-2 py-1 text-left">Package</th>
+                <th class="border px-2 py-1 text-left">Best for</th>
+                <th class="border px-2 py-1 text-left">Up‑front</th>
+                <th class="border px-2 py-1 text-left">Timeline</th>
+                <th class="border px-2 py-1 text-left">What’s included</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td class="border px-2 py-1">Standard Launch</td>
+                <td class="border px-2 py-1">Leaky DIY sites</td>
+                <td class="border px-2 py-1">$2,499</td>
+                <td class="border px-2 py-1">7 days</td>
+                <td class="border px-2 py-1">1‑page high‑converter, contact form, GBP tune‑up</td>
+              </tr>
+              <tr>
+                <td class="border px-2 py-1">Premium Launch</td>
+                <td class="border px-2 py-1">Multi‑location yards</td>
+                <td class="border px-2 py-1">$5,499</td>
+                <td class="border px-2 py-1">10 days</td>
+                <td class="border px-2 py-1">Up to 7 pages, location pages, structured‑data SEO, 60‑day tuning</td>
+              </tr>
+              <tr>
+                <td class="border px-2 py-1">Care Plan</td>
+                <td class="border px-2 py-1">Peace of mind</td>
+                <td class="border px-2 py-1">$99/mo</td>
+                <td class="border px-2 py-1">–</td>
+                <td class="border px-2 py-1">Unlimited edits, security, quarterly KPIs</td>
+              </tr>
+            </tbody>
+          </table>
         </div>
-          <!-- Care Plan -->
-          <div class="carousel-item z-30 bg-gray-50 border border-brand-steel/10 rounded-xl shadow-sm transition transform hover:-translate-y-1 px-6 py-10 md:p-10">
-            <h3 class="text-xl font-semibold mb-4">Care Plan</h3>
-            <p class="text-5xl font-extrabold tracking-tight">$99<span class="text-2xl font-bold">/mo</span></p>
-            <ul class="text-base md:text-sm text-brand-steel mt-6 space-y-2 text-left">
-              <li>• Unlimited text & photo updates (24 hour turnaround)</li>
-              <li>• Security patches, backups, uptime checks</li>
-              <li>• Quarterly performance report</li>
-              <li>• Priority email support</li>
-            </ul>
-          </div>
+        <p class="text-xs mt-2"><small>50 % deposit books your build week · ACH, card, or check · No surprise fees</small></p>
+
+        <p class="mt-6 text-sm">
+          <strong>Need extras?</strong><br>
+          • Additional pages – $350/ea<br>
+          • On‑site photo/video – from $750 (Lower 48)<br>
+          • Hand‑off to your own server – $199 one‑time
+        </p>
+
+        <p class="mt-6 text-sm">
+          <strong>Money‑Back Edge:</strong> If your new site doesn’t pay for itself within 90 days (measured in new loads or quotes), we refund the build fee—no hoops.
+        </p>
+
+        <div class="mt-6 text-center">
+          <a href="https://book.stripe.com/eVqeVd8Vi9U45RbdJy73G00" class="btn-primary">
+            Lock Your Build Week <small class="ml-1">Pay Deposit ➜</small>
+          </a>
         </div>
-      </div>
 
       <!-- FAQ stays below packages -->
     </section>


### PR DESCRIPTION
## Summary
- update headline to **Straight‑Shooter Pricing—with ROI Math**
- replace package carousel with a simple table of offerings
- add notes on deposit, optional extras, and money‑back guarantee
- keep existing FAQ section

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68755b7aafec8329adea1d5d522e454c