### PR TITLE
Revise pricing page layout

### DIFF
--- a/pricing/index.html
+++ b/pricing/index.html
@@ -155,67 +155,31 @@
             </ul>
           </div>
         </div>
-          <div class="mt-8">
-            <div class="hidden md:block overflow-x-auto">
-              <table class="min-w-full text-sm border">
-                <thead class="bg-gray-100">
-                  <tr>
-                    <th class="border px-2 py-1 text-left">Package</th>
-                    <th class="border px-2 py-1 text-left">Best for</th>
-                    <th class="border px-2 py-1 text-left">Up‑front</th>
-                    <th class="border px-2 py-1 text-left">Timeline</th>
-                    <th class="border px-2 py-1 text-left">What’s included</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  <tr>
-                    <td class="border px-2 py-1">Standard Launch</td>
-                    <td class="border px-2 py-1">Leaky DIY sites</td>
-                    <td class="border px-2 py-1">$2,499</td>
-                    <td class="border px-2 py-1">7‑days</td>
-                    <td class="border px-2 py-1">1‑page site, contact form, GBP tune‑up</td>
-                  </tr>
-                  <tr>
-                    <td class="border px-2 py-1">Premium Launch</td>
-                    <td class="border px-2 py-1">Multi‑location yards</td>
-                    <td class="border px-2 py-1">$5,499</td>
-                    <td class="border px-2 py-1">10‑days</td>
-                    <td class="border px-2 py-1">Up to 7 pages, location pages, maps and SEO, 60‑day tuning</td>
-                  </tr>
-                  <tr>
-                    <td class="border px-2 py-1">Care Plan</td>
-                    <td class="border px-2 py-1">Peace of mind</td>
-                    <td class="border px-2 py-1">$99/mo</td>
-                    <td class="border px-2 py-1">&ndash;</td>
-                    <td class="border px-2 py-1">Unlimited edits, security, quarterly KPIs</td>
-                  </tr>
-                </tbody>
-              </table>
-            </div>
-          </div>
+          
 <div class="mt-6 pt-0.5 text-center">
   <a href="/contact?plan=selected" class="btn-primary">Pay Deposit</a>
 </div>
 </div>
       <!-- FAQ stays below packages -->
     </section>
-<section id="how-it-works" class="payment-details mt-16 text-left max-w-2xl mx-auto px-6">
-  <h2 class="text-2xl font-bold mb-4">How It Works</h2>
-  <ul class="list-disc pl-5 mt-2 text-sm text-brand-steel">
-    <li><strong>Book your build week:</strong> Pay a 50% deposit to secure your slot.</li>
-    <li><strong>Launch your site:</strong> Remaining 50% due when your new site goes live.</li>
-    <li><strong>Payment methods:</strong> Cards, ACH, or check—no hidden fees.</li>
-    <li><strong>Our promise:</strong> If your site doesn’t pay for itself within 90 days, we refund the build fee.</li>
-  </ul>
-</section>
-<section id="extras" class="extras mt-16 text-left max-w-2xl mx-auto px-6">
-  <h2 class="text-2xl font-bold mb-4">Extras</h2>
-  <ul class="list-disc pl-5 mt-2 text-sm text-brand-steel">
-    <li>Add extra pages – $350 each</li>
-    <li>On-site photo/video (Lower 48) – from $750</li>
-    <li>Hand-off to your server – $199</li>
-  </ul>
-  <p class="text-sm mt-1">Need something custom? <a href="/contact" class="text-brand-orange underline">Let us know.</a></p>
+<section id="how-it-works" class="mt-16 py-12 bg-gray-50">
+  <div class="max-w-2xl mx-auto px-6 text-left">
+    <h2 class="text-2xl font-bold mb-4">How It Works</h2>
+    <ul class="list-disc pl-5 mt-2 text-sm text-brand-steel">
+      <li><strong>Book your build week:</strong> Pay a 50% deposit to secure your slot.</li>
+      <li><strong>Launch your site:</strong> Remaining 50% due when your new site goes live.</li>
+      <li><strong>Payment methods:</strong> Cards, ACH, or check—no hidden fees.</li>
+      <li><strong>Our promise:</strong> If your site doesn’t pay for itself within 90 days, we refund the build fee.</li>
+    </ul>
+
+    <h2 class="text-2xl font-bold mb-4 mt-8">Extras</h2>
+    <ul class="list-disc pl-5 mt-2 text-sm text-brand-steel">
+      <li>Add extra pages – $350 each</li>
+      <li>On-site photo/video (Lower 48) – from $750</li>
+      <li>Hand-off to your server – $199</li>
+    </ul>
+    <p class="text-sm mt-1">Need something custom? <a href="/contact" class="text-brand-orange underline">Let us know.</a></p>
+  </div>
 </section>
     <section id="faq" class="scroll-mt-16 py-12 bg-white">
       <div class="mx-auto max-w-2xl px-6">


### PR DESCRIPTION
## Summary
- remove outdated pricing comparison table
- combine How It Works and Extras bullets into a single off-white section

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688131b0a708832990358fad8a50a297