### PR TITLE
Move launch promise and update service section colors

### DIFF
--- a/services/index.html
+++ b/services/index.html
@@ -224,13 +224,12 @@
           <p class="text-sm mb-4">Ongoing monitoring and updates.</p>
           <a href="/pricing" class="btn-primary mt-auto">View Pricing</a>
         </div>
+        </div>
+        <p class="max-w-3xl mx-auto text-brand-charcoal text-center mt-8">Our seven‑day launch promise means your site goes live fast. We back every build with a satisfaction guarantee and ongoing support.</p>
       </div>
     </section>
-    <section class="pt-4 pb-16 text-center bg-gray-50">
-      <p class="max-w-3xl mx-auto text-brand-charcoal">Our seven‑day launch promise means your site goes live fast. We back every build with a satisfaction guarantee and ongoing support.</p>
-    </section>
     <!-- Work / Demo -->
-      <section id="work" class="scroll-mt-16 bg-white py-20">
+      <section id="work" class="scroll-mt-16 bg-gray-100 py-20">
         <div class="mx-auto max-w-6xl px-6 text-center">
           <h2 class="text-3xl font-bold">See It in Action</h2>
           <p class="text-brand-steel mb-10">These demo yards are real code built with our reputation‑first approach.</p>


### PR DESCRIPTION
## Summary
- relocate the launch promise text to the Service Packages area and drop its old section
- alternate section backgrounds for better contrast

## Testing
- `grep -n seven services/index.html`

------
https://chatgpt.com/codex/tasks/task_e_687fe57059588329be24bb8ddc0bdad6