### PR TITLE
Fix demo page beta section layout

### DIFF
--- a/demos/index.html
+++ b/demos/index.html
@@ -152,7 +152,7 @@
           </div>
         </div>
       </div>
-      <section class="beta-invite bg-brand-orange text-white py-10 text-center">
+      <section class="beta-invite bg-brand-orange text-white py-10 text-center mt-16">
         <div class="max-w-4xl mx-auto px-6">
           <h2 class="text-2xl font-bold mb-2">Be Part of Our First Wave</h2>
           <p>We’re partnering with select scrapyards to finalize our services. Get early access, shape the platform, and enjoy priority support by joining our beta program.</p>


### PR DESCRIPTION
## Summary
- add top margin to "Be Part of Our First Wave" on the demos page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687ff7450af88329a24dc763174c55a4