### PR TITLE
Fix spacing before CTA on services page

### DIFF
--- a/services/index.html
+++ b/services/index.html
@@ -238,7 +238,7 @@
         </div>
       </div>
     </section>
-    <section class="mt-16 py-12 bg-brand-orange text-white text-center">
+    <section class="py-12 bg-brand-orange text-white text-center">
       <h2 class="text-2xl font-bold mb-4">Ready to upgrade your yard's site?</h2>
       <a href="/contact" class="btn-secondary">Book a Discovery Call</a>
     </section>


### PR DESCRIPTION
## Summary
- remove extra top margin before the "Ready to upgrade" call-to-action on `/services`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687fac11b5c48329985fc3000c7bbfc8