### PR TITLE
Fix mobile overlap

### DIFF
--- a/index.html
+++ b/index.html
@@ -286,7 +286,7 @@
     <!-- Problem & solution columns -->
     <div class="grid grid-cols-1 md:grid-cols-2 gap-0 md:gap-12 mb-16 text-center md:text-left">
       <!-- Problem column -->
-      <div class="bg-white p-6 md:p-0 md:bg-transparent -mx-6 md:mx-0">
+      <div class="bg-white p-6 md:p-0 md:bg-transparent sm:-mx-6 md:mx-0">
         <h3 class="mt-6 md:mt-0 text-2xl font-bold text-gray-900 mb-4">If You Don’t Look the Part…</h3>
         <div class="space-y-6">
           <!-- Invisible to Sellers -->
@@ -323,7 +323,7 @@
       </div>
 
       <!-- Solution column -->
-      <div class="bg-gray-100 p-6 md:p-0 md:bg-transparent -mx-6 md:mx-0">
+      <div class="bg-gray-100 p-6 md:p-0 md:bg-transparent sm:-mx-6 md:mx-0">
         <h3 class="mt-6 md:mt-0 text-2xl font-bold text-gray-900 mb-4">We Fix That</h3>
         <div class="space-y-6">
           <!-- Secure & Compliant -->


### PR DESCRIPTION
## Summary
- fix overlapping mobile layout in reputation section by limiting negative margins to `sm` breakpoint

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_687f9abe169483299f5b757713aff527