### PR TITLE
Revert demos page layout

### DIFF
--- a/demos/index.html
+++ b/demos/index.html
@@ -102,11 +102,6 @@
         <p class="mt-4 text-lg text-white">Explore our concept builds designed with real scrap‑yard scenarios. Each demo shows how a professional website built on our reputation‑first pillars—credibility, qualification, visibility and reliability—can transform perception and drive results.</p>
       </div>
     </section>
-    <section class="beta-invite bg-gray-100 py-10 mt-8 mb-0 text-center px-6">
-      <h2 class="text-2xl font-bold mb-2">Be Part of Our First Wave</h2>
-      <p>We’re partnering with select scrapyards to finalize our services. Get early access, shape the platform, and enjoy priority support by joining our beta program.</p>
-      <a href="/contact" class="btn-primary mt-4 inline-block">Join the Beta</a>
-    </section>
     <section class="explanation py-8 text-center px-6 max-w-3xl mx-auto">
       <h2 class="text-2xl font-bold mb-2">Why Demos?</h2>
       <p>Case studies and demos offer tangible proof of what’s possible. They cut through generic marketing claims by showcasing concrete results. We use these demo yards to illustrate how a reputation‑first website can elevate credibility and drive real-world outcomes. Think of these as mini case studies, showing you the power of our process before you invest.</p>
@@ -157,6 +152,11 @@
           </div>
         </div>
       </div>
+      <section class="beta-invite bg-gray-100 py-10 mt-8 mb-0 text-center px-6">
+        <h2 class="text-2xl font-bold mb-2">Be Part of Our First Wave</h2>
+        <p>We’re partnering with select scrapyards to finalize our services. Get early access, shape the platform, and enjoy priority support by joining our beta program.</p>
+        <a href="/contact" class="btn-primary mt-4 inline-block">Join the Beta</a>
+      </section>
       <section class="py-12 bg-brand-orange text-white text-center mt-0">
         <h2 class="text-2xl font-bold mb-4">Ready to Build Your Yard’s Reputation?</h2>
         <p>Book a Discovery Call to discuss your yard’s unique needs and explore how our reputation‑first process can deliver measurable results.</p>


### PR DESCRIPTION
## Summary
- revert Beta invite section on `demos/index.html` to previous position

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687ff28badd88329a1c0b72fbdfb96d2