### PR TITLE
Fix text on calculator page

### DIFF
--- a/risk-calculator/index.html
+++ b/risk-calculator/index.html
@@ -300,7 +300,7 @@
             >
             <p class="text-xs mt-6">
               Click to schedule a call and receive a personalized reputation
-              risk scan with your calculated leakage pre‑filled.
+              risk scan.
             </p>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- update CTA text on the risk calculator page

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688035b9efac83298156b83d256bb2dd