### PR TITLE
Fix mobile spacing for home reputation section

### DIFF
--- a/index.html
+++ b/index.html
@@ -284,9 +284,9 @@
     </div>
 
     <!-- Problem & solution columns -->
-    <div class="grid grid-cols-1 md:grid-cols-2 gap-0 md:gap-12 mb-16 text-center md:text-left">
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-y-12 md:gap-12 mb-16 text-center md:text-left">
       <!-- Problem column -->
-      <div class="bg-white px-6 pt-6 pb-8 md:p-0 md:bg-transparent -mx-6 md:mx-0">
+      <div class="bg-white px-6 pt-6 pb-12 md:p-0 md:bg-transparent -mx-6 md:mx-0">
         <h3 class="mt-6 md:mt-0 text-2xl font-bold text-gray-900 mb-4">If You Don’t Look the Part…</h3>
         <div class="space-y-6">
           <!-- Invisible to Sellers -->
@@ -323,7 +323,7 @@
       </div>
 
       <!-- Solution column -->
-      <div class="bg-gray-100 px-6 pt-6 pb-8 md:p-0 md:bg-transparent -mx-6 md:mx-0">
+      <div class="bg-gray-100 px-6 pt-6 pb-12 md:p-0 md:bg-transparent -mx-6 md:mx-0">
         <h3 class="mt-6 md:mt-0 text-2xl font-bold text-gray-900 mb-4">We Fix That</h3>
         <div class="space-y-6">
           <!-- Secure & Compliant -->
@@ -358,7 +358,7 @@
           </div>
         </div>
       </div>
-      <div class="md:col-span-2 text-center mt-12">
+      <div class="md:col-span-2 text-center mt-12 flex flex-col items-center justify-center py-8">
         <p class="mt-6 text-lg text-gray-700 max-w-3xl mx-auto mb-6">
           When your reputation is reinforced online, trust goes up and so do your loads. Engage visitors, collect quotes, and become the yard drivers choose every time.
         </p>


### PR DESCRIPTION
## Summary
- tweak grid spacing for the reputation section
- add padding and flex utilities so CTA block centers vertically
- give columns extra bottom padding

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687fa5f2bc1c8329b2b5c73fc493e5e3