### PR TITLE
Align contact FAQ style with homepage

### DIFF
--- a/contact/index.html
+++ b/contact/index.html
@@ -131,19 +131,31 @@
         Not ready to chat? <a href="/risk-calculator" class="underline">Try our Risk Calculator</a> to see how much revenue you’re missing.
       </p>
     </div>
-    <section class="mt-20 max-w-4xl mx-auto" id="faq">
-      <h2 class="text-3xl font-bold text-center mb-10">FAQ</h2>
-      <div class="space-y-6 text-center md:text-left">
-        <details class="group"><summary class="cursor-pointer font-semibold text-brand-charcoal group-open:text-brand-orange">What happens after I hit send?</summary><p class="mt-1 text-brand-steel text-base md:text-sm md:pl-4 md:border-l md:border-brand-orange/40">We'll reply within 15 minutes to confirm details and schedule your call. No spam.</p></details>
-        <details class="group"><summary class="cursor-pointer font-semibold text-brand-charcoal group-open:text-brand-orange">Can we just get the price?</summary><p class="mt-1 text-brand-steel text-base md:text-sm md:pl-4 md:border-l md:border-brand-orange/40">Of course. No hidden fees, no “call for quote.” You’ll know the cost before we write a line of code.</p></details>
-        <details class="group">
-          <summary class="cursor-pointer font-semibold text-brand-charcoal group-open:text-brand-orange">How do you handle my data?</summary>
-          <p class="mt-1 text-brand-steel text-base md:text-sm md:pl-4 md:border-l md:border-brand-orange/40">
-            We use your information only to schedule your call and prepare your reputation scan. We never share or sell your data, and you won’t be added to any CRM without your permission.
-          </p>
-        </details>
+    <section id="faq" class="scroll-mt-16 py-12 bg-white">
+      <div class="mx-auto max-w-2xl px-6">
+        <h2 class="text-2xl font-bold text-center mb-6">FAQ</h2>
+        <div class="space-y-4 text-center md:text-left">
+          <details class="group">
+            <summary class="flex items-center gap-2 cursor-pointer font-semibold text-brand-charcoal group-open:text-brand-orange">What happens after I hit send?<span class="ml-auto transition-transform group-open:rotate-180">▾</span></summary>
+            <p class="mt-1 text-brand-steel text-base md:text-sm md:pl-4 md:border-l md:border-brand-orange/40 text-left">
+              We'll reply within 15 minutes to confirm details and schedule your call. No spam.
+            </p>
+          </details>
+          <details class="group">
+            <summary class="flex items-center gap-2 cursor-pointer font-semibold text-brand-charcoal group-open:text-brand-orange">Can we just get the price?<span class="ml-auto transition-transform group-open:rotate-180">▾</span></summary>
+            <p class="mt-1 text-brand-steel text-base md:text-sm md:pl-4 md:border-l md:border-brand-orange/40 text-left">
+              Of course. No hidden fees, no “call for quote.” You’ll know the cost before we write a line of code.
+            </p>
+          </details>
+          <details class="group">
+            <summary class="flex items-center gap-2 cursor-pointer font-semibold text-brand-charcoal group-open:text-brand-orange">How do you handle my data?<span class="ml-auto transition-transform group-open:rotate-180">▾</span></summary>
+            <p class="mt-1 text-brand-steel text-base md:text-sm md:pl-4 md:border-l md:border-brand-orange/40 text-left">
+              We use your information only to schedule your call and prepare your reputation scan. We never share or sell your data, and you won’t be added to any CRM without your permission.
+            </p>
+          </details>
+        </div>
       </div>
-      </section>
+    </section>
     </main>
   <nav class="mb-2 flex flex-wrap justify-center gap-x-2 gap-y-1">
     <a href="/">Home</a>


### PR DESCRIPTION
## Summary
- match FAQ markup on the contact page with the homepage FAQ styling

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688130b8d99c8329bf041e9700c3ec98