### PR TITLE
Fix mobile carousel layout

### DIFF
--- a/process/index.html
+++ b/process/index.html
@@ -165,7 +165,7 @@
     <section id="process" class="py-16">
       <div class="max-w-5xl mx-auto px-6">
         <h2 class="text-2xl font-bold text-center mb-10">Our Process</h2>
-        <div id="process-carousel" class="carousel-track grid gap-8 px-4 md:grid-cols-2">
+        <div id="process-carousel" class="carousel-track md:grid md:grid-cols-2 gap-8 px-4">
           <div class="p-6 bg-gray-50 border border-brand-steel/10 rounded-xl flex flex-col items-start text-left transition-transform hover:-translate-y-1">
             <div class="flex items-center justify-center w-14 h-14 rounded-full bg-brand-orange mb-4">
               <i data-lucide="search" class="w-8 h-8 text-white"></i>
@@ -221,7 +221,7 @@
     <section class="py-12 bg-gray-50">
       <div class="mx-auto max-w-5xl px-6">
         <h2 class="text-2xl font-bold text-center mb-10">Straight‑Shooter Pricing</h2>
-        <div id="pricing-carousel" class="carousel-track grid gap-8 px-4 md:grid-cols-3">
+        <div id="pricing-carousel" class="carousel-track md:grid md:grid-cols-3 gap-8 px-4">
           <div class="border border-brand-steel/10 rounded-xl bg-white p-6 text-center">
             <h3 class="font-semibold text-xl mb-2">Standard Launch</h3>
             <p class="text-4xl font-extrabold">$2,499</p>


### PR DESCRIPTION
## Summary
- fix carousel card layout by only enabling grid above the mobile breakpoint

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687faf3ec00c8329be95b2f88d699a27