### PR TITLE
Update process layout and FAQ

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -172,6 +172,14 @@ header nav ul a.text-brand-orange {
   box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
 }
 
+/* Hide default disclosure triangles on FAQ items */
+details summary::-webkit-details-marker {
+  display: none;
+}
+details summary::marker {
+  content: '';
+}
+
 /* Testimonial carousel buttons */
 #testimonialWrapper button {
   background: transparent;

--- a/process/index.html
+++ b/process/index.html
@@ -131,8 +131,8 @@
     <section id="process" class="py-16">
       <div class="max-w-5xl mx-auto px-6">
         <h2 class="text-2xl font-bold text-center mb-10">Our Process</h2>
-        <div class="grid gap-8 md:grid-cols-2 lg:grid-cols-4">
-          <div class="p-6 bg-white border border-brand-steel/10 rounded-xl flex flex-col items-start text-center md:text-left">
+        <div class="grid gap-8 md:grid-cols-2">
+          <div class="p-6 bg-white border border-brand-steel/10 rounded-xl flex flex-col items-start text-center md:text-left card-hover">
             <div class="flex items-center justify-center w-12 h-12 rounded-full bg-brand-orange mb-4">
               <i data-lucide="search" class="w-6 h-6 text-white"></i>
             </div>
@@ -144,7 +144,7 @@
               <li>Site map outline</li>
             </ul>
           </div>
-          <div class="p-6 bg-white border border-brand-steel/10 rounded-xl flex flex-col items-start text-center md:text-left">
+          <div class="p-6 bg-white border border-brand-steel/10 rounded-xl flex flex-col items-start text-center md:text-left card-hover">
             <div class="flex items-center justify-center w-12 h-12 rounded-full bg-brand-orange mb-4">
               <i data-lucide="pen-tool" class="w-6 h-6 text-white"></i>
             </div>
@@ -156,7 +156,7 @@
               <li>Staging link for review</li>
             </ul>
           </div>
-          <div class="p-6 bg-white border border-brand-steel/10 rounded-xl flex flex-col items-start text-center md:text-left">
+          <div class="p-6 bg-white border border-brand-steel/10 rounded-xl flex flex-col items-start text-center md:text-left card-hover">
             <div class="flex items-center justify-center w-12 h-12 rounded-full bg-brand-orange mb-4">
               <i data-lucide="badge-check" class="w-6 h-6 text-white"></i>
             </div>
@@ -168,7 +168,7 @@
               <li>30-day support</li>
             </ul>
           </div>
-          <div class="p-6 bg-white border border-brand-steel/10 rounded-xl flex flex-col items-start text-center md:text-left">
+          <div class="p-6 bg-white border border-brand-steel/10 rounded-xl flex flex-col items-start text-center md:text-left card-hover">
             <div class="flex items-center justify-center w-12 h-12 rounded-full bg-brand-orange mb-4">
               <i data-lucide="shield" class="w-6 h-6 text-white"></i>
             </div>
@@ -188,21 +188,24 @@
       <div class="mx-auto max-w-5xl px-6">
         <h2 class="text-2xl font-bold text-center mb-10">Straight‑Shooter Pricing</h2>
         <div class="grid gap-8 md:grid-cols-3">
-          <div class="border border-brand-steel/10 rounded-xl bg-white p-6 text-center">
+          <div class="border border-brand-steel/10 rounded-xl bg-white p-6 text-center card-hover">
             <h3 class="font-semibold text-xl mb-2">Standard Launch</h3>
             <p class="text-4xl font-extrabold">$2,499</p>
             <p class="text-sm mt-2">Includes everything in the first three phases above, perfect if you need a credible site quickly.</p>
           </div>
-          <div class="border border-brand-steel/10 rounded-xl bg-white p-6 text-center">
+          <div class="border border-brand-steel/10 rounded-xl bg-white p-6 text-center card-hover">
             <h3 class="font-semibold text-xl mb-2">Premium Launch</h3>
             <p class="text-4xl font-extrabold">$5,499</p>
             <p class="text-sm mt-2">Everything in Standard plus additional pages and local SEO enhancements.</p>
           </div>
-          <div class="border border-brand-steel/10 rounded-xl bg-white p-6 text-center">
-            <h3 class="font-semibold text-xl mb-2">Care Plan</h3>
-            <p class="text-4xl font-extrabold">$99<span class="text-base font-normal">/month</span></p>
-            <p class="text-sm mt-2">Unlimited text and photo updates, security patches, backups and quarterly reports.</p>
+          <div class="border border-brand-steel/10 rounded-xl bg-white p-6 text-center card-hover">
+          <h3 class="font-semibold text-xl mb-2">Care Plan</h3>
+          <p class="text-4xl font-extrabold">$99<span class="text-base font-normal">/month</span></p>
+          <p class="text-sm mt-2">Unlimited text and photo updates, security patches, backups and quarterly reports.</p>
           </div>
+        </div>
+        <div class="mt-8 text-center">
+          <a href="/contact" class="btn-primary">Start My Build</a>
         </div>
       </div>
     </section>
@@ -211,15 +214,15 @@
         <h2 class="text-2xl font-bold text-center mb-6">Mini FAQ</h2>
         <div class="space-y-4 text-center md:text-left">
           <details class="group">
-            <summary class="flex items-center gap-2 cursor-pointer font-semibold text-brand-charcoal group-open:text-brand-orange">What if my photos aren’t great?</summary>
+            <summary class="flex items-center gap-2 cursor-pointer font-semibold text-brand-charcoal group-open:text-brand-orange">What if my photos aren’t great?<span class="ml-auto transition-transform group-open:rotate-180">▾</span></summary>
             <p class="mt-1 text-brand-steel text-base md:text-sm md:pl-4 md:border-l md:border-brand-orange/40">Send what you have—we’ll polish them or use stock placeholders.</p>
           </details>
           <details class="group">
-            <summary class="flex items-center gap-2 cursor-pointer font-semibold text-brand-charcoal group-open:text-brand-orange">Do I need to be tech‑savvy?</summary>
+            <summary class="flex items-center gap-2 cursor-pointer font-semibold text-brand-charcoal group-open:text-brand-orange">Do I need to be tech‑savvy?<span class="ml-auto transition-transform group-open:rotate-180">▾</span></summary>
             <p class="mt-1 text-brand-steel text-base md:text-sm md:pl-4 md:border-l md:border-brand-orange/40">No. We handle everything and guide you through any approvals.</p>
           </details>
           <details class="group">
-            <summary class="flex items-center gap-2 cursor-pointer font-semibold text-brand-charcoal group-open:text-brand-orange">Is ongoing support available?</summary>
+            <summary class="flex items-center gap-2 cursor-pointer font-semibold text-brand-charcoal group-open:text-brand-orange">Is ongoing support available?<span class="ml-auto transition-transform group-open:rotate-180">▾</span></summary>
             <p class="mt-1 text-brand-steel text-base md:text-sm md:pl-4 md:border-l md:border-brand-orange/40">Yes. Thirty days of tweaks are free, and our Care Plan keeps your site up‑to‑date.</p>
           </details>
         </div>


### PR DESCRIPTION
## Summary
- keep process cards in two columns on desktop
- add hover animation to all cards
- add CTA button to pricing section
- add triangles to the FAQ items
- hide default markers for FAQ details

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687fa061c2ac8329ad8a64de22d073e8