### PR TITLE
Fix homepage card layout and spacing

### DIFF
--- a/index.html
+++ b/index.html
@@ -357,7 +357,7 @@
     <!-- Problem & solution columns -->
     <div class="grid grid-cols-1 md:grid-cols-2 gap-y-12 md:gap-12 mb-16 text-center md:text-left">
       <!-- Problem column -->
-      <div class="bg-white px-6 pt-6 pb-12 md:p-0 md:bg-transparent md:mx-0">
+      <div class="bg-white px-6 pt-6 pb-12 md:p-0 md:pl-6 md:bg-transparent md:mx-0">
         <h3 class="mt-6 md:mt-0 text-2xl font-bold text-gray-900 mb-4" data-aos="fade-up">If You Don’t Look the Part…</h3>
         <div class="space-y-6">
           <!-- Invisible to Sellers -->
@@ -443,7 +443,7 @@
 <section id="work" class="scroll-mt-16 bg-white py-20">
   <div class="mx-auto max-w-6xl px-6 text-center">
     <h2 class="text-3xl font-bold mb-10">Demo Yards</h2>
-    <div id="portfolio-carousel" class="carousel-track flex px-4 md:grid md:grid-cols-3 gap-8">
+    <div id="portfolio-carousel" class="carousel-track flex px-4 md:grid md:grid-cols-1 lg:grid-cols-3 gap-8">
       <!-- Demo project cards -->
       <a href="#contact" class="carousel-item block bg-gray-50 border border-brand-steel/10 rounded-xl shadow-sm p-10 flex flex-col items-center text-center hover:bg-gray-100 hover:shadow-lg transition transform hover:-translate-y-1 hover:cursor-pointer">
         <div class="w-full rounded-xl overflow-hidden border border-brand-steel/10">
@@ -502,7 +502,7 @@
       No hidden fees, no “call for quote”. You’ll know the cost before we write a line of code.
     </p>
 
-    <div id="pricing-carousel" class="carousel-track flex gap-10 px-4 mt-14 md:grid md:grid-cols-3 relative z-40">
+    <div id="pricing-carousel" class="carousel-track flex gap-10 px-4 mt-14 md:grid md:grid-cols-1 lg:grid-cols-3 relative z-40">
       <!-- Launch -->
       <div class="carousel-item relative z-30 overflow-visible bg-gray-50 border border-brand-steel/10 rounded-xl shadow-sm transition transform hover:-translate-y-1 px-6 py-10 md:p-10">
         <span


### PR DESCRIPTION
## Summary
- keep demo and pricing cards in a grid at desktop widths
- collapse the grids to one column when desktop width is narrow
- restore left padding for the "If You Don’t Look the Part…" list

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68838eae47188329b318b73e104ebcf5