### PR TITLE
Adjust mobile reputation section padding

### DIFF
--- a/index.html
+++ b/index.html
@@ -259,7 +259,7 @@
 </section>
 <!-- ── Reputation Section (Mobile) ───────────────────────── -->
 
-<section class="py-20 bg-gray-50 md:hidden">
+<section class="pt-16 pb-20 bg-gray-50 md:hidden">
   <div class="max-w-3xl mx-auto px-6 text-center">
     <h2 class="text-3xl font-extrabold text-gray-900 mb-4" data-aos="fade-up">
       Your Digital Yard&nbsp;Is&nbsp;Your&nbsp;Edge


### PR DESCRIPTION
## Summary
- tweak top padding for the mobile-only Reputation section on the homepage

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68801d0d05cc832995b7602848ae5aec