### PR TITLE
Add About page to navigation

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -49,6 +49,7 @@
         <li><a href="/portfolio">Portfolio</a></li>
         <li><a href="/pricing">Pricing</a></li>
         <li><a href="/risk-calculator">Calculator</a></li>
+        <li><a href="/about">About</a></li>
         <li><a href="/contact">Contact</a></li>
         <li class="md:hidden"><a href="/contact" class="btn-primary">Book Call</a></li>
       </ul>
@@ -65,6 +66,7 @@
       <a href="/portfolio">Portfolio</a>
       <a href="/pricing">Pricing</a>
       <a href="/risk-calculator">Calculator</a>
+      <a href="/about">About</a>
       <a href="/contact">Contact</a>
       <a href="/contact" class="btn-primary">Book Call</a>
     </div>

--- a/blog/index.html
+++ b/blog/index.html
@@ -40,6 +40,7 @@
         <li><a href="/portfolio">Portfolio</a></li>
         <li><a href="/pricing">Pricing</a></li>
         <li><a href="/risk-calculator">Calculator</a></li>
+        <li><a href="/about">About</a></li>
         <li><a href="/contact">Contact</a></li>
       </ul>
       <a href="/contact" class="btn-primary hidden md:block">Book Call</a>
@@ -55,6 +56,7 @@
       <a href="/portfolio">Portfolio</a>
       <a href="/pricing">Pricing</a>
       <a href="/risk-calculator">Calculator</a>
+      <a href="/about">About</a>
       <a href="/contact">Contact</a>
       <a href="/contact" class="btn-primary">Book Call</a>
     </div>

--- a/contact/index.html
+++ b/contact/index.html
@@ -40,6 +40,7 @@
         <li><a href="/portfolio">Portfolio</a></li>
         <li><a href="/pricing">Pricing</a></li>
         <li><a href="/risk-calculator">Calculator</a></li>
+        <li><a href="/about">About</a></li>
         <li><a href="/contact">Contact</a></li>
       </ul>
       <a href="/contact" class="btn-primary hidden md:block">Book Call</a>
@@ -55,6 +56,7 @@
       <a href="/portfolio">Portfolio</a>
       <a href="/pricing">Pricing</a>
       <a href="/risk-calculator">Calculator</a>
+      <a href="/about">About</a>
       <a href="/contact">Contact</a>
       <a href="/contact" class="btn-primary">Book Call</a>
     </div>

--- a/index.html
+++ b/index.html
@@ -185,6 +185,7 @@
         <li><a href="/portfolio">Portfolio</a></li>
         <li><a href="/pricing">Pricing</a></li>
         <li><a href="/risk-calculator">Calculator</a></li>
+        <li><a href="/about">About</a></li>
         <li><a href="/contact">Contact</a></li>
       </ul>
       <a href="/contact" class="btn-primary hidden md:block">Book Call</a>
@@ -200,6 +201,7 @@
       <a href="/portfolio">Portfolio</a>
       <a href="/pricing">Pricing</a>
       <a href="/risk-calculator">Calculator</a>
+      <a href="/about">About</a>
       <a href="/contact">Contact</a>
       <a href="/contact" class="btn-primary">Book Call</a>
     </div>

--- a/portfolio/index.html
+++ b/portfolio/index.html
@@ -44,6 +44,7 @@
         <li><a href="/portfolio">Portfolio</a></li>
         <li><a href="/pricing">Pricing</a></li>
         <li><a href="/risk-calculator">Calculator</a></li>
+        <li><a href="/about">About</a></li>
         <li><a href="/contact">Contact</a></li>
       </ul>
       <a href="/contact" class="btn-primary hidden md:block">Book Call</a>
@@ -59,6 +60,7 @@
       <a href="/portfolio">Portfolio</a>
       <a href="/pricing">Pricing</a>
       <a href="/risk-calculator">Calculator</a>
+      <a href="/about">About</a>
       <a href="/contact">Contact</a>
       <a href="/contact" class="btn-primary">Book Call</a>
     </div>

--- a/pricing/index.html
+++ b/pricing/index.html
@@ -44,6 +44,7 @@
         <li><a href="/portfolio">Portfolio</a></li>
         <li><a href="/pricing">Pricing</a></li>
         <li><a href="/risk-calculator">Calculator</a></li>
+        <li><a href="/about">About</a></li>
         <li><a href="/contact">Contact</a></li>
       </ul>
       <a href="/contact" class="btn-primary hidden md:block">Book Call</a>
@@ -59,6 +60,7 @@
       <a href="/portfolio">Portfolio</a>
       <a href="/pricing">Pricing</a>
       <a href="/risk-calculator">Calculator</a>
+      <a href="/about">About</a>
       <a href="/contact">Contact</a>
       <a href="/contact" class="btn-primary">Book Call</a>
     </div>

--- a/privacy/index.html
+++ b/privacy/index.html
@@ -105,6 +105,7 @@
         <li><a href="/portfolio">Portfolio</a></li>
         <li><a href="/pricing">Pricing</a></li>
         <li><a href="/risk-calculator">Calculator</a></li>
+        <li><a href="/about">About</a></li>
         <li><a href="/contact">Contact</a></li>
       </ul>
       <a href="/contact" class="btn-primary hidden md:block">Book Call</a>
@@ -120,6 +121,7 @@
       <a href="/portfolio">Portfolio</a>
       <a href="/pricing">Pricing</a>
       <a href="/risk-calculator">Calculator</a>
+      <a href="/about">About</a>
       <a href="/contact">Contact</a>
       <a href="/contact" class="btn-primary">Book Call</a>
     </div>

--- a/process/index.html
+++ b/process/index.html
@@ -69,6 +69,7 @@
         <li><a href="/portfolio">Portfolio</a></li>
         <li><a href="/pricing">Pricing</a></li>
         <li><a href="/risk-calculator">Calculator</a></li>
+        <li><a href="/about">About</a></li>
         <li><a href="/contact">Contact</a></li>
       </ul>
       <a href="/contact" class="btn-primary hidden md:block">Book Call</a>
@@ -84,6 +85,7 @@
       <a href="/portfolio">Portfolio</a>
       <a href="/pricing">Pricing</a>
       <a href="/risk-calculator">Calculator</a>
+      <a href="/about">About</a>
       <a href="/contact">Contact</a>
       <a href="/contact" class="btn-primary">Book Call</a>
     </div>

--- a/risk-calculator/index.html
+++ b/risk-calculator/index.html
@@ -40,6 +40,7 @@
         <li><a href="/portfolio">Portfolio</a></li>
         <li><a href="/pricing">Pricing</a></li>
         <li><a href="/risk-calculator">Calculator</a></li>
+        <li><a href="/about">About</a></li>
         <li><a href="/contact">Contact</a></li>
       </ul>
       <a href="/contact" class="btn-primary hidden md:block">Book Call</a>
@@ -55,6 +56,7 @@
       <a href="/portfolio">Portfolio</a>
       <a href="/pricing">Pricing</a>
       <a href="/risk-calculator">Calculator</a>
+      <a href="/about">About</a>
       <a href="/contact">Contact</a>
       <a href="/contact" class="btn-primary">Book Call</a>
     </div>

--- a/services/index.html
+++ b/services/index.html
@@ -63,6 +63,7 @@
         <li><a href="/portfolio">Portfolio</a></li>
         <li><a href="/pricing">Pricing</a></li>
         <li><a href="/risk-calculator">Calculator</a></li>
+        <li><a href="/about">About</a></li>
         <li><a href="/contact">Contact</a></li>
       </ul>
       <a href="/contact" class="btn-primary hidden md:block">Book Call</a>
@@ -78,6 +79,7 @@
       <a href="/portfolio">Portfolio</a>
       <a href="/pricing">Pricing</a>
       <a href="/risk-calculator">Calculator</a>
+      <a href="/about">About</a>
       <a href="/contact">Contact</a>
       <a href="/contact" class="btn-primary">Book Call</a>
     </div>

--- a/terms-of-service/index.html
+++ b/terms-of-service/index.html
@@ -44,6 +44,7 @@
         <li><a href="/portfolio">Portfolio</a></li>
         <li><a href="/pricing">Pricing</a></li>
         <li><a href="/risk-calculator">Calculator</a></li>
+        <li><a href="/about">About</a></li>
         <li><a href="/contact">Contact</a></li>
       </ul>
       <a href="/contact" class="btn-primary hidden md:block">Book Call</a>
@@ -59,6 +60,7 @@
       <a href="/portfolio">Portfolio</a>
       <a href="/pricing">Pricing</a>
       <a href="/risk-calculator">Calculator</a>
+      <a href="/about">About</a>
       <a href="/contact">Contact</a>
       <a href="/contact" class="btn-primary">Book Call</a>
     </div>


### PR DESCRIPTION
## Summary
- include About link in desktop and mobile navigation menus

## Testing
- `grep -n "About" index.html`


------
https://chatgpt.com/codex/tasks/task_e_687803cb06908329bc4abb00c439508c