### PR TITLE
Fix hero shading on pricing page

### DIFF
--- a/pricing/index.html
+++ b/pricing/index.html
@@ -97,7 +97,7 @@
     <!-- Hero -->
     <section class="relative flex items-center justify-center min-h-[60vh] text-center">
       <img src="/assets/hero.jpg" alt="Scrapyard hero" class="absolute inset-0 w-full h-full object-cover" />
-      <div class="absolute inset-0 bg-black/70"></div>
+      <div class="absolute inset-0 bg-black/80"></div>
       <div class="relative z-10 px-6 py-24 text-white max-w-4xl mx-auto">
         <h1 class="text-4xl md:text-5xl font-extrabold">Invest in Your Reputation</h1>
         <p class="mt-4 text-lg">Transparent pricing for scrapyard sites. Two flat packages, no surprises.</p>


### PR DESCRIPTION
## Summary
- adjust hero overlay on pricing page to match other pages

## Testing
- `grep -n "bg-black" pricing/index.html`

------
https://chatgpt.com/codex/tasks/task_e_687fee2006b08329b0cf652ff5982b87