### PR TITLE
Add deliverables accordion on services page

### DIFF
--- a/services/index.html
+++ b/services/index.html
@@ -178,6 +178,27 @@
         </article>
       </div>
 
+      <div class="mt-12 max-w-3xl mx-auto space-y-4 px-6">
+        <details class="group border border-brand-steel/10 bg-white rounded-md p-4">
+          <summary class="cursor-pointer font-semibold text-brand-charcoal group-open:text-brand-orange">
+            Standard Package Deliverables
+          </summary>
+          <ul class="mt-2 pl-4 list-disc text-brand-steel text-sm">
+            <li>1‑page high‑converter with contact form</li>
+            <li>Google Business Profile tune‑up</li>
+          </ul>
+        </details>
+        <details class="group border border-brand-steel/10 bg-white rounded-md p-4">
+          <summary class="cursor-pointer font-semibold text-brand-charcoal group-open:text-brand-orange">
+            Premium Package Deliverables
+          </summary>
+          <ul class="mt-2 pl-4 list-disc text-brand-steel text-sm">
+            <li>Up to 7 pages including location pages</li>
+            <li>Structured‑data SEO and 60‑day tuning</li>
+          </ul>
+        </details>
+      </div>
+
       <div class="text-center mt-12">
         <p class="mb-2 text-sm">Ready to plug the leak?</p>
         <a href="/contact" class="btn-primary"><small>Book a 15-min Leak Detection Call ➜</small></a>


### PR DESCRIPTION
## Summary
- add accordion listing deliverables for Standard and Premium packages

## Testing
- `npx htmlhint services/index.html` *(fails: 403 Forbidden, npm registry blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68756f576ba88329b678fb3499315d9e