### PR TITLE
Ensure hero sections clear fixed nav

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -99,7 +99,7 @@
   });
 
   </script>
-  <main class="pt-0 pb-20 px-0">
+  <main class="pt-24 pb-20 px-0">
 <section class="relative text-center flex items-center justify-center min-h-[60vh]">
   <img src="/assets/hero.jpg" alt="Scrapyard hero" class="absolute inset-0 w-full h-full object-cover" />
   <div class="absolute inset-0 bg-black/80"></div>

--- a/index.html
+++ b/index.html
@@ -236,6 +236,8 @@
 
   </script>
 
+  <main class="pt-24 pb-20">
+
 <!-- ── Hero ───────────────────────────────────────────────── -->
 <section class="relative text-center flex items-center justify-center min-h-[80vh]">
   <img src="/assets/hero.jpg" alt="Scrapyard hero" class="absolute inset-0 w-full h-full object-cover"/>
@@ -686,6 +688,8 @@
   </nav>
   <p>© <span id="year"></span> Scrapyard Sites — All rights reserved.</p>
 </footer>
+
+</main>
 
 <script>
   /* dynamic year for footer */

--- a/portfolio/index.html
+++ b/portfolio/index.html
@@ -93,7 +93,7 @@
 });
   </script>
 
-  <main class="pb-20">
+  <main class="pt-24 pb-20">
     <section class="relative flex flex-col items-center justify-center min-h-[60vh] text-center">
       <img src="/assets/hero.jpg" alt="Scrapyard hero" class="absolute inset-0 w-full h-full object-cover">
       <div class="absolute inset-0 bg-black/80"></div>

--- a/process/index.html
+++ b/process/index.html
@@ -152,7 +152,7 @@
   });
 
   </script>
-  <main class="pt-0 pb-20">
+  <main class="pt-24 pb-20">
     <section class="relative flex flex-col items-center justify-center min-h-[60vh] text-center">
       <img src="/assets/hero.jpg" alt="Scrapyard hero" class="absolute inset-0 w-full h-full object-cover">
       <div class="absolute inset-0 bg-black/80"></div>

--- a/services/index.html
+++ b/services/index.html
@@ -119,7 +119,7 @@
   function toggleMobileMenu(){const menu=document.getElementById('mobileMenu');const btn=document.getElementById('menuToggle');menu.classList.toggle('hidden');const isOpen=!menu.classList.contains('hidden');document.body.classList.toggle('overflow-hidden',isOpen);btn.classList.toggle('open');}
   document.addEventListener('DOMContentLoaded',()=>{const currentPath=location.pathname.replace(/\/index.html$/,'').replace(/\/$/,'');document.querySelectorAll('#menu a:not(.no-highlight), #mobileMenu a:not(.no-highlight)').forEach(link=>{const linkPath=new URL(link.getAttribute('href'),location.origin).pathname.replace(/\/index.html$/,'').replace(/\/$/,'');if(linkPath===currentPath){link.classList.add('text-brand-orange');}});document.getElementById('menuToggle')?.addEventListener('click',toggleMobileMenu);document.getElementById('menuClose')?.addEventListener('click',toggleMobileMenu);});
   </script>
-  <main class="pt-0 pb-0 bg-gray-50">
+  <main class="pt-24 pb-0 bg-gray-50">
     <!-- Hero -->
     <section class="relative flex flex-col items-center justify-center min-h-[60vh] text-center py-16 gap-8">
       <img src="/assets/hero.jpg" alt="Grapple loading shred" class="absolute inset-0 w-full h-full object-cover">


### PR DESCRIPTION
## Summary
- add a `<main>` wrapper with top padding on the homepage
- add top padding to other hero pages so the nav no longer overlaps

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687fe23525bc8329a4dd9328a339d153