### PR TITLE
Improve process page design

### DIFF
--- a/process/index.html
+++ b/process/index.html
@@ -116,10 +116,13 @@
 
   </script>
   <main class="pt-24 pb-20 px-6">
-    <section class="py-16">
-      <div class="max-w-3xl mx-auto px-6 text-center">
-        <h1 class="text-3xl font-bold text-center">7&nbsp;Days from Ghost‑Site&nbsp;to&nbsp;Google‑Proof</h1>
-        <p class="text-center max-w-2xl mx-auto text-sm mt-2">A one‑week plan that patches your leaks and locks in rankings.</p>
+    <section class="relative flex items-center justify-center text-center min-h-[60vh]">
+      <img src="/assets/hero.jpg" alt="Scrapyard crew at work" class="absolute inset-0 w-full h-full object-cover" />
+      <div class="absolute inset-0 bg-black/70"></div>
+      <div class="relative z-10 max-w-3xl mx-auto px-6">
+        <h1 class="text-3xl font-bold">7&nbsp;Days from Ghost‑Site&nbsp;to&nbsp;Google‑Proof</h1>
+        <p class="text-sm max-w-2xl mx-auto mt-2">We turn your outdated scrap‑yard website into a 24/7 scale‑house magnet in one week—guaranteed.</p>
+      </div>
 
         <ol class="mt-12 flex flex-col md:flex-row justify-between gap-8">
           <li class="flex flex-col items-center gap-2">
@@ -138,62 +141,96 @@
 
         <div class="mt-10 space-y-4 text-left">
           <details>
-            <summary class="font-semibold cursor-pointer">Day&nbsp;0 – Leak Detection</summary>
+            <summary class="font-semibold cursor-pointer flex items-start gap-2">
+              <span aria-hidden="true">🔍</span>Day&nbsp;0 – Leak Detection
+              <span class="text-brand-steel text-sm font-normal">Walk away with a punch‑list and fixed price.</span>
+            </summary>
             <ul class="text-sm list-disc list-inside mt-2">
               <li>15‑minute screen‑share</li>
-              <li>Spot missed calls, unranked pages &amp; messy metal lists</li>
-              <li>Leave with a punch‑list and fixed price</li>
+              <li>Spot missed calls and messy metal lists</li>
             </ul>
           </details>
           <details>
-            <summary class="font-semibold cursor-pointer">Day&nbsp;1 – Design kickoff</summary>
+            <summary class="font-semibold cursor-pointer flex items-start gap-2">
+              <span aria-hidden="true">✏️</span>Day&nbsp;1 – Design kickoff
+              <span class="text-brand-steel text-sm font-normal">Mobile, loader‑cab &amp; desktop polished from day one.</span>
+            </summary>
             <ul class="text-sm list-disc list-inside mt-2">
-              <li>Design desktop, mobile &amp; loader‑cab breakpoints</li>
+              <li>Design breakpoints</li>
               <li>Industry‑fluent copy outline</li>
             </ul>
           </details>
           <details>
-            <summary class="font-semibold cursor-pointer">Day&nbsp;2 – Build staging site</summary>
+            <summary class="font-semibold cursor-pointer flex items-start gap-2">
+              <span aria-hidden="true">🔧</span>Day&nbsp;2 – Build staging site
+              <span class="text-brand-steel text-sm font-normal">Your yard’s new site goes live on a private link.</span>
+            </summary>
             <ul class="text-sm list-disc list-inside mt-2">
               <li>Jamstack repo you can watch</li>
               <li>Copy refined by GPT‑4o</li>
             </ul>
           </details>
           <details>
-            <summary class="font-semibold cursor-pointer">Day&nbsp;3 – SEO &amp; schema</summary>
-            <ul class="text-sm list-disc list-inside mt-2">
-              <li>Pages optimized and schema pushed</li>
-            </ul>
+            <summary class="font-semibold cursor-pointer flex items-start gap-2">
+              <span aria-hidden="true">📈</span>Day&nbsp;3 – SEO &amp; schema
+              <span class="text-brand-steel text-sm font-normal">We wire your site for Google signals: on‑page SEO, metals‑list schema &amp; Google‑Business sync.</span>
+            </summary>
           </details>
           <details>
-            <summary class="font-semibold cursor-pointer">Day&nbsp;4 – Review round</summary>
-            <ul class="text-sm list-disc list-inside mt-2">
-              <li>One review keeps the timeline bullet‑proof</li>
-            </ul>
+            <summary class="font-semibold cursor-pointer flex items-start gap-2">
+              <span aria-hidden="true">🛠️</span>Day&nbsp;4 – Review round
+              <span class="text-brand-steel text-sm font-normal">One review keeps the timeline bullet‑proof.</span>
+            </summary>
           </details>
           <details>
-            <summary class="font-semibold cursor-pointer">Day&nbsp;5 – Final tweaks</summary>
-            <ul class="text-sm list-disc list-inside mt-2">
-              <li>Prepare for after‑hours DNS flip</li>
-            </ul>
+            <summary class="font-semibold cursor-pointer flex items-start gap-2">
+              <span aria-hidden="true">🚀</span>Day&nbsp;5 – Final tweaks
+              <span class="text-brand-steel text-sm font-normal">Ready for after‑hours DNS flip.</span>
+            </summary>
           </details>
           <details>
-            <summary class="font-semibold cursor-pointer">Days&nbsp;6‑7 – Launch &amp; 30‑day watch</summary>
-            <ul class="text-sm list-disc list-inside mt-2">
-              <li>DNS flips after hours—no downtime</li>
-              <li>Backups and weekly checks for 30 days</li>
-              <li>Free tweaks included</li>
-            </ul>
+            <summary class="font-semibold cursor-pointer flex items-start gap-2">
+              <span aria-hidden="true">⚙️</span>Days&nbsp;6‑7 – Launch &amp; 30‑day watch
+              <span class="text-brand-steel text-sm font-normal">Zero downtime plus a month of backups and tweaks.</span>
+            </summary>
           </details>
         </div>
 
-        <div class="border border-brand-steel/20 rounded-xl p-6 mt-10 flex items-center gap-4">
-          <svg class="w-8 h-8 text-brand-orange" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 1l3 5 5 .7-3.6 3.5.8 5-4.2-2.2L8 15l.8-5L5 6.7l5-.7 2-5z"/></svg>
-          <p class="text-sm font-medium">If we miss the seven‑day launch window, you receive your first month of our Care Plan entirely free—plus we keep working until everything performs perfectly.</p>
+        <div class="bg-brand-orange/10 border-l-4 border-brand-orange rounded-xl p-6 mt-10 flex items-start gap-4">
+          <svg class="w-8 h-8 text-brand-orange flex-shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 1l3 5 5 .7-3.6 3.5.8 5-4.2-2.2L8 15l.8-5L5 6.7l5-.7 2-5z"/></svg>
+          <div>
+            <h3 class="font-bold mb-1">No‑Excuses Guarantee</h3>
+            <p class="text-sm font-medium">If we miss the seven‑day launch window, your first month of our Care Plan is on us—plus we keep working until everything performs perfectly.</p>
+          </div>
+        </div>
+
+        <div class="mt-8 flex justify-center gap-4">
+          <a href="/contact" class="btn-primary">Book 15‑min Leak Audit</a>
+          <a href="/risk-calculator" class="btn-secondary">See My Lost Tonnage</a>
         </div>
 
       </div>
+        <div class="mt-8 flex justify-center gap-4">
+          <a href="/contact" class="btn-primary">Book 15‑min Leak Audit</a>
+          <a href="/risk-calculator" class="btn-secondary">See My Lost Tonnage</a>
+        </div>
+      </div>
     </section>
+
+    <section class="py-16 bg-gray-50">
+      <div class="max-w-5xl mx-auto grid md:grid-cols-2 gap-8 items-center px-6">
+        <img src="/assets/hero.jpg" alt="Yard crew loading metal" class="rounded-lg shadow" />
+        <p class="text-brand-charcoal">Real photos show off your operation. We’ll polish what you have or use stock until you capture the real thing.</p>
+      </div>
+    </section>
+
+    <section class="py-16">
+      <div class="max-w-5xl mx-auto grid md:grid-cols-2 gap-8 items-center px-6">
+        <p class="order-2 md:order-1 text-brand-charcoal">Mobile mock‑ups and live site screenshots prove every page runs fast in the loader cab.</p>
+        <img src="/assets/hero.jpg" alt="Mobile phone with scrapyard website" class="order-1 md:order-2 rounded-lg shadow" />
+      </div>
+    </section>
+
     <section class="py-12">
       <div class="mx-auto max-w-2xl px-6">
         <h2 class="text-2xl font-bold text-center mb-6">Mini FAQ</h2>
@@ -210,9 +247,49 @@
             <summary class="cursor-pointer font-semibold text-brand-charcoal group-open:text-brand-orange">Do you offer ongoing support?</summary>
             <p class="mt-1 text-brand-steel text-base md:text-sm md:pl-4 md:border-l md:border-brand-orange/40">Yes. Thirty days of tweaks are free and Care Plan options follow.</p>
           </details>
+          <details class="group">
+            <summary class="cursor-pointer font-semibold text-brand-charcoal group-open:text-brand-orange">How much does it cost?</summary>
+            <p class="mt-1 text-brand-steel text-base md:text-sm md:pl-4 md:border-l md:border-brand-orange/40">Projects start at $2,499 for a Standard Launch.</p>
+          </details>
+          <details class="group">
+            <summary class="cursor-pointer font-semibold text-brand-charcoal group-open:text-brand-orange">Do I own the code?</summary>
+            <p class="mt-1 text-brand-steel text-base md:text-sm md:pl-4 md:border-l md:border-brand-orange/40">Absolutely—you get full access to the GitHub repo.</p>
+          </details>
+          <details class="group">
+            <summary class="cursor-pointer font-semibold text-brand-charcoal group-open:text-brand-orange">Can you integrate iScrap?</summary>
+            <p class="mt-1 text-brand-steel text-base md:text-sm md:pl-4 md:border-l md:border-brand-orange/40">Yes. We work with iScrap and other inventory platforms.</p>
+          </details>
         </div>
       </div>
     </section>
+
+    <section class="py-12 bg-gray-50">
+      <div class="max-w-4xl mx-auto px-6">
+        <h2 class="text-2xl font-bold text-center mb-6">What Yards Say</h2>
+        <div id="testimonialCarousel" class="flex overflow-x-auto gap-6 snap-x snap-mandatory">
+          <blockquote class="min-w-[80%] snap-center bg-white border border-brand-steel/20 rounded-xl p-6 shadow-sm">
+            <img src="/assets/logo.svg" alt="Demo Yard 1 logo" class="h-8 mb-2" />
+            <p class="text-sm italic">“Our tonnage jumped 20% after launch.”</p>
+            <cite class="text-xs mt-2 block text-right">— Demo Yard 1</cite>
+          </blockquote>
+          <blockquote class="min-w-[80%] snap-center bg-white border border-brand-steel/20 rounded-xl p-6 shadow-sm">
+            <img src="/assets/logo.svg" alt="Demo Yard 2 logo" class="h-8 mb-2" />
+            <p class="text-sm italic">“Phones started ringing again within days.”</p>
+            <cite class="text-xs mt-2 block text-right">— Demo Yard 2</cite>
+          </blockquote>
+          <blockquote class="min-w-[80%] snap-center bg-white border border-brand-steel/20 rounded-xl p-6 shadow-sm">
+            <img src="/assets/logo.svg" alt="Demo Yard 3 logo" class="h-8 mb-2" />
+            <p class="text-sm italic">“We booked 30 more loads the first month.”</p>
+            <cite class="text-xs mt-2 block text-right">— Demo Yard 3</cite>
+          </blockquote>
+        </div>
+        <div class="flex justify-center gap-4 mt-4">
+          <button id="prevTestimonial" aria-label="Previous testimonial" class="text-brand-orange">&#8592;</button>
+          <button id="nextTestimonial" aria-label="Next testimonial" class="text-brand-orange">&#8594;</button>
+        </div>
+      </div>
+    </section>
+
     <section class="py-12">
       <div class="mx-auto max-w-3xl px-6">
         <div class="border border-brand-steel/20 rounded-xl p-6 bg-white">
@@ -238,15 +315,13 @@
             <p class="text-sm mt-2">
               A Standard Launch pays for itself in <strong id="roiDays">‑‑</strong> days.
             </p>
-            <a id="contactBtn" href="/contact" class="btn-primary mt-6 inline-block">
-              Patch My Leak
-            </a>
+            <a id="contactBtn" href="/contact" class="btn-primary mt-6 inline-block">Book 15‑min Leak Audit</a>
           </div>
         </div>
       </div>
     </section>
     <div class="bg-brand-orange text-white text-center py-4 shadow-md">
-      <a href="/contact" class="font-semibold hover:opacity-90">Book 15‑min Reputation Risk Scan</a>
+      <a href="/contact" class="font-semibold hover:opacity-90">Book 15‑min Leak Audit</a>
     </div>
   </main>
 <footer class="bg-white py-8 text-center text-xs text-gray-400">
@@ -270,7 +345,7 @@
     function fmt(x){
       return x.toLocaleString('en-US',{style:'currency',currency:'USD',minimumFractionDigits:0});
     }
-    document.getElementById('calcForm').addEventListener('submit',e=>{
+  document.getElementById('calcForm').addEventListener('submit',e=>{
       e.preventDefault();
       const t=+e.target.tons.value, m=+e.target.margin.value, l=+e.target.missed.value;
       if(!t||!m||!l) return alert('Fill every field');
@@ -278,8 +353,14 @@
       document.getElementById('lossFig').textContent=fmt(annual);
       document.getElementById('roiDays').textContent=Math.ceil(2499/(annual/365));
       document.getElementById('contactBtn').href=`/contact?leak=${annual}`;
-      document.getElementById('resultBox').classList.remove('hidden');
-    });
+  document.getElementById('resultBox').classList.remove('hidden');
+  });
+
+  const testimonials=document.getElementById('testimonialCarousel');
+  let ti=0;const slides=testimonials?.children;
+  function showTestimonial(i){if(!testimonials)return;testimonials.scrollTo({left:testimonials.clientWidth*i,behavior:'smooth'});} 
+  document.getElementById('nextTestimonial')?.addEventListener('click',()=>{ti=(ti+1)%slides.length;showTestimonial(ti);});
+  document.getElementById('prevTestimonial')?.addEventListener('click',()=>{ti=(ti-1+slides.length)%slides.length;showTestimonial(ti);});
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- refresh hero section with subheadline and background image
- convert process steps to timeline with icons and benefits
- surface "No‑Excuses" guarantee box and clear CTAs
- add design screenshots, testimonial carousel and expanded FAQ
- switch all calls to action to "Book 15‑min Leak Audit"

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68758568aa548329bc44cee8f48e0e36