### PR TITLE
Update service page layout

### DIFF
--- a/services/index.html
+++ b/services/index.html
@@ -132,8 +132,8 @@
     </section>
     <section id="reputation-first" class="py-12 bg-gray-100">
       <div class="max-w-5xl mx-auto px-6">
-        <h2 class="text-2xl font-bold mb-4">Our Reputation‑First Approach</h2>
-        <p class="mb-4">Every scrapyard website we build is engineered to strengthen your reputation—from the first click to the final load ticket. Your site becomes your 24/7 sales engine.</p>
+        <h2 class="text-2xl font-bold mb-4 text-center">Our Reputation‑First Approach</h2>
+        <p class="mb-4 text-center max-w-3xl mx-auto">Every scrapyard website we build is engineered to strengthen your reputation—from the first click to the final load ticket. Your site becomes your 24/7 sales engine.</p>
         <ul class="list-disc pl-5 space-y-2">
           <li class="flex items-start"><i data-lucide="shield" class="w-5 h-5 text-brand-orange mr-2 flex-shrink-0"></i><span><strong>Instant credibility:</strong> Professional design builds trust instantly—visitors judge reliability in milliseconds.</span></li>
           <li class="flex items-start"><i data-lucide="filter" class="w-5 h-5 text-brand-orange mr-2 flex-shrink-0"></i><span><strong>Pre‑qualifying forms:</strong> Customized intake questions filter out tire‑kickers, saving your team’s time.</span></li>
@@ -182,14 +182,15 @@
           <a href="/process#reliability" class="text-brand-orange mt-2">Learn more</a>
           </div>
         </div>
-        <a href="/contact" class="btn-primary inline-block w-max mt-8 mx-auto">Book a Discovery Call</a>
+        <a href="/contact" class="btn-primary block w-max mx-auto mt-8">Book a Discovery Call</a>
       </div>
     </section>
     <!-- Packages -->
-    <section class="max-w-5xl mx-auto px-6 pb-16">
-      <h2 class="text-3xl font-bold text-center mb-2">Service Packages</h2>
-      <p class="text-brand-steel text-center mb-6">Pick the level that best fits your goals.</p>
-      <div id="packages-carousel" class="carousel-track flex px-4 md:grid md:grid-cols-3 gap-8">
+    <section class="py-16 bg-white">
+      <div class="max-w-5xl mx-auto px-6">
+        <h2 class="text-3xl font-bold text-center mb-2">Service Packages</h2>
+        <p class="text-brand-steel text-center mb-6">Pick the level that best fits your goals.</p>
+        <div id="packages-carousel" class="carousel-track flex px-4 md:grid md:grid-cols-3 gap-8">
         <div class="carousel-item package-card bg-white border border-brand-steel/10 rounded-xl p-6 flex flex-col text-center">
           <h3 class="font-semibold mb-3">Standard</h3>
           <ul class="text-sm mb-4 space-y-1 text-left">
@@ -225,7 +226,7 @@
         </div>
       </div>
     </section>
-    <section class="py-6 text-center bg-gray-50">
+    <section class="pt-4 pb-16 text-center bg-gray-50">
       <p class="max-w-3xl mx-auto text-brand-charcoal">Our seven‑day launch promise means your site goes live fast. We back every build with a satisfaction guarantee and ongoing support.</p>
     </section>
     <!-- Work / Demo -->


### PR DESCRIPTION
## Summary
- center Reputation-First heading and description
- center the CTA below Four Pillars
- alternate background color for Service Packages section
- tighten spacing around the seven-day guarantee text

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687fe1de29fc8329b8713b6619c9c4d9