### PR TITLE
Fix about page layout for shield cards and headings

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -127,7 +127,7 @@
 </section>
 <section class="py-10 bg-gray-100">
   <h2 class="text-2xl font-semibold text-center">Our Reputation Shields</h2>
-  <div class="grid gap-6 md:grid-cols-2 px-6 mt-6">
+  <div class="max-w-6xl mx-auto grid gap-6 md:grid-cols-2 px-6 mt-6">
     <article class="bg-gray-50 border border-brand-steel/10 rounded-xl shadow-sm p-6 text-center transition transform hover:-translate-y-1" data-aos="fade-up" data-aos-delay="0">
       <i class="fa-solid fa-shield-alt text-5xl card-icon mb-4" data-icon></i>
       <h3 class="font-semibold mb-1">Credibility</h3>
@@ -151,7 +151,7 @@
   </div>
 </section>
 <section class="py-10">
-  <h2 class="text-2xl font-semibold">Our Core Values</h2>
+  <h2 class="text-2xl font-semibold text-center">Our Core Values</h2>
   <ul class="mt-4 space-y-3 px-6 max-w-3xl mx-auto text-center">
     <li>
       <strong>Honesty:</strong> Clear pricing, plain language, no hidden fees—ever.
@@ -165,7 +165,7 @@
   </ul>
 </section>
 <section class="py-10 bg-gray-100">
-  <h2 class="text-2xl font-semibold">Why Choose Scrapyard Sites?</h2>
+  <h2 class="text-2xl font-semibold text-center">Why Choose Scrapyard Sites?</h2>
   <ul class="mt-4 space-y-3 px-6 max-w-3xl mx-auto text-center">
     <li>
       <strong>Industry Expertise:</strong> Built by someone who works in scrapyard operations every day.


### PR DESCRIPTION
## Summary
- center headings for "Our Core Values" and "Why Choose Scrapyard Sites"
- wrap reputation shields grid in a max-width container so cards don't touch page edges

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6881303ee1e0832988b81a124c857d08