### PR TITLE
Apply shadowless hover on demo cards

### DIFF
--- a/demos/index.html
+++ b/demos/index.html
@@ -108,47 +108,47 @@
     </section>
       <div class="mx-auto max-w-6xl px-6 mt-12">
         <div id="demos-carousel" class="carousel-track flex px-4 md:grid md:grid-cols-3 gap-8">
-          <div class="carousel-item bg-gray-50 border border-brand-steel/10 rounded-xl shadow-sm p-6 flex flex-col h-full demo-card">
+          <div class="carousel-item bg-gray-50 border border-brand-steel/10 rounded-xl shadow-sm p-6 flex flex-col h-full demo-card transition transform hover:-translate-y-1">
             <a href="demo-yard-1/">
               <img class="w-full rounded-md border border-brand-steel/10" src="https://placehold.co/600x400/2B2B2B/FFFFFF?text=Demo+Yard+1" alt="Demo Yard 1">
             </a>
             <h3 class="font-semibold mt-4">Metro Yard Demo</h3>
             <p class="text-sm mt-1">A modern design for a busy urban scrapyard competing for attention.</p>
-            <ul class="mt-4 text-sm space-y-1 list-disc list-inside">
+            <ul class="mt-4 mb-4 text-sm space-y-1 list-disc list-inside">
               <li><strong>Credibility:</strong> Responsive design and secure SSL build trust instantly.</li>
               <li><strong>Qualification:</strong> Quick‑quote form filters serious sellers.</li>
               <li><strong>Visibility:</strong> SEO‑tuned pages help win “near me” searches.</li>
               <li><strong>Reliability:</strong> 24/7 uptime ensures you never miss a lead.</li>
             </ul>
-            <a href="demo-yard-1/" class="btn-primary mt-4 md:mt-auto inline-block">View Demo</a>
+            <a href="demo-yard-1/" class="btn-primary md:mt-auto inline-block">View Demo</a>
           </div>
-          <div class="carousel-item bg-gray-50 border border-brand-steel/10 rounded-xl shadow-sm p-6 flex flex-col h-full demo-card">
+          <div class="carousel-item bg-gray-50 border border-brand-steel/10 rounded-xl shadow-sm p-6 flex flex-col h-full demo-card transition transform hover:-translate-y-1">
             <a href="demo-yard-2/">
               <img class="w-full rounded-md border border-brand-steel/10" src="https://placehold.co/600x400/2B2B2B/FFFFFF?text=Demo+Yard+2" alt="Demo Yard 2">
             </a>
             <h3 class="font-semibold mt-4">Mobile‑Friendly Demo</h3>
             <p class="text-sm mt-1">Easy quoting from any device for sellers on the move.</p>
-            <ul class="mt-4 text-sm space-y-1 list-disc list-inside">
+            <ul class="mt-4 mb-4 text-sm space-y-1 list-disc list-inside">
               <li><strong>Credibility:</strong> SSL lock and responsive design.</li>
               <li><strong>Qualification:</strong> Clear materials list up front filters calls.</li>
               <li><strong>Visibility:</strong> Local SEO and speed boost mobile searches.</li>
               <li><strong>Reliability:</strong> Instant call button connects you fast.</li>
             </ul>
-            <a href="demo-yard-2/" class="btn-primary mt-4 md:mt-auto inline-block">View Demo</a>
+            <a href="demo-yard-2/" class="btn-primary md:mt-auto inline-block">View Demo</a>
           </div>
-          <div class="carousel-item bg-gray-50 border border-brand-steel/10 rounded-xl shadow-sm p-6 flex flex-col h-full demo-card">
+          <div class="carousel-item bg-gray-50 border border-brand-steel/10 rounded-xl shadow-sm p-6 flex flex-col h-full demo-card transition transform hover:-translate-y-1">
             <a href="demo-yard-3/">
               <img class="w-full rounded-md border border-brand-steel/10" src="https://placehold.co/600x400/2B2B2B/FFFFFF?text=Demo+Yard+3" alt="Demo Yard 3">
             </a>
             <h3 class="font-semibold mt-4">Industrial Client Demo</h3>
             <p class="text-sm mt-1">Service-focused layout built for large loads and multiple locations.</p>
-            <ul class="mt-4 text-sm space-y-1 list-disc list-inside">
+            <ul class="mt-4 mb-4 text-sm space-y-1 list-disc list-inside">
               <li><strong>Credibility:</strong> Certification badges and real photos.</li>
               <li><strong>Qualification:</strong> Detailed service pages speak to industrial clients.</li>
               <li><strong>Visibility:</strong> Optimized content attracts high-volume suppliers.</li>
               <li><strong>Reliability:</strong> Dependable uptime proves you're ready for big jobs.</li>
             </ul>
-            <a href="demo-yard-3/" class="btn-primary mt-4 md:mt-auto inline-block">View Demo</a>
+            <a href="demo-yard-3/" class="btn-primary md:mt-auto inline-block">View Demo</a>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- lift demo cards without adding hover shadow
- even out space above the CTA buttons

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6880fd4693b88329b5d0518036fc0b44