### PR TITLE
Make risk calculator section off-white

### DIFF
--- a/process/index.html
+++ b/process/index.html
@@ -282,7 +282,7 @@
         </div>
       </div>
     </section>
-    <section class="py-12">
+    <section class="py-12 bg-gray-50">
       <div class="mx-auto max-w-3xl px-6">
         <div class="border border-brand-steel/20 rounded-xl p-6 bg-white">
           <h2 class="text-2xl font-bold text-center">Reputation&nbsp;Risk&nbsp;Calculator</h2>


### PR DESCRIPTION
## Summary
- use an off‑white background for the Reputation Risk Calculator section on the process page

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687fe29cf5188329afa7fc64ab51b3eb