### PR TITLE
Restore pricing card hover effect

### DIFF
--- a/process/index.html
+++ b/process/index.html
@@ -222,17 +222,17 @@
       <div class="mx-auto max-w-5xl px-6">
         <h2 class="text-2xl font-bold text-center mb-10">Straight‑Shooter Pricing</h2>
         <div id="pricing-carousel" class="carousel-track md:grid md:grid-cols-3 gap-8 px-4">
-          <div class="border border-brand-steel/10 rounded-xl bg-white p-6 text-center">
+          <div class="border border-brand-steel/10 rounded-xl shadow-sm transition-transform hover:-translate-y-1 bg-white p-6 text-center">
             <h3 class="font-semibold text-xl mb-2">Standard Launch</h3>
             <p class="text-4xl font-extrabold">$2,499</p>
             <p class="text-sm mt-2">Includes everything in the first three phases above, perfect if you need a credible site quickly.</p>
           </div>
-          <div class="border border-brand-steel/10 rounded-xl bg-white p-6 text-center">
+          <div class="border border-brand-steel/10 rounded-xl shadow-sm transition-transform hover:-translate-y-1 bg-white p-6 text-center">
             <h3 class="font-semibold text-xl mb-2">Premium Launch</h3>
             <p class="text-4xl font-extrabold">$5,499</p>
             <p class="text-sm mt-2">Everything in Standard plus additional pages and local SEO enhancements.</p>
           </div>
-          <div class="border border-brand-steel/10 rounded-xl bg-white p-6 text-center">
+          <div class="border border-brand-steel/10 rounded-xl shadow-sm transition-transform hover:-translate-y-1 bg-white p-6 text-center">
           <h3 class="font-semibold text-xl mb-2">Care Plan</h3>
           <p class="text-4xl font-extrabold">$99<span class="text-base font-normal">/month</span></p>
           <p class="text-sm mt-2">Unlimited text and photo updates, security patches, backups and quarterly reports.</p>


### PR DESCRIPTION
## Summary
- add `shadow-sm transition-transform hover:-translate-y-1` classes to pricing cards on Process page

## Testing
- `npm test` *(fails: could not find package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_687fb174d6c48329865776c4455be04b