### PR TITLE
Adjust calculator layout

### DIFF
--- a/risk-calculator/index.html
+++ b/risk-calculator/index.html
@@ -213,9 +213,8 @@
     </script>
     <main class="pt-16 px-6">
       <section class="py-12 bg-gray-50">
-        <div class="mx-auto max-w-3xl px-6">
-          <div class="border border-brand-steel/20 rounded-xl p-6 bg-white">
-            <h1 class="text-2xl font-bold text-center">Reputation&nbsp;Risk&nbsp;Calculator</h1>
+        <div class="border border-brand-steel/20 rounded-xl p-6 bg-white mx-auto max-w-3xl px-6">
+          <h1 class="text-2xl font-bold text-center">Reputation&nbsp;Risk&nbsp;Calculator</h1>
             <p class="text-base leading-relaxed max-w-md mx-auto mt-2">
               Use this interactive tool to estimate how much revenue you’re losing
               from missed loads. Interactive calculators bridge the gap between
@@ -233,13 +232,13 @@
             </p>
             <form id="calcForm" class="mt-6 grid gap-6 max-w-md mx-auto">
               <input type="number" step="0.1" name="tons" inputmode="decimal" required
-                     placeholder="Average monthly tons"
+                     placeholder="Average monthly tons" value="2"
                      class="w-full rounded-md px-4 py-3 bg-white border border-brand-steel/20 text-brand-charcoal" />
               <input type="number" step="0.1" name="margin" inputmode="decimal" required
-                     placeholder="Margin per ton ($)"
+                     placeholder="Margin per ton ($)" value="50"
                      class="w-full rounded-md px-4 py-3 bg-white border border-brand-steel/20 text-brand-charcoal" />
               <input type="number" name="missed" inputmode="numeric" required
-                     placeholder="Missed calls per month"
+                     placeholder="Missed calls per month" value="10"
                      class="w-full rounded-md px-4 py-3 bg-white border border-brand-steel/20 text-brand-charcoal" />
               <button class="btn-primary w-full" type="submit">Calculate</button>
             </form>
@@ -253,8 +252,7 @@
               </a>
             </div>
           </div>
-        </div>
-      </section>
+        </section>
       <section class="mt-16 py-12 bg-brand-orange text-white text-center -mx-6">
         <h2 class="text-2xl font-bold mb-4">
           Ready to upgrade your yard's site?


### PR DESCRIPTION
## Summary
- remove extra wrapper div around risk calculator card
- center heading and add default values

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68815b2e705c83298bf2f691b627fc0d