### PR TITLE
Restore pricing cards above table

### DIFF
--- a/pricing/index.html
+++ b/pricing/index.html
@@ -99,6 +99,66 @@
           Every missed roll‑off equals $2–3 k. One per month costs $30 k—more than our Premium build.
         </p>
 
+        <!-- Packages -->
+        <div id="pricing-carousel" class="carousel-track flex gap-10 px-4 mt-14 md:grid md:grid-cols-2 lg:grid-cols-3 relative z-40">
+          <!-- Launch -->
+          <div class="carousel-item relative z-30 overflow-visible bg-gray-50 border border-brand-steel/10 rounded-xl shadow-sm transition transform hover:-translate-y-1 px-6 py-10 md:p-10 flex flex-col">
+            <span
+              class="hidden md:block mx-auto mb-4 md:absolute md:mb-0 md:-top-3 md:left-1/2 md:-translate-x-1/2 transform bg-brand-orange text-white text-xs font-semibold px-3 py-1 rounded-full shadow whitespace-nowrap z-10 pointer-events-none"
+              style="background-color:#D75E02">
+              Most yards start here
+            </span>
+            <h3 class="text-xl font-semibold mb-4">Standard Launch</h3>
+            <p class="text-5xl font-extrabold tracking-tight">$2,499</p>
+            <ul class="text-base md:text-sm text-brand-steel mt-6 space-y-2 text-left">
+              <li>• Quick fix that stops missed-call bleed—for yards losing business right now.</li>
+              <li>• Contact form straight to your inbox</li>
+              <li>• Google Maps embed</li>
+              <li>• Google Business Profile tune-up + basic SEO</li>
+              <li>• 30 days of free tweaks</li>
+            </ul>
+            <div class="mt-auto pt-6 text-center">
+              <a
+                href="https://book.stripe.com/eVqeVd8Vi9U45RbdJy73G00"
+                class="btn-primary"
+              >
+                Pay Deposit
+              </a>
+            </div>
+          </div>
+          <!-- Premium Launch -->
+          <div class="carousel-item z-30 bg-gray-50 border border-brand-steel/10 rounded-xl shadow-sm transition transform hover:-translate-y-1 px-6 py-10 md:p-10 flex flex-col">
+            <h3 class="text-xl font-semibold mb-4">Premium Launch</h3>
+            <p class="text-5xl font-extrabold tracking-tight">$5,499</p>
+          <ul class="text-base md:text-sm text-brand-steel mt-6 space-y-2 text-left">
+            <li>• Full insurance policy: multi-page muscle so Google never buries you again.</li>
+            <li>• Contact forms on every key page</li>
+            <li>• Location pages with Google Maps</li>
+            <li>• Structured-data SEO + GBP cleanup</li>
+            <li>• 60 days of fine-tuning after go-live</li>
+          </ul>
+          <div class="mt-auto pt-6 text-center">
+            <a
+              href="https://book.stripe.com/4gM28r2wU7LW3J36h673G01"
+              class="btn-primary"
+            >
+              Pay Deposit
+            </a>
+          </div>
+        </div>
+          <!-- Care Plan -->
+          <div class="carousel-item z-30 bg-gray-50 border border-brand-steel/10 rounded-xl shadow-sm transition transform hover:-translate-y-1 px-6 py-10 md:p-10">
+            <h3 class="text-xl font-semibold mb-4">Care Plan</h3>
+            <p class="text-5xl font-extrabold tracking-tight">$99<span class="text-2xl font-bold">/mo</span></p>
+            <ul class="text-base md:text-sm text-brand-steel mt-6 space-y-2 text-left">
+              <li>• Unlimited text & photo updates (24 hour turnaround)</li>
+              <li>• Security patches, backups, uptime checks</li>
+              <li>• Quarterly performance report</li>
+              <li>• Priority email support</li>
+            </ul>
+          </div>
+        </div>
+
         <div class="overflow-x-auto mt-8">
           <table class="min-w-full text-sm border">
             <thead class="bg-gray-100">


### PR DESCRIPTION
## Summary
- reintroduce carousel pricing cards on the pricing page
- keep ROI table below the cards

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68756ebd66748329b065f2a7033793d9