### PR TITLE
Fix contrast on services page

### DIFF
--- a/services/index.html
+++ b/services/index.html
@@ -15,7 +15,7 @@
           },
           colors: {
             brand: {
-              orange: '#FF6B00',
+              orange: '#D75E02',
               steel: '#5E6367',
               charcoal: '#2B2B2B'
             }
@@ -28,7 +28,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;900&display=swap" rel="stylesheet"/>
   <link rel="stylesheet" href="/assets/styles.css"/>
   <style>
-    :root{--color-links:#FF6B00;}
+    :root{--color-links:#D75E02;}
     header nav ul a,#mobileMenu a:not(.bg-yellow-500):not(.btn-primary){position:relative;text-decoration:none;}
     header nav ul a:hover,#mobileMenu a:not(.bg-yellow-500):not(.btn-primary):hover{color:currentColor!important;}
     header nav ul a.text-brand-orange:hover{color:var(--color-links)!important;}
@@ -91,7 +91,7 @@
     <!-- Shield Grid -->
     <section class="py-16 bg-gray-50 relative">
       <div class="relative max-w-5xl mx-auto grid md:grid-cols-2 gap-8 px-6">
-        <article class="p-6 rounded-lg bg-brand-charcoal text-gray-200 shadow slide-up">
+        <article class="p-6 rounded-lg bg-brand-charcoal text-white shadow slide-up">
           <div class="flex items-center gap-2 mb-2"><i data-lucide="shield-check" class="w-6 h-6 text-brand-orange"></i><h3 class="font-semibold">Credibility Shield</h3></div>
           <p class="text-sm">Brokers know you’re legit—before they dial.</p>
           <details class="mt-2">
@@ -103,7 +103,7 @@
             </ul>
           </details>
         </article>
-        <article class="p-6 rounded-lg bg-brand-charcoal text-gray-200 shadow slide-up" data-aos-delay="100">
+        <article class="p-6 rounded-lg bg-brand-charcoal text-white shadow slide-up" data-aos-delay="100">
           <div class="flex items-center gap-2 mb-2"><i data-lucide="shield-x" class="w-6 h-6 text-brand-orange"></i><h3 class="font-semibold">Objection Killer</h3></div>
           <p class="text-sm">Phone stops ringing with tire‑kickers.</p>
           <details class="mt-2">
@@ -115,7 +115,7 @@
             </ul>
           </details>
         </article>
-        <article class="p-6 rounded-lg bg-brand-charcoal text-gray-200 shadow slide-up" data-aos-delay="200">
+        <article class="p-6 rounded-lg bg-brand-charcoal text-white shadow slide-up" data-aos-delay="200">
           <div class="flex items-center gap-2 mb-2"><i data-lucide="eye" class="w-6 h-6 text-brand-orange"></i><h3 class="font-semibold">Visibility Lock</h3></div>
           <p class="text-sm">LocalBusiness schema + “scrap-metal + city” H1s float you above nationals.</p>
           <details class="mt-2">
@@ -127,7 +127,7 @@
             </ul>
           </details>
         </article>
-        <article class="p-6 rounded-lg bg-brand-charcoal text-gray-200 shadow slide-up" data-aos-delay="300">
+        <article class="p-6 rounded-lg bg-brand-charcoal text-white shadow slide-up" data-aos-delay="300">
           <div class="flex items-center gap-2 mb-2"><i data-lucide="life-buoy" class="w-6 h-6 text-brand-orange"></i><h3 class="font-semibold">Break-Fix Warranty</h3></div>
           <p class="text-sm">24/7 monitor pings us, not you. Unlimited edits mean yesterday’s price board never haunts tomorrow’s sellers.</p>
           <details class="mt-2">


### PR DESCRIPTION
## Summary
- restore brand orange to `#D75E02`
- lighten text color on service cards for readability

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687593e503c883299b01c3f5be946754