### PR TITLE
Fix pricing section layout

### DIFF
--- a/pricing/index.html
+++ b/pricing/index.html
@@ -107,7 +107,7 @@
       
     </section>
     <!-- Packages -->
-    <section class="py-20 bg-white" id="packages">
+    <section class="pt-20 pb-0 bg-white" id="packages">
       <div class="mx-auto max-w-6xl px-6 text-center">
         <h2 class="text-3xl font-bold mb-8">Service Pricing</h2>
         <div id="pricing-carousel" class="carousel-track flex gap-10 px-4 mt-14 md:grid md:grid-cols-2 lg:grid-cols-3 relative z-40">
@@ -164,7 +164,7 @@
     </section>
 <section id="how-it-works" class="mt-16 py-12 bg-gray-50">
   <div class="max-w-2xl mx-auto px-6 text-left">
-    <h2 class="text-2xl font-bold mb-4">How It Works</h2>
+    <h2 class="text-2xl font-bold mb-4 text-center">How It Works</h2>
     <ul class="list-disc pl-5 mt-2 text-sm text-brand-steel">
       <li><strong>Book your build week:</strong> Pay a 50% deposit to secure your slot.</li>
       <li><strong>Launch your site:</strong> Remaining 50% due when your new site goes live.</li>
@@ -172,7 +172,7 @@
       <li><strong>Our promise:</strong> If your site doesn’t pay for itself within 90 days, we refund the build fee.</li>
     </ul>
 
-    <h2 class="text-2xl font-bold mb-4 mt-8">Extras</h2>
+    <h2 class="text-2xl font-bold mb-4 mt-8 text-center">Extras</h2>
     <ul class="list-disc pl-5 mt-2 text-sm text-brand-steel">
       <li>Add extra pages – $350 each</li>
       <li>On-site photo/video (Lower 48) – from $750</li>


### PR DESCRIPTION
## Summary
- remove extra bottom padding from the Service Pricing section
- center "How It Works" and "Extras" headings

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68813e870ac48329a0f9c23dc32ee0b4