### PR TITLE
Adjust services page layout

### DIFF
--- a/services/index.html
+++ b/services/index.html
@@ -131,21 +131,16 @@
       </div>
     </section>
     <section id="reputation-first" class="py-12 bg-gray-100">
-      <div class="max-w-5xl mx-auto px-6 grid md:grid-cols-2 gap-8 items-center">
-        <div>
-          <h2 class="text-2xl font-bold mb-4">Our Reputation‑First Approach</h2>
-          <p class="mb-4">Every scrapyard website we build is engineered to strengthen your reputation—from the first click to the final load ticket. Your site becomes your 24/7 sales engine.</p>
-          <ul class="list-disc pl-5 space-y-2">
-            <li class="flex items-start"><i data-lucide="shield" class="w-5 h-5 text-brand-orange mr-2 flex-shrink-0"></i><span><strong>Instant credibility:</strong> Professional design builds trust instantly—visitors judge reliability in milliseconds.</span></li>
-            <li class="flex items-start"><i data-lucide="filter" class="w-5 h-5 text-brand-orange mr-2 flex-shrink-0"></i><span><strong>Pre‑qualifying forms:</strong> Customized intake questions filter out tire‑kickers, saving your team’s time.</span></li>
-            <li class="flex items-start"><i data-lucide="map-pin" class="w-5 h-5 text-brand-orange mr-2 flex-shrink-0"></i><span><strong>Local visibility:</strong> Structured data, Google Business integration, and local SEO help your yard appear first in nearby searches.</span></li>
-            <li class="flex items-start"><i data-lucide="clock" class="w-5 h-5 text-brand-orange mr-2 flex-shrink-0"></i><span><strong>Rock‑solid reliability:</strong> Our hosting infrastructure ensures 24/7 uptime—downtime erodes trust and revenue.</span></li>
-          </ul>
-          <a href="/contact" class="btn-secondary inline-block mt-6">Book a Discovery Call</a>
-        </div>
-        <div class="hidden md:flex justify-center">
-          <i data-lucide="trending-up" class="w-40 h-40 text-brand-steel/40"></i>
-        </div>
+      <div class="max-w-5xl mx-auto px-6">
+        <h2 class="text-2xl font-bold mb-4">Our Reputation‑First Approach</h2>
+        <p class="mb-4">Every scrapyard website we build is engineered to strengthen your reputation—from the first click to the final load ticket. Your site becomes your 24/7 sales engine.</p>
+        <ul class="list-disc pl-5 space-y-2">
+          <li class="flex items-start"><i data-lucide="shield" class="w-5 h-5 text-brand-orange mr-2 flex-shrink-0"></i><span><strong>Instant credibility:</strong> Professional design builds trust instantly—visitors judge reliability in milliseconds.</span></li>
+          <li class="flex items-start"><i data-lucide="filter" class="w-5 h-5 text-brand-orange mr-2 flex-shrink-0"></i><span><strong>Pre‑qualifying forms:</strong> Customized intake questions filter out tire‑kickers, saving your team’s time.</span></li>
+          <li class="flex items-start"><i data-lucide="map-pin" class="w-5 h-5 text-brand-orange mr-2 flex-shrink-0"></i><span><strong>Local visibility:</strong> Structured data, Google Business integration, and local SEO help your yard appear first in nearby searches.</span></li>
+          <li class="flex items-start"><i data-lucide="clock" class="w-5 h-5 text-brand-orange mr-2 flex-shrink-0"></i><span><strong>Rock‑solid reliability:</strong> Our hosting infrastructure ensures 24/7 uptime—downtime erodes trust and revenue.</span></li>
+        </ul>
+        <a href="/contact" class="btn-primary inline-block mt-6 text-center w-max mx-auto">Book a Discovery Call</a>
       </div>
     </section>
     <!-- Pillars -->
@@ -185,55 +180,44 @@
           <a href="/process#reliability" class="text-brand-orange mt-2">Learn more</a>
           </div>
         </div>
-        <a href="/contact" class="btn-secondary mt-8 mx-auto block">Book a Discovery Call</a>
+        <a href="/contact" class="btn-primary mt-8 mx-auto block">Book a Discovery Call</a>
       </div>
     </section>
     <!-- Packages -->
     <section class="max-w-5xl mx-auto px-6 pb-16">
-      <div class="grid gap-8 md:grid-cols-4">
-        <div class="package-card bg-white border border-brand-steel/10 rounded-xl p-6 flex flex-col text-center">
-          <h3 class="font-semibold mb-3">Pillar</h3>
-          <ul class="text-sm mb-4 space-y-1">
-            <li>✔️ Credibility</li>
-            <li>— Qualification</li>
-            <li>— Visibility</li>
-            <li>— Reliability</li>
-          </ul>
-          <p class="text-sm mb-4">Solid foundation for new yards wanting a trustworthy image.</p>
-          <a href="/contact" class="btn-secondary mt-auto">Request a Quote</a>
-        </div>
-        <div class="package-card bg-white border border-brand-steel/10 rounded-xl p-6 flex flex-col text-center">
+      <div id="packages-carousel" class="carousel-track flex px-4 md:grid md:grid-cols-3 gap-8">
+        <div class="carousel-item package-card bg-white border border-brand-steel/10 rounded-xl p-6 flex flex-col text-center">
           <h3 class="font-semibold mb-3">Standard</h3>
-          <ul class="text-sm mb-4 space-y-1">
-            <li>✔️ Credibility</li>
-            <li>✔️ Qualification</li>
-            <li>— Visibility</li>
-            <li>— Reliability</li>
+          <ul class="text-sm mb-4 space-y-1 text-left">
+            <li class="flex items-center gap-2"><i data-lucide="check" class="w-4 h-4 text-brand-orange"></i><span>Credibility</span></li>
+            <li class="flex items-center gap-2"><i data-lucide="check" class="w-4 h-4 text-brand-orange"></i><span>Qualification</span></li>
+            <li class="flex items-center gap-2"><i data-lucide="minus" class="w-4 h-4 text-brand-steel"></i><span>Visibility</span></li>
+            <li class="flex items-center gap-2"><i data-lucide="minus" class="w-4 h-4 text-brand-steel"></i><span>Reliability</span></li>
           </ul>
           <p class="text-sm mb-4">Quick, reputable web presence.</p>
-          <a href="/contact" class="btn-secondary mt-auto">Request a Quote</a>
+          <a href="/pricing" class="btn-primary mt-auto">View Pricing</a>
         </div>
-        <div class="package-card bg-white border border-brand-steel/10 rounded-xl p-6 flex flex-col text-center">
+        <div class="carousel-item package-card bg-white border border-brand-steel/10 rounded-xl p-6 flex flex-col text-center">
           <h3 class="font-semibold mb-3">Premium</h3>
-          <ul class="text-sm mb-4 space-y-1">
-            <li>✔️ Credibility</li>
-            <li>✔️ Qualification</li>
-            <li>✔️ Visibility</li>
-            <li>— Reliability</li>
+          <ul class="text-sm mb-4 space-y-1 text-left">
+            <li class="flex items-center gap-2"><i data-lucide="check" class="w-4 h-4 text-brand-orange"></i><span>Credibility</span></li>
+            <li class="flex items-center gap-2"><i data-lucide="check" class="w-4 h-4 text-brand-orange"></i><span>Qualification</span></li>
+            <li class="flex items-center gap-2"><i data-lucide="check" class="w-4 h-4 text-brand-orange"></i><span>Visibility</span></li>
+            <li class="flex items-center gap-2"><i data-lucide="minus" class="w-4 h-4 text-brand-steel"></i><span>Reliability</span></li>
           </ul>
           <p class="text-sm mb-4">Dominate local search results.</p>
-          <a href="/contact" class="btn-secondary mt-auto">Request a Quote</a>
+          <a href="/pricing" class="btn-primary mt-auto">View Pricing</a>
         </div>
-        <div class="package-card bg-white border border-brand-steel/10 rounded-xl p-6 flex flex-col text-center">
+        <div class="carousel-item package-card bg-white border border-brand-steel/10 rounded-xl p-6 flex flex-col text-center">
           <h3 class="font-semibold mb-3">Care Plan</h3>
-          <ul class="text-sm mb-4 space-y-1">
-            <li>— Credibility</li>
-            <li>— Qualification</li>
-            <li>— Visibility</li>
-            <li>✔️ Reliability</li>
+          <ul class="text-sm mb-4 space-y-1 text-left">
+            <li class="flex items-center gap-2"><i data-lucide="minus" class="w-4 h-4 text-brand-steel"></i><span>Credibility</span></li>
+            <li class="flex items-center gap-2"><i data-lucide="minus" class="w-4 h-4 text-brand-steel"></i><span>Qualification</span></li>
+            <li class="flex items-center gap-2"><i data-lucide="minus" class="w-4 h-4 text-brand-steel"></i><span>Visibility</span></li>
+            <li class="flex items-center gap-2"><i data-lucide="check" class="w-4 h-4 text-brand-orange"></i><span>Reliability</span></li>
           </ul>
           <p class="text-sm mb-4">Ongoing monitoring and updates.</p>
-          <a href="/contact" class="btn-secondary mt-auto">Request a Quote</a>
+          <a href="/pricing" class="btn-primary mt-auto">View Pricing</a>
         </div>
       </div>
       <a href="/contact" class="btn-primary mt-10 mx-auto block w-max">Get Started</a>
@@ -277,10 +261,6 @@
     </section>
     <section class="py-6 text-center bg-gray-50">
       <p class="max-w-3xl mx-auto text-brand-charcoal">Our seven‑day launch promise means your site goes live fast. We back every build with a satisfaction guarantee and ongoing support.</p>
-    </section>
-    <section class="py-12 bg-brand-orange text-white text-center">
-      <h2 class="text-2xl font-bold mb-4">Ready to upgrade your yard's site?</h2>
-      <a href="/contact" class="btn-secondary">Book a Discovery Call</a>
     </section>
   </main>
   <footer class="bg-white py-8 text-center text-xs text-gray-400">
@@ -346,6 +326,7 @@
   if (window.matchMedia('(max-width: 767px)').matches) {
     initCarousel('pillars-carousel');
     initCarousel('portfolio-carousel');
+    initCarousel('packages-carousel');
   }
 </script>
   <script src="https://unpkg.com/lucide@latest"></script>


### PR DESCRIPTION
## Summary
- center `Our Reputation-First Approach` CTA and remove its graphic
- update discovery call buttons to orange
- make package comparison cards a mobile carousel and drop the Pillar tier
- swap checkmarks for lucide icons and left-align lists
- remove upgrade callout section
- initialize carousel for packages on mobile

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687fdc7ba8048329ac7ea8e6c6438bd4