### PR TITLE
Replace bottom CTA with Beta invite

### DIFF
--- a/index.html
+++ b/index.html
@@ -664,9 +664,12 @@
       </div>
     </div>
   </section>
-  <section class="mt-16 py-12 bg-brand-orange text-white text-center">
-    <h2 class="text-2xl font-bold mb-4">Ready to upgrade your yard's site?</h2>
-    <a href="/contact" class="btn-secondary">Book a Discovery Call</a>
+  <section class="beta-invite bg-brand-orange text-white py-10 text-center">
+    <div class="max-w-4xl mx-auto px-6">
+      <h2 class="text-2xl font-bold mb-4">Join Our Beta Program</h2>
+      <p class="mb-6">We’re finalising our services with a select group of scrapyards. Get early access to build your reputation engine and shape the future of scrapyard websites.</p>
+      <a href="/contact" class="btn-secondary">Reserve Your Spot</a>
+    </div>
   </section>
 
 <!-- ── Footer ──────────────────────────────────────────────── -->


### PR DESCRIPTION
## Summary
- update the bottom call-to-action banner on the homepage to use the beta program invite

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688020f859888329a252904e91e772ec