### PR TITLE
Fix calculator section padding

### DIFF
--- a/risk-calculator/index.html
+++ b/risk-calculator/index.html
@@ -212,7 +212,7 @@
       });
     </script>
     <main class="pt-16 px-6">
-      <section class="py-12 bg-gray-50 -mx-6">
+      <section class="pt-12 pb-28 bg-gray-50 -mx-6">
         <div class="border border-brand-steel/20 rounded-xl p-6 bg-white mx-auto max-w-3xl px-6">
           <h1 class="text-2xl font-bold text-center">Reputation&nbsp;Risk&nbsp;Calculator</h1>
             <p class="text-base leading-relaxed max-w-md mx-auto mt-2">
@@ -253,7 +253,7 @@
             </div>
           </div>
         </section>
-      <section class="mt-16 py-12 bg-brand-orange text-white text-center -mx-6">
+      <section class="py-12 bg-brand-orange text-white text-center -mx-6">
         <h2 class="text-2xl font-bold mb-4">
           Ready to upgrade your yard's site?
         </h2>


### PR DESCRIPTION
## Summary
- adjust padding on risk calculator section
- remove margin above CTA section to avoid white gap

## Testing
- `git diff --stat`


------
https://chatgpt.com/codex/tasks/task_e_6883926f72b0832986838741489c5e20