### PR TITLE
Fix risk calculator padding

### DIFF
--- a/risk-calculator/index.html
+++ b/risk-calculator/index.html
@@ -211,7 +211,7 @@
           ?.addEventListener("click", toggleMobileMenu);
       });
     </script>
-    <main class="pt-16 pb-32 px-6">
+    <main class="pt-16 px-6">
       <section class="py-16">
         <div class="max-w-xl mx-auto px-6 text-center">
           <h1 class="text-3xl font-bold">Reputation Risk Calculator</h1>


### PR DESCRIPTION
## Summary
- remove excess bottom padding from calculator page

## Testing
- `grep -rn pb-32 .`


------
https://chatgpt.com/codex/tasks/task_e_688034e8b1608329a21349b28285f543