### PR TITLE
Apply portfolio carousel styles to Services

### DIFF
--- a/services/index.html
+++ b/services/index.html
@@ -37,8 +37,43 @@
     .site-title{position:relative;display:inline-block;}
     .site-title::after{content:'';position:absolute;left:0;bottom:-2px;width:0;height:2px;background-color:var(--color-links);transition:width .3s ease;}
     a:hover .site-title::after{width:100%;}
+
     .slide-up{transform:translateY(30px);opacity:0;transition:opacity .6s ease,transform .6s ease;}
     .slide-up.aos-active{transform:translateY(0);opacity:1;}
+
+    /* Mobile carousel styles */
+    @media (max-width: 767px) {
+      .carousel-track {
+        display: flex;
+        overflow-x: auto;
+        scroll-snap-type: x mandatory;
+        -webkit-overflow-scrolling: touch;
+        scroll-behavior: smooth;
+      }
+      .carousel-item {
+        flex: 0 0 100%;
+        scroll-snap-align: center;
+      }
+    }
+
+    .carousel-indicators {
+      display: flex;
+      justify-content: center;
+      gap: 0.5rem;
+      margin-top: 2.5rem;
+    }
+    .carousel-indicators span {
+      background: #D75E02;
+      border-radius: 9999px;
+      width: 0.5rem;
+      height: 0.5rem;
+      opacity: 0.5;
+      transition: width 0.3s ease, opacity 0.3s ease;
+    }
+    .carousel-indicators span.active {
+      width: 1.5rem;
+      opacity: 1;
+    }
 
   </style>
 </head>


### PR DESCRIPTION
## Summary
- add mobile carousel CSS to `services/index.html`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_687fa3328e888329b440c4e1555b6346