### PR TITLE
Fix pricing grid columns

### DIFF
--- a/pricing/index.html
+++ b/pricing/index.html
@@ -110,7 +110,7 @@
     <section class="pt-20 pb-0 bg-white" id="packages">
       <div class="mx-auto max-w-6xl px-6 text-center">
         <h2 class="text-3xl font-bold mb-8">Service Pricing</h2>
-        <div id="pricing-carousel" class="carousel-track flex gap-10 px-4 mt-14 md:grid md:grid-cols-2 lg:grid-cols-3 relative z-40">
+        <div id="pricing-carousel" class="carousel-track flex gap-10 px-4 mt-14 md:grid md:grid-cols-1 lg:grid-cols-3 relative z-40">
           <!-- Launch -->
           <div class="carousel-item relative z-30 overflow-visible bg-gray-50 border border-brand-steel/10 rounded-xl shadow-sm transition transform hover:-translate-y-1 px-6 py-10 md:p-10 flex flex-col">
             <span


### PR DESCRIPTION
## Summary
- adjust pricing carousel grid to show one column on medium screens and three columns on large screens

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_6883907882a483299266730383dd4958