### PR TITLE
Fix process hero spacing and add intro blurb

### DIFF
--- a/process/index.html
+++ b/process/index.html
@@ -152,7 +152,7 @@
   });
 
   </script>
-  <main class="pt-24 pb-20">
+  <main class="pt-0 pb-20">
     <section class="relative flex flex-col items-center justify-center min-h-[60vh] text-center">
       <img src="/assets/hero.jpg" alt="Scrapyard hero" class="absolute inset-0 w-full h-full object-cover">
       <div class="absolute inset-0 bg-black/80"></div>
@@ -165,7 +165,8 @@
 
     <section id="process" class="py-16">
       <div class="max-w-5xl mx-auto px-6">
-        <h2 class="text-2xl font-bold text-center mb-10">Our Process</h2>
+        <h2 class="text-2xl font-bold text-center mb-4">Our Process</h2>
+        <p class="text-center text-brand-steel max-w-3xl mx-auto mb-10">Our four-step build keeps you informed at every stage and gets your new site live fast.</p>
         <div id="process-carousel" class="carousel-track md:grid md:grid-cols-2 gap-8 px-4">
           <div class="carousel-item p-6 bg-gray-50 border border-brand-steel/10 rounded-xl flex flex-col items-start text-left transition-transform hover:-translate-y-1">
             <div class="flex items-center justify-center w-14 h-14 rounded-full bg-brand-orange mb-4">


### PR DESCRIPTION
## Summary
- remove extra top padding so hero image sits flush
- add short introduction paragraph under the "Our Process" heading

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687fe0507268832996e74b049b15ad03