### PR TITLE
Improve mobile readability on calculator

### DIFF
--- a/risk-calculator/index.html
+++ b/risk-calculator/index.html
@@ -215,14 +215,14 @@
       <section class="py-16">
         <div class="max-w-xl mx-auto px-6 text-center">
           <h1 class="text-3xl font-bold">Reputation Risk Calculator</h1>
-          <p class="text-sm max-w-md mx-auto mt-2">
+          <p class="text-base leading-relaxed max-w-md mx-auto mt-2">
             Use this interactive tool to estimate how much revenue you’re losing
             from missed loads. Interactive calculators bridge the gap between
             words and numbers—they translate complex data into personalized
             insights and create a clear “aha” moment. Enter a few numbers to see
             how quickly a reputation‑first website pays for itself.
           </p>
-          <div class="py-6 max-w-xl mx-auto text-center text-sm text-gray-600">
+          <div class="py-6 max-w-xl mx-auto text-center text-base leading-relaxed text-gray-600">
             <p>
               Interactive calculators bridge the gap between words and numbers.
               They demonstrate your expertise by transforming abstract concepts
@@ -235,7 +235,7 @@
 
           <form id="calcForm" class="mt-10 grid gap-6 max-w-md mx-auto">
             <label class="text-left">
-              <span class="block text-sm font-medium"
+              <span class="block text-base font-medium"
                 >Average load weight (tons)</span
               >
               <input
@@ -249,7 +249,7 @@
               />
             </label>
             <label class="text-left">
-              <span class="block text-sm font-medium"
+              <span class="block text-base font-medium"
                 >Average margin ($/ton)</span
               >
               <input
@@ -263,7 +263,7 @@
               />
             </label>
             <label class="text-left">
-              <span class="block text-sm font-medium"
+              <span class="block text-base font-medium"
                 >Loads missed per month</span
               >
               <input
@@ -282,12 +282,12 @@
             <h2 class="text-xl font-bold">
               You’re leaking <span id="lossFig">$‑‑‑</span> per year
             </h2>
-            <p class="text-sm mt-2">
+            <p class="text-base leading-relaxed mt-2">
               We calculate this by multiplying your missed loads, average margin
               and weight, then annualizing the result. Think of this as money
               slipping through cracks in your process.
             </p>
-            <p class="text-sm mt-2">
+            <p class="text-base leading-relaxed mt-2">
               A Standard Launch ($2,499) pays for itself in
               <strong id="roiDays">‑‑</strong> days—then starts putting money
               back in your pocket.


### PR DESCRIPTION
## Summary
- increase text size and line spacing on the calculator page
- enlarge form labels for better mobile usability

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68803339b6388329aa9cfa029dcf83a6