### PR TITLE
Fix spacing on calculator intro paragraphs

### DIFF
--- a/risk-calculator/index.html
+++ b/risk-calculator/index.html
@@ -222,16 +222,14 @@
             insights and create a clear “aha” moment. Enter a few numbers to see
             how quickly a reputation‑first website pays for itself.
           </p>
-          <div class="py-6 max-w-xl mx-auto text-center text-base leading-relaxed text-gray-600">
-            <p>
-              Interactive calculators bridge the gap between words and numbers.
-              They demonstrate your expertise by transforming abstract concepts
-              into personalized insights and create an “aha” moment that
-              inspires confidence. This Risk Calculator is designed to give you
-              a clear picture of your missed‑call losses—so you can make an
-              informed decision about improving your online presence.
-            </p>
-          </div>
+          <p class="text-base leading-relaxed max-w-md mx-auto mt-4 text-gray-600">
+            Interactive calculators bridge the gap between words and numbers.
+            They demonstrate your expertise by transforming abstract concepts
+            into personalized insights and create an “aha” moment that inspires
+            confidence. This Risk Calculator is designed to give you a clear
+            picture of your missed‑call losses—so you can make an informed
+            decision about improving your online presence.
+          </p>
 
           <form id="calcForm" class="mt-10 grid gap-6 max-w-md mx-auto">
             <label class="text-left">


### PR DESCRIPTION
## Summary
- align margins for the intro paragraphs on the calculator page

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688131e570e08329a1f2fc82bb13a882