### PR TITLE
Fix nav and layout spacing

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -169,6 +169,11 @@ header nav ul a.text-brand-orange {
   color: #D75E02 !important;
 }
 
+/* Vertically center brand title in the nav */
+header .site-title {
+  line-height: 1;
+}
+
 
 /* Hide default disclosure triangles on FAQ items */
 details summary::-webkit-details-marker {

--- a/index.html
+++ b/index.html
@@ -357,7 +357,7 @@
     <!-- Problem & solution columns -->
     <div class="grid grid-cols-1 md:grid-cols-2 gap-y-12 md:gap-12 mb-16 text-center md:text-left">
       <!-- Problem column -->
-      <div class="bg-white px-6 pt-6 pb-12 md:p-0 md:bg-transparent -mx-6 md:mx-0">
+      <div class="bg-white px-6 pt-6 pb-12 md:p-0 md:bg-transparent md:mx-0">
         <h3 class="mt-6 md:mt-0 text-2xl font-bold text-gray-900 mb-4" data-aos="fade-up">If You Don’t Look the Part…</h3>
         <div class="space-y-6">
           <!-- Invisible to Sellers -->
@@ -394,7 +394,7 @@
       </div>
 
       <!-- Solution column -->
-      <div class="bg-gray-100 px-6 pt-6 pb-12 md:p-0 md:bg-transparent -mx-6 md:mx-0">
+      <div class="bg-gray-100 px-6 pt-6 pb-12 md:p-0 md:bg-transparent md:mx-0">
         <h3 class="mt-6 md:mt-0 text-2xl font-bold text-gray-900 mb-4" data-aos="fade-up">We Fix That</h3>
         <div class="space-y-6">
           <!-- Secure & Compliant -->
@@ -502,7 +502,7 @@
       No hidden fees, no “call for quote”. You’ll know the cost before we write a line of code.
     </p>
 
-    <div id="pricing-carousel" class="carousel-track flex gap-10 px-4 mt-14 md:grid md:grid-cols-2 lg:grid-cols-3 relative z-40">
+    <div id="pricing-carousel" class="carousel-track flex gap-10 px-4 mt-14 md:grid md:grid-cols-3 relative z-40">
       <!-- Launch -->
       <div class="carousel-item relative z-30 overflow-visible bg-gray-50 border border-brand-steel/10 rounded-xl shadow-sm transition transform hover:-translate-y-1 px-6 py-10 md:p-10">
         <span


### PR DESCRIPTION
## Summary
- tweak pricing grid on desktop
- remove extra margin on reputation section
- vertically center logo title in nav

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68838cd9d3008329816f6c024241e231