### PR TITLE
Update demos page CTA and banner

### DIFF
--- a/demos/index.html
+++ b/demos/index.html
@@ -152,15 +152,12 @@
           </div>
         </div>
       </div>
-      <section class="beta-invite bg-gray-100 py-10 mt-8 mb-0 text-center px-6">
-        <h2 class="text-2xl font-bold mb-2">Be Part of Our First Wave</h2>
-        <p>We’re partnering with select scrapyards to finalize our services. Get early access, shape the platform, and enjoy priority support by joining our beta program.</p>
-        <a href="/contact" class="btn-primary mt-4 inline-block">Join the Beta</a>
-      </section>
-      <section class="py-12 bg-brand-orange text-white text-center mt-0">
-        <h2 class="text-2xl font-bold mb-4">Ready to Build Your Yard’s Reputation?</h2>
-        <p>Book a Discovery Call to discuss your yard’s unique needs and explore how our reputation‑first process can deliver measurable results.</p>
-        <a href="/contact" class="btn-secondary mt-4">Book a Discovery Call</a>
+      <section class="beta-invite bg-brand-orange text-white py-10 text-center">
+        <div class="max-w-4xl mx-auto px-6">
+          <h2 class="text-2xl font-bold mb-2">Be Part of Our First Wave</h2>
+          <p>We’re partnering with select scrapyards to finalize our services. Get early access, shape the platform, and enjoy priority support by joining our beta program.</p>
+          <a href="/contact" class="btn-secondary mt-4 inline-block">Join the Beta</a>
+        </div>
       </section>
     </main>
 <footer class="bg-white py-8 text-center text-xs text-gray-400">


### PR DESCRIPTION
## Summary
- restyle the beta banner in `demos/index.html` to use an orange background with a white button
- remove the final CTA section from the demos page

## Testing
- `npx --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ff5a8a58c83299cb19a529fe67019