### PR TITLE
Center hero subhead on services

### DIFF
--- a/services/index.html
+++ b/services/index.html
@@ -89,7 +89,7 @@
   </script>
   <main class="pt-0 pb-20 bg-gray-50">
     <!-- Hero -->
-    <section class="relative flex items-center justify-center min-h-[60vh] text-center">
+    <section class="relative flex flex-col items-center justify-center min-h-[60vh] text-center">
       <img src="/assets/hero.jpg" alt="Grapple loading shred" class="absolute inset-0 w-full h-full object-cover">
       <div class="absolute inset-0 bg-black/80"></div>
       <h1 class="relative z-10 text-4xl md:text-5xl font-extrabold text-white px-6">Four Shields. One Plug-The-Leak Service.</h1>


### PR DESCRIPTION
## Summary
- fix hero layout so subhead stacks below the header on the Services page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6875a6980050832983f4e9b01e13a8ab