### PR TITLE
Fix alignment and icons in features section

### DIFF
--- a/index.html
+++ b/index.html
@@ -284,20 +284,15 @@
     </div>
 
     <!-- Problem & solution columns -->
-    <div class="grid grid-cols-1 md:grid-cols-2 gap-12 mb-16 text-left">
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-12 mb-16 text-center md:text-left">
       <!-- Problem column -->
       <div>
         <h3 class="text-2xl font-bold text-gray-900 mb-4">If You Don’t Look the Part…</h3>
         <div class="space-y-6">
           <!-- Invisible to Sellers -->
-          <div class="flex items-start" data-aos="fade-up">
-            <div class="flex-shrink-0 w-12 h-12 flex items-center justify-center bg-brand-orange text-white rounded-full mr-4">
-              <!-- eye-off icon -->
-              <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13.875 18.825A10.05 10.05 0 0112 19c-5.523 0-10-4.477-10-10 0-1.455.314-2.838.875-4.067" />
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.458 12C3.732 7.943 7.522 5 12 5c.967 0 1.905.155 2.788.443" />
-              </svg>
+          <div class="flex flex-col items-center text-center md:flex-row md:items-start md:text-left" data-aos="fade-up">
+            <div class="flex-shrink-0 w-12 h-12 flex items-center justify-center bg-brand-orange text-white rounded-full mb-4 md:mb-0 md:mr-4">
+              <i class="fa-solid fa-eye-slash fa-lg"></i>
             </div>
             <div>
               <h4 class="font-semibold text-gray-900 mb-1">Invisible to Sellers</h4>
@@ -305,38 +300,19 @@
             </div>
           </div>
           <!-- Outdated Signals -->
-          <div class="flex items-start" data-aos="fade-up">
-            <div class="flex-shrink-0 w-12 h-12 flex items-center justify-center bg-brand-orange text-white rounded-full mr-4">
-              <!-- clock icon -->
-              <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
-              </svg>
+          <div class="flex flex-col items-center text-center md:flex-row md:items-start md:text-left" data-aos="fade-up">
+            <div class="flex-shrink-0 w-12 h-12 flex items-center justify-center bg-brand-orange text-white rounded-full mb-4 md:mb-0 md:mr-4">
+              <i class="fa-solid fa-clock-rotate-left fa-lg"></i>
             </div>
             <div>
               <h4 class="font-semibold text-gray-900 mb-1">Outdated Signals</h4>
               <p class="text-gray-700">An old site makes you look unlicensed or unreliable.</p>
             </div>
           </div>
-          <!-- No Proof of Compliance -->
-          <div class="flex items-start" data-aos="fade-up">
-            <div class="flex-shrink-0 w-12 h-12 flex items-center justify-center bg-brand-orange text-white rounded-full mr-4">
-              <!-- document icon -->
-              <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m3-4v.01m-.01 0h.01m-6.343 2.808a5.5 5.5 0 01-7.778 0A5.5 5.5 0 0112 4.772a5.5 5.5 0 013.778 1.536z" />
-              </svg>
-            </div>
-            <div>
-              <h4 class="font-semibold text-gray-900 mb-1">No Proof of Compliance</h4>
-              <p class="text-gray-700">Regulators and suppliers can’t verify your permits.</p>
-            </div>
-          </div>
           <!-- Missed Leads -->
-          <div class="flex items-start" data-aos="fade-up">
-            <div class="flex-shrink-0 w-12 h-12 flex items-center justify-center bg-brand-orange text-white rounded-full mr-4">
-              <!-- phone-off icon -->
-              <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 3l18 18M8.373 8.374A3 3 0 0112 7a3 3 0 012.12 5.12L12 15.243l-2.372-2.372a3 3 0 01.745-4.497z" />
-              </svg>
+          <div class="flex flex-col items-center text-center md:flex-row md:items-start md:text-left" data-aos="fade-up">
+            <div class="flex-shrink-0 w-12 h-12 flex items-center justify-center bg-brand-orange text-white rounded-full mb-4 md:mb-0 md:mr-4">
+              <i class="fa-solid fa-phone-slash fa-lg"></i>
             </div>
             <div>
               <h4 class="font-semibold text-gray-900 mb-1">Missed Leads</h4>
@@ -351,12 +327,9 @@
         <h3 class="text-2xl font-bold text-gray-900 mb-4">We Fix That</h3>
         <div class="space-y-6">
           <!-- Secure & Compliant -->
-          <div class="flex items-start" data-aos="fade-up">
-            <div class="flex-shrink-0 w-12 h-12 flex items-center justify-center bg-brand-orange text-white rounded-full mr-4">
-              <!-- lock icon -->
-              <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 15v2a2 2 0 104 0v-2m-4 0V7a4 4 0 10-4 4h4z" />
-              </svg>
+          <div class="flex flex-col items-center text-center md:flex-row md:items-start md:text-left" data-aos="fade-up">
+            <div class="flex-shrink-0 w-12 h-12 flex items-center justify-center bg-brand-orange text-white rounded-full mb-4 md:mb-0 md:mr-4">
+              <i class="fa-solid fa-shield-halved fa-lg"></i>
             </div>
             <div>
               <h4 class="font-semibold text-gray-900 mb-1">Secure &amp; Compliant</h4>
@@ -364,12 +337,9 @@
             </div>
           </div>
           <!-- Showcase Your Edge -->
-          <div class="flex items-start" data-aos="fade-up">
-            <div class="flex-shrink-0 w-12 h-12 flex items-center justify-center bg-brand-orange text-white rounded-full mr-4">
-              <!-- badge icon -->
-              <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m3-4v.01m-.01 0h.01m-6.343 2.808a5.5 5.5 0 01-7.778 0A5.5 5.5 0 0112 4.772a5.5 5.5 0 013.778 1.536z" />
-              </svg>
+          <div class="flex flex-col items-center text-center md:flex-row md:items-start md:text-left" data-aos="fade-up">
+            <div class="flex-shrink-0 w-12 h-12 flex items-center justify-center bg-brand-orange text-white rounded-full mb-4 md:mb-0 md:mr-4">
+              <i class="fa-solid fa-trophy fa-lg"></i>
             </div>
             <div>
               <h4 class="font-semibold text-gray-900 mb-1">Showcase Your Edge</h4>
@@ -377,12 +347,9 @@
             </div>
           </div>
           <!-- Built for Conversion -->
-          <div class="flex items-start" data-aos="fade-up">
-            <div class="flex-shrink-0 w-12 h-12 flex items-center justify-center bg-brand-orange text-white rounded-full mr-4">
-              <!-- chat icon -->
-              <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 10h.01M12 10h.01M16 10h.01M21 12a9 9 0 11-9-9 9 9 0 019 9z" />
-              </svg>
+          <div class="flex flex-col items-center text-center md:flex-row md:items-start md:text-left" data-aos="fade-up">
+            <div class="flex-shrink-0 w-12 h-12 flex items-center justify-center bg-brand-orange text-white rounded-full mb-4 md:mb-0 md:mr-4">
+              <i class="fa-solid fa-chart-line fa-lg"></i>
             </div>
             <div>
               <h4 class="font-semibold text-gray-900 mb-1">Built for Conversion</h4>


### PR DESCRIPTION
## Summary
- center "Your Digital Yard Is Your Edge" features on mobile
- remove the compliance bullet
- swap in Font Awesome icons for each item

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687f941f53848329aa8cfe6844256f6a