### PR TITLE
Fix pricing page padding

### DIFF
--- a/pricing/index.html
+++ b/pricing/index.html
@@ -199,7 +199,7 @@
 </div>
       <!-- FAQ stays below packages -->
     </section>
-<section id="how-it-works" class="payment-details mt-16 text-left max-w-2xl mx-auto">
+<section id="how-it-works" class="payment-details mt-16 text-left max-w-2xl mx-auto px-6">
   <h2 class="text-2xl font-bold mb-4">How It Works</h2>
   <ul class="list-disc pl-5 mt-2 text-sm text-brand-steel">
     <li><strong>Book your build week:</strong> Pay a 50% deposit to secure your slot.</li>
@@ -208,7 +208,7 @@
     <li><strong>Our promise:</strong> If your site doesn’t pay for itself within 90 days, we refund the build fee.</li>
   </ul>
 </section>
-<section id="extras" class="extras mt-16 text-left max-w-2xl mx-auto">
+<section id="extras" class="extras mt-16 text-left max-w-2xl mx-auto px-6">
   <h2 class="text-2xl font-bold mb-4">Extras</h2>
   <ul class="list-disc pl-5 mt-2 text-sm text-brand-steel">
     <li>Add extra pages – $350 each</li>
@@ -217,7 +217,7 @@
   </ul>
   <p class="text-sm mt-1">Need something custom? <a href="/contact" class="text-brand-orange underline">Let us know.</a></p>
 </section>
-    <section class="mt-20 max-w-4xl mx-auto" id="faq">
+    <section class="mt-20 max-w-4xl mx-auto px-6" id="faq">
       <h2 class="text-3xl font-bold text-center mb-10">FAQ</h2>
       <div class="space-y-6 text-left">
         <details class="group"><summary class="cursor-pointer font-semibold text-brand-charcoal group-open:text-brand-orange">How fast can my site go live?</summary><p class="mt-1 text-brand-steel text-base md:text-sm md:pl-4 md:border-l md:border-brand-orange/40">Most sites launch in about a week for Standard or 10 days for Premium.</p></details>


### PR DESCRIPTION
## Summary
- adjust `How It Works`, `Extras`, and `FAQ` sections on pricing page to include horizontal padding

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68802d4ce48c8329a82a852dd1a84b6b