### PR TITLE
Unify CTA banners across pages

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -163,12 +163,9 @@
     </ul>
   </div>
 </section>
-<section class="mt-16 bg-brand-charcoal text-white py-12 text-center">
-  <h2 class="text-2xl font-bold" style="color:#D75E02">Ready to Plug the Revenue Leak?</h2>
-  <div class="mt-6 flex flex-col sm:flex-row gap-4 justify-center">
-    <a href="/risk-calculator" class="btn-primary">Calculator</a>
-    <a href="/contact" class="btn-primary">Book Call</a>
-  </div>
+<section class="mt-16 py-12 bg-brand-orange text-white text-center">
+  <h2 class="text-2xl font-bold mb-4">Ready to upgrade your yard's site?</h2>
+  <a href="/contact" class="btn-secondary">Book a Discovery Call</a>
 </section>
 </main>
 <footer class="bg-white py-8 text-center text-xs text-gray-400">

--- a/blog/index.html
+++ b/blog/index.html
@@ -93,6 +93,10 @@
     <div class="mx-auto max-w-2xl prose">
       <p>Articles and resources on building trust, improving SEO and growing your scrap yard. We’re currently crafting our first posts—check back soon.</p>
     </div>
+    <section class="mt-16 py-12 bg-brand-orange text-white text-center">
+      <h2 class="text-2xl font-bold mb-4">Ready to upgrade your yard's site?</h2>
+      <a href="/contact" class="btn-secondary">Book a Discovery Call</a>
+    </section>
   </main>
 <footer class="bg-white py-8 text-center text-xs text-gray-400">
   <nav class="mb-2 space-x-2">

--- a/contact/index.html
+++ b/contact/index.html
@@ -113,6 +113,10 @@
         <details class="group"><summary class="cursor-pointer font-semibold text-brand-charcoal group-open:text-brand-orange">Can we just get the price?</summary><p class="mt-1 text-brand-steel text-base md:text-sm md:pl-4 md:border-l md:border-brand-orange/40">Of course. No hidden fees, no “call for quote.” You’ll know the cost before we write a line of code.</p></details>
       </div>
     </section>
+    <section class="mt-16 py-12 bg-brand-orange text-white text-center">
+      <h2 class="text-2xl font-bold mb-4">Ready to upgrade your yard's site?</h2>
+      <a href="/contact" class="btn-secondary">Book a Discovery Call</a>
+    </section>
   </main>
 <footer class="bg-white py-8 text-center text-xs text-gray-400">
   <nav class="mb-2 space-x-2">

--- a/index.html
+++ b/index.html
@@ -591,6 +591,10 @@
       </div>
     </div>
   </section>
+  <section class="mt-16 py-12 bg-brand-orange text-white text-center">
+    <h2 class="text-2xl font-bold mb-4">Ready to upgrade your yard's site?</h2>
+    <a href="/contact" class="btn-secondary">Book a Discovery Call</a>
+  </section>
 
 <!-- ── Footer ──────────────────────────────────────────────── -->
 <footer class="bg-white py-8 text-center text-xs text-gray-400">

--- a/portfolio/demo-yard-1/index.html
+++ b/portfolio/demo-yard-1/index.html
@@ -58,6 +58,10 @@
     <h2 class="text-xl font-semibold mt-4">Results</h2>
     <p class="text-brand-charcoal mb-4">This layout would instill confidence in suppliers and brokers by proving you’re legitimate and easy to work with.</p>
     <a href="../" class="text-brand-orange underline">Back to portfolio</a>
+    <section class="mt-16 py-12 bg-brand-orange text-white text-center">
+      <h2 class="text-2xl font-bold mb-4">Ready to upgrade your yard's site?</h2>
+      <a href="/contact" class="btn-secondary">Book a Discovery Call</a>
+    </section>
   </main>
 <footer class="bg-white py-8 text-center text-xs text-gray-400">
   <nav class="mb-2 space-x-2">

--- a/portfolio/demo-yard-2/index.html
+++ b/portfolio/demo-yard-2/index.html
@@ -58,6 +58,10 @@
     <h2 class="text-xl font-semibold mt-4">Results</h2>
     <p class="text-brand-charcoal mb-4">Fast quotes and trustworthy visuals encourage suppliers to reach out from their phones.</p>
     <a href="../" class="text-brand-orange underline">Back to portfolio</a>
+    <section class="mt-16 py-12 bg-brand-orange text-white text-center">
+      <h2 class="text-2xl font-bold mb-4">Ready to upgrade your yard's site?</h2>
+      <a href="/contact" class="btn-secondary">Book a Discovery Call</a>
+    </section>
   </main>
 <footer class="bg-white py-8 text-center text-xs text-gray-400">
   <nav class="mb-2 space-x-2">

--- a/portfolio/demo-yard-3/index.html
+++ b/portfolio/demo-yard-3/index.html
@@ -58,6 +58,10 @@
     <h2 class="text-xl font-semibold mt-4">Results</h2>
     <p class="text-brand-charcoal mb-4">Industrial suppliers and brokers see a reliable partner capable of handling big loads.</p>
     <a href="../" class="text-brand-orange underline">Back to portfolio</a>
+    <section class="mt-16 py-12 bg-brand-orange text-white text-center">
+      <h2 class="text-2xl font-bold mb-4">Ready to upgrade your yard's site?</h2>
+      <a href="/contact" class="btn-secondary">Book a Discovery Call</a>
+    </section>
   </main>
 <footer class="bg-white py-8 text-center text-xs text-gray-400">
   <nav class="mb-2 space-x-2">

--- a/pricing/index.html
+++ b/pricing/index.html
@@ -218,6 +218,10 @@
         <details class="group"><summary class="cursor-pointer font-semibold text-brand-charcoal group-open:text-brand-orange">Do you shoot photos or video?</summary><p class="mt-1 text-brand-steel text-base md:text-sm md:pl-4 md:border-l md:border-brand-orange/40">We can—onsite photo/video packages start at $750 in the lower 48. Most yards start with their own shots and upgrade later.</p></details>
       </div>
     </section>
+    <section class="mt-16 py-12 bg-brand-orange text-white text-center">
+      <h2 class="text-2xl font-bold mb-4">Ready to upgrade your yard's site?</h2>
+      <a href="/contact" class="btn-secondary">Book a Discovery Call</a>
+    </section>
   </main>
 <footer class="bg-white py-8 text-center text-xs text-gray-400">
   <nav class="mb-2 space-x-2">

--- a/privacy/index.html
+++ b/privacy/index.html
@@ -287,6 +287,10 @@
     <p class="mb-4">We despise spam as much as you do. We will only send you commercial emails if you expressly opt in, and we honor every unsubscribe request immediately.</p>
 
     <p class="mb-8">Thank you for trusting Scrapyard&nbsp;Sites. We value your privacy and strive to be transparent about our practices while providing you with exceptional service and spam&#8209;free communications.</p>
+  <section class="mt-16 py-12 bg-brand-orange text-white text-center">
+    <h2 class="text-2xl font-bold mb-4">Ready to upgrade your yard's site?</h2>
+    <a href="/contact" class="btn-secondary">Book a Discovery Call</a>
+  </section>
   </main>
 
 <footer class="bg-white py-8 text-center text-xs text-gray-400">

--- a/process/index.html
+++ b/process/index.html
@@ -297,10 +297,10 @@
         </div>
       </div>
     </section>
-    <div class="py-6 bg-gray-100 flex justify-center gap-4">
-      <a href="/risk-calculator" class="btn-primary">Patch My Leak</a>
-      <a href="/contact" class="btn-secondary">Book Call</a>
-    </div>
+    <section class="mt-16 py-12 bg-brand-orange text-white text-center">
+      <h2 class="text-2xl font-bold mb-4">Ready to upgrade your yard's site?</h2>
+      <a href="/contact" class="btn-secondary">Book a Discovery Call</a>
+    </section>
   </main>
 <footer class="bg-white py-8 text-center text-xs text-gray-400">
   <nav class="mb-2 space-x-2">

--- a/risk-calculator/index.html
+++ b/risk-calculator/index.html
@@ -123,6 +123,10 @@
       </div>
       </div>
     </section>
+    <section class="mt-16 py-12 bg-brand-orange text-white text-center">
+      <h2 class="text-2xl font-bold mb-4">Ready to upgrade your yard's site?</h2>
+      <a href="/contact" class="btn-secondary">Book a Discovery Call</a>
+    </section>
   </main>
 <footer class="bg-white py-8 text-center text-xs text-gray-400">
   <nav class="mb-2 space-x-2">

--- a/services/index.html
+++ b/services/index.html
@@ -203,10 +203,10 @@
         </div>
       </div>
     </section>
-    <div class="pt-6 pb-0 bg-gray-100 flex justify-center gap-4">
-      <a href="/risk-calculator" class="btn-primary">Patch My Leak</a>
-      <a href="/contact" class="btn-secondary">Book Call</a>
-    </div>
+    <section class="mt-16 py-12 bg-brand-orange text-white text-center">
+      <h2 class="text-2xl font-bold mb-4">Ready to upgrade your yard's site?</h2>
+      <a href="/contact" class="btn-secondary">Book a Discovery Call</a>
+    </section>
   </main>
   <footer class="bg-white py-8 text-center text-xs text-gray-400">
       <nav class="mb-2 space-x-2">

--- a/terms-of-service/index.html
+++ b/terms-of-service/index.html
@@ -96,6 +96,10 @@
   <main class="max-w-3xl mx-auto pt-24 pb-20 px-6 prose prose-a:text-brand-orange">
     <h1 class="text-3xl font-bold mb-4">Terms of Service</h1>
     <p class="mb-4">The terms of service will be posted here soon.</p>
+  <section class="mt-16 py-12 bg-brand-orange text-white text-center">
+    <h2 class="text-2xl font-bold mb-4">Ready to upgrade your yard's site?</h2>
+    <a href="/contact" class="btn-secondary">Book a Discovery Call</a>
+  </section>
   </main>
 
 <footer class="bg-white py-8 text-center text-xs text-gray-400">


### PR DESCRIPTION
## Summary
- replace old CTAs with "Ready to upgrade" banner
- add banner CTA on pages that were missing one

## Testing
- `grep -r "Ready to upgrade your yard's site" -n | wc -l`

------
https://chatgpt.com/codex/tasks/task_e_687f9b681ba08329a1fab029bab47fd5