### PR TITLE
Add 1px padding above pricing CTA

### DIFF
--- a/pricing/index.html
+++ b/pricing/index.html
@@ -193,7 +193,7 @@
               </table>
             </div>
           </div>
-<div class="mt-6 text-center">
+<div class="mt-6 pt-px text-center">
   <a href="/contact?plan=selected" class="btn-primary">Lock My Build Week</a>
 </div>
 </div>


### PR DESCRIPTION
## Summary
- tweak CTA container on pricing page to add a 1px top padding

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68802cccbf70832998eca650ef201513