### PR TITLE
Move deposit CTA below pricing

### DIFF
--- a/index.html
+++ b/index.html
@@ -359,14 +359,7 @@
           <li>• Google Business Profile tune-up + basic SEO</li>
           <li>• 30 days of free tweaks</li>
         </ul>
-        <div class="pt-6 text-center">
-          <a
-            href="https://book.stripe.com/eVqeVd8Vi9U45RbdJy73G00"
-            class="btn-primary"
-          >
-            Pay Deposit
-          </a>
-        </div>
+        
       </div>
       <!-- Premium Launch -->
       <div class="carousel-item z-30 bg-gray-50 border border-brand-steel/10 rounded-xl shadow-sm transition transform hover:-translate-y-1 px-6 py-10 md:p-10">
@@ -379,14 +372,7 @@
           <li>• Structured-data SEO + GBP cleanup</li>
           <li>• 60 days of fine-tuning after go-live</li>
         </ul>
-        <div class="pt-6 text-center">
-          <a
-            href="https://book.stripe.com/4gM28r2wU7LW3J36h673G01"
-            class="btn-primary"
-          >
-            Pay Deposit
-          </a>
-        </div>
+        
       </div>
       <!-- Care Plan -->
       <div class="carousel-item z-30 bg-gray-50 border border-brand-steel/10 rounded-xl shadow-sm transition transform hover:-translate-y-1 px-6 py-10 md:p-10">
@@ -400,7 +386,9 @@
         </ul>
       </div>
     </div>
-
+    <div class="mt-10 text-center">
+      <a href="https://book.stripe.com/eVqeVd8Vi9U45RbdJy73G00" class="btn-primary">Pay Deposit</a>
+    </div>
   </div>
 </section>
 

--- a/pricing/index.html
+++ b/pricing/index.html
@@ -117,16 +117,9 @@
               <li>• Google Business Profile tune-up + basic SEO</li>
               <li>• 30 days of free tweaks</li>
             </ul>
-            <div class="mt-auto pt-6 text-center">
-              <a
-                href="https://book.stripe.com/eVqeVd8Vi9U45RbdJy73G00"
-                class="btn-primary"
-              >
-                Pay Deposit
-              </a>
+              
             </div>
-          </div>
-          <!-- Premium Launch -->
+            <!-- Premium Launch -->
           <div class="carousel-item z-30 bg-gray-50 border border-brand-steel/10 rounded-xl shadow-sm transition transform hover:-translate-y-1 px-6 py-10 md:p-10 flex flex-col">
             <h3 class="text-xl font-semibold mb-4">Premium Launch</h3>
             <p class="text-5xl font-extrabold tracking-tight">$5,499</p>
@@ -137,16 +130,9 @@
             <li>• Structured-data SEO + GBP cleanup</li>
             <li>• 60 days of fine-tuning after go-live</li>
           </ul>
-          <div class="mt-auto pt-6 text-center">
-            <a
-              href="https://book.stripe.com/4gM28r2wU7LW3J36h673G01"
-              class="btn-primary"
-            >
-              Pay Deposit
-            </a>
+            
           </div>
-        </div>
-          <!-- Care Plan -->
+            <!-- Care Plan -->
           <div class="carousel-item z-30 bg-gray-50 border border-brand-steel/10 rounded-xl shadow-sm transition transform hover:-translate-y-1 px-6 py-10 md:p-10">
             <h3 class="text-xl font-semibold mb-4">Care Plan</h3>
             <p class="text-5xl font-extrabold tracking-tight">$99<span class="text-2xl font-bold">/mo</span></p>


### PR DESCRIPTION
## Summary
- drop deposit buttons from pricing cards
- add single deposit button at bottom of home page pricing section
- keep deposit button at bottom of pricing page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68759950da4c8329a999fb9b573c1e52