### PR TITLE
Add limited-time deposit promo banner

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -34,6 +34,11 @@
   </style>
 </head>
 <body class="font-sans text-brand-charcoal antialiased bg-white overflow-x-hidden">
+<div id="promoBanner" class="bg-brand-orange text-white text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
+  <span>Save 10% on your build — pay your deposit by Aug 30. Lock in your slot; go live before peak Q4 scrap season.</span>
+  <a href="https://book.stripe.com/eVqeVd8Vi9U45RbdJy73G00" class="btn-secondary whitespace-nowrap">Pay Deposit →</a>
+  <span data-days-left class="text-xs"></span>
+</div>
   <header class="fixed top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
     <nav class="max-w-7xl mx-auto relative flex items-center justify-between py-3 px-6">
       <a href="/" class="flex items-center gap-2"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-8 w-8"/><span class="site-title text-xl text-brand-charcoal"><span class="font-bold text-brand-orange">Scrapyard</span> <span class="font-bold">Sites</span></span></a>
@@ -242,5 +247,6 @@
       });
     }
   </script>
+<script src="/assets/promo-banner.js"></script>
 </body>
 </html>

--- a/assets/promo-banner.js
+++ b/assets/promo-banner.js
@@ -1,0 +1,15 @@
+(function(){
+  const banner = document.getElementById('promoBanner');
+  if(!banner) return;
+  const countdownEl = banner.querySelector('[data-days-left]');
+  const target = new Date('2024-08-31T00:00:00');
+  const now = new Date();
+  const diff = Math.ceil((target - now) / (1000*60*60*24));
+  if(diff <= 0){
+    const btn = banner.querySelector('a');
+    if(btn) btn.remove();
+    if(countdownEl) countdownEl.textContent = 'Slots now full';
+  } else if(countdownEl){
+    countdownEl.textContent = diff + ' day' + (diff === 1 ? '' : 's') + ' left';
+  }
+})();

--- a/blog/index.html
+++ b/blog/index.html
@@ -25,6 +25,11 @@
   </style>
 </head>
 <body class="font-sans text-brand-charcoal antialiased bg-white overflow-x-hidden">
+<div id="promoBanner" class="bg-brand-orange text-white text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
+  <span>Save 10% on your build — pay your deposit by Aug 30. Lock in your slot; go live before peak Q4 scrap season.</span>
+  <a href="https://book.stripe.com/eVqeVd8Vi9U45RbdJy73G00" class="btn-secondary whitespace-nowrap">Pay Deposit →</a>
+  <span data-days-left class="text-xs"></span>
+</div>
   <header class="fixed top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
     <nav class="max-w-7xl mx-auto relative flex items-center justify-between py-3 px-6">
       <a href="/" class="flex items-center gap-2"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-8 w-8"/><span class="site-title text-xl text-brand-charcoal"><span class="font-bold text-brand-orange">Scrapyard</span> <span class="font-bold">Sites</span></span></a>
@@ -156,5 +161,6 @@
   <p>© <span id="year"></span> Scrapyard Sites — All rights reserved.</p>
 </footer>
   <script>document.getElementById('year').textContent=new Date().getFullYear();</script>
+<script src="/assets/promo-banner.js"></script>
 </body>
 </html>

--- a/blog/post-template.html
+++ b/blog/post-template.html
@@ -25,6 +25,11 @@
   </style>
 </head>
 <body class="font-sans text-brand-charcoal antialiased bg-white overflow-x-hidden">
+<div id="promoBanner" class="bg-brand-orange text-white text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
+  <span>Save 10% on your build — pay your deposit by Aug 30. Lock in your slot; go live before peak Q4 scrap season.</span>
+  <a href="https://book.stripe.com/eVqeVd8Vi9U45RbdJy73G00" class="btn-secondary whitespace-nowrap">Pay Deposit →</a>
+  <span data-days-left class="text-xs"></span>
+</div>
   <header class="fixed top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
     <nav class="max-w-7xl mx-auto relative flex items-center justify-between py-3 px-6">
       <a href="/" class="flex items-center gap-2"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-8 w-8"/><span class="site-title text-xl text-brand-charcoal"><span class="font-bold text-brand-orange">Scrapyard</span> <span class="font-bold">Sites</span></span></a>
@@ -118,5 +123,6 @@
   <p>© <span id="year"></span> Scrapyard Sites — All rights reserved.</p>
 </footer>
 <script>document.getElementById('year').textContent=new Date().getFullYear();</script>
+<script src="/assets/promo-banner.js"></script>
 </body>
 </html>

--- a/blog/posts/care-plan-essentials.html
+++ b/blog/posts/care-plan-essentials.html
@@ -25,6 +25,11 @@
   </style>
 </head>
 <body class="font-sans text-brand-charcoal antialiased bg-white overflow-x-hidden">
+<div id="promoBanner" class="bg-brand-orange text-white text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
+  <span>Save 10% on your build — pay your deposit by Aug 30. Lock in your slot; go live before peak Q4 scrap season.</span>
+  <a href="https://book.stripe.com/eVqeVd8Vi9U45RbdJy73G00" class="btn-secondary whitespace-nowrap">Pay Deposit →</a>
+  <span data-days-left class="text-xs"></span>
+</div>
   <header class="fixed top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
     <nav class="max-w-7xl mx-auto relative flex items-center justify-between py-3 px-6">
       <a href="/" class="flex items-center gap-2"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-8 w-8"/><span class="site-title text-xl text-brand-charcoal"><span class="font-bold text-brand-orange">Scrapyard</span> <span class="font-bold">Sites</span></span></a>
@@ -118,5 +123,6 @@
   <p>© <span id="year"></span> Scrapyard Sites — All rights reserved.</p>
 </footer>
 <script>document.getElementById('year').textContent=new Date().getFullYear();</script>
+<script src="/assets/promo-banner.js"></script>
 </body>
 </html>

--- a/blog/posts/pre-qualify-scrap-sellers.html
+++ b/blog/posts/pre-qualify-scrap-sellers.html
@@ -25,6 +25,11 @@
   </style>
 </head>
 <body class="font-sans text-brand-charcoal antialiased bg-white overflow-x-hidden">
+<div id="promoBanner" class="bg-brand-orange text-white text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
+  <span>Save 10% on your build — pay your deposit by Aug 30. Lock in your slot; go live before peak Q4 scrap season.</span>
+  <a href="https://book.stripe.com/eVqeVd8Vi9U45RbdJy73G00" class="btn-secondary whitespace-nowrap">Pay Deposit →</a>
+  <span data-days-left class="text-xs"></span>
+</div>
   <header class="fixed top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
     <nav class="max-w-7xl mx-auto relative flex items-center justify-between py-3 px-6">
       <a href="/" class="flex items-center gap-2"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-8 w-8"/><span class="site-title text-xl text-brand-charcoal"><span class="font-bold text-brand-orange">Scrapyard</span> <span class="font-bold">Sites</span></span></a>
@@ -118,5 +123,6 @@
   <p>© <span id="year"></span> Scrapyard Sites — All rights reserved.</p>
 </footer>
 <script>document.getElementById('year').textContent=new Date().getFullYear();</script>
+<script src="/assets/promo-banner.js"></script>
 </body>
 </html>

--- a/blog/posts/seo-basics-for-scrap-yards.html
+++ b/blog/posts/seo-basics-for-scrap-yards.html
@@ -25,6 +25,11 @@
   </style>
 </head>
 <body class="font-sans text-brand-charcoal antialiased bg-white overflow-x-hidden">
+<div id="promoBanner" class="bg-brand-orange text-white text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
+  <span>Save 10% on your build — pay your deposit by Aug 30. Lock in your slot; go live before peak Q4 scrap season.</span>
+  <a href="https://book.stripe.com/eVqeVd8Vi9U45RbdJy73G00" class="btn-secondary whitespace-nowrap">Pay Deposit →</a>
+  <span data-days-left class="text-xs"></span>
+</div>
   <header class="fixed top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
     <nav class="max-w-7xl mx-auto relative flex items-center justify-between py-3 px-6">
       <a href="/" class="flex items-center gap-2"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-8 w-8"/><span class="site-title text-xl text-brand-charcoal"><span class="font-bold text-brand-orange">Scrapyard</span> <span class="font-bold">Sites</span></span></a>
@@ -118,5 +123,6 @@
   <p>© <span id="year"></span> Scrapyard Sites — All rights reserved.</p>
 </footer>
 <script>document.getElementById('year').textContent=new Date().getFullYear();</script>
+<script src="/assets/promo-banner.js"></script>
 </body>
 </html>

--- a/contact/index.html
+++ b/contact/index.html
@@ -25,6 +25,11 @@
   </style>
 </head>
 <body class="font-sans text-brand-charcoal antialiased bg-white overflow-x-hidden">
+<div id="promoBanner" class="bg-brand-orange text-white text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
+  <span>Save 10% on your build — pay your deposit by Aug 30. Lock in your slot; go live before peak Q4 scrap season.</span>
+  <a href="https://book.stripe.com/eVqeVd8Vi9U45RbdJy73G00" class="btn-secondary whitespace-nowrap">Pay Deposit →</a>
+  <span data-days-left class="text-xs"></span>
+</div>
   <header class="fixed top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
     <nav class="max-w-7xl mx-auto relative flex items-center justify-between py-3 px-6">
       <a href="/" class="flex items-center gap-2"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-8 w-8"/><span class="site-title text-xl text-brand-charcoal"><span class="font-bold text-brand-orange">Scrapyard</span> <span class="font-bold">Sites</span></span></a>
@@ -174,5 +179,6 @@
   <p>© <span id="year"></span> Scrapyard Sites — All rights reserved.</p>
 </footer>
   <script>document.getElementById('year').textContent=new Date().getFullYear();</script>
+<script src="/assets/promo-banner.js"></script>
 </body>
 </html>

--- a/demos/demo-yard-1/index.html
+++ b/demos/demo-yard-1/index.html
@@ -25,6 +25,11 @@
   </style>
 </head>
 <body class="font-sans text-brand-charcoal antialiased bg-white overflow-x-hidden">
+<div id="promoBanner" class="bg-brand-orange text-white text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
+  <span>Save 10% on your build — pay your deposit by Aug 30. Lock in your slot; go live before peak Q4 scrap season.</span>
+  <a href="https://book.stripe.com/eVqeVd8Vi9U45RbdJy73G00" class="btn-secondary whitespace-nowrap">Pay Deposit →</a>
+  <span data-days-left class="text-xs"></span>
+</div>
   <header class="sticky top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
     <div class="mx-auto max-w-7xl relative flex items-center justify-between px-6 py-3">
       <a href="/" class="flex items-center gap-2">
@@ -95,5 +100,6 @@
     }
   });
   </script>
+<script src="/assets/promo-banner.js"></script>
 </body>
 </html>

--- a/demos/demo-yard-2/index.html
+++ b/demos/demo-yard-2/index.html
@@ -25,6 +25,11 @@
   </style>
 </head>
 <body class="font-sans text-brand-charcoal antialiased bg-white overflow-x-hidden">
+<div id="promoBanner" class="bg-brand-orange text-white text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
+  <span>Save 10% on your build — pay your deposit by Aug 30. Lock in your slot; go live before peak Q4 scrap season.</span>
+  <a href="https://book.stripe.com/eVqeVd8Vi9U45RbdJy73G00" class="btn-secondary whitespace-nowrap">Pay Deposit →</a>
+  <span data-days-left class="text-xs"></span>
+</div>
   <header class="sticky top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
     <div class="mx-auto max-w-7xl relative flex items-center justify-between px-6 py-3">
       <a href="/" class="flex items-center gap-2">
@@ -94,5 +99,6 @@
     }
   });
   </script>
+<script src="/assets/promo-banner.js"></script>
 </body>
 </html>

--- a/demos/demo-yard-3/index.html
+++ b/demos/demo-yard-3/index.html
@@ -25,6 +25,11 @@
   </style>
 </head>
 <body class="font-sans text-brand-charcoal antialiased bg-white overflow-x-hidden">
+<div id="promoBanner" class="bg-brand-orange text-white text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
+  <span>Save 10% on your build — pay your deposit by Aug 30. Lock in your slot; go live before peak Q4 scrap season.</span>
+  <a href="https://book.stripe.com/eVqeVd8Vi9U45RbdJy73G00" class="btn-secondary whitespace-nowrap">Pay Deposit →</a>
+  <span data-days-left class="text-xs"></span>
+</div>
   <header class="sticky top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
     <div class="mx-auto max-w-7xl relative flex items-center justify-between px-6 py-3">
       <a href="/" class="flex items-center gap-2">
@@ -95,5 +100,6 @@
     }
   });
   </script>
+<script src="/assets/promo-banner.js"></script>
 </body>
 </html>

--- a/demos/index.html
+++ b/demos/index.html
@@ -29,6 +29,11 @@
   </style>
 </head>
 <body class="font-sans text-brand-charcoal antialiased bg-white overflow-x-hidden">
+<div id="promoBanner" class="bg-brand-orange text-white text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
+  <span>Save 10% on your build — pay your deposit by Aug 30. Lock in your slot; go live before peak Q4 scrap season.</span>
+  <a href="https://book.stripe.com/eVqeVd8Vi9U45RbdJy73G00" class="btn-secondary whitespace-nowrap">Pay Deposit →</a>
+  <span data-days-left class="text-xs"></span>
+</div>
   <header class="fixed top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
     <nav class="max-w-7xl mx-auto relative flex items-center justify-between py-3 px-6">
       <a href="/" class="flex items-center gap-2"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-8 w-8"/><span class="site-title text-xl text-brand-charcoal"><span class="font-bold text-brand-orange">Scrapyard</span> <span class="font-bold">Sites</span></span></a>
@@ -216,5 +221,6 @@
     initCarousel('demos-carousel');
   }
   </script>
+<script src="/assets/promo-banner.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -168,6 +168,11 @@
 </head>
 
 <body class="font-sans text-brand-charcoal antialiased bg-white overflow-x-hidden">
+<div id="promoBanner" class="bg-brand-orange text-white text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
+  <span>Save 10% on your build — pay your deposit by Aug 30. Lock in your slot; go live before peak Q4 scrap season.</span>
+  <a href="https://book.stripe.com/eVqeVd8Vi9U45RbdJy73G00" class="btn-secondary whitespace-nowrap">Pay Deposit →</a>
+  <span data-days-left class="text-xs"></span>
+</div>
 
 <!-- ── Header ─────────────────────────────────────────────── -->
   <header class="fixed top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
@@ -757,5 +762,6 @@
     initCarousel('pricing-carousel');
   }
 </script>
+<script src="/assets/promo-banner.js"></script>
 </body>
 </html>

--- a/pricing/index.html
+++ b/pricing/index.html
@@ -29,6 +29,11 @@
   </style>
 </head>
 <body class="font-sans text-brand-charcoal antialiased bg-white overflow-x-hidden">
+<div id="promoBanner" class="bg-brand-orange text-white text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
+  <span>Save 10% on your build — pay your deposit by Aug 30. Lock in your slot; go live before peak Q4 scrap season.</span>
+  <a href="https://book.stripe.com/eVqeVd8Vi9U45RbdJy73G00" class="btn-secondary whitespace-nowrap">Pay Deposit →</a>
+  <span data-days-left class="text-xs"></span>
+</div>
   <header class="fixed top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
     <nav class="max-w-7xl mx-auto relative flex items-center justify-between py-3 px-6">
       <a href="/" class="flex items-center gap-2"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-8 w-8"/><span class="site-title text-xl text-brand-charcoal"><span class="font-bold text-brand-orange">Scrapyard</span> <span class="font-bold">Sites</span></span></a>
@@ -236,5 +241,6 @@
   }
   if(window.matchMedia('(max-width: 767px)').matches){initCarousel('pricing-carousel');}
   </script>
+<script src="/assets/promo-banner.js"></script>
 </body>
 </html>

--- a/privacy/index.html
+++ b/privacy/index.html
@@ -90,6 +90,11 @@
 </style>
 </head>
 <body class="font-sans text-brand-charcoal antialiased bg-white overflow-x-hidden">
+<div id="promoBanner" class="bg-brand-orange text-white text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
+  <span>Save 10% on your build — pay your deposit by Aug 30. Lock in your slot; go live before peak Q4 scrap season.</span>
+  <a href="https://book.stripe.com/eVqeVd8Vi9U45RbdJy73G00" class="btn-secondary whitespace-nowrap">Pay Deposit →</a>
+  <span data-days-left class="text-xs"></span>
+</div>
   <header class="fixed top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
     <nav class="max-w-7xl mx-auto relative flex items-center justify-between py-3 px-6">
       <a href="/" class="flex items-center gap-2"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-8 w-8"/><span class="site-title text-xl text-brand-charcoal"><span class="font-bold text-brand-orange">Scrapyard</span> <span class="font-bold">Sites</span></span></a>
@@ -313,5 +318,6 @@
   <script>
     document.getElementById('year').textContent = new Date().getFullYear();
   </script>
+<script src="/assets/promo-banner.js"></script>
 </body>
 </html>

--- a/process/index.html
+++ b/process/index.html
@@ -89,6 +89,11 @@
   </style>
 </head>
 <body class="font-sans text-brand-charcoal antialiased bg-white overflow-x-hidden">
+<div id="promoBanner" class="bg-brand-orange text-white text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
+  <span>Save 10% on your build — pay your deposit by Aug 30. Lock in your slot; go live before peak Q4 scrap season.</span>
+  <a href="https://book.stripe.com/eVqeVd8Vi9U45RbdJy73G00" class="btn-secondary whitespace-nowrap">Pay Deposit →</a>
+  <span data-days-left class="text-xs"></span>
+</div>
   <header class="fixed top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
     <nav class="max-w-7xl w-full mx-auto relative flex items-center justify-between py-3 px-6">
       <a href="/" class="flex items-center gap-2"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-8 w-8"/><span class="site-title text-xl text-brand-charcoal"><span class="font-bold text-brand-orange">Scrapyard</span> <span class="font-bold">Sites</span></span></a>
@@ -389,5 +394,6 @@
   </script>
   <script src="https://unpkg.com/lucide@latest"></script>
   <script>lucide.createIcons();</script>
+<script src="/assets/promo-banner.js"></script>
 </body>
 </html>

--- a/risk-calculator/index.html
+++ b/risk-calculator/index.html
@@ -304,5 +304,6 @@
         document.getElementById("resultBox").classList.remove("hidden");
       });
     </script>
+<script src="/assets/promo-banner.js"></script>
   </body>
 </html>

--- a/services/index.html
+++ b/services/index.html
@@ -78,6 +78,11 @@
   </style>
 </head>
 <body class="font-sans text-brand-charcoal antialiased bg-white overflow-x-hidden">
+<div id="promoBanner" class="bg-brand-orange text-white text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
+  <span>Save 10% on your build — pay your deposit by Aug 30. Lock in your slot; go live before peak Q4 scrap season.</span>
+  <a href="https://book.stripe.com/eVqeVd8Vi9U45RbdJy73G00" class="btn-secondary whitespace-nowrap">Pay Deposit →</a>
+  <span data-days-left class="text-xs"></span>
+</div>
   <header class="fixed top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
     <nav class="max-w-7xl mx-auto relative flex items-center justify-between py-3 px-6">
       <a href="/" class="flex items-center gap-2"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-8 w-8"/><span class="site-title text-xl text-brand-charcoal"><span class="font-bold text-brand-orange">Scrapyard</span> <span class="font-bold">Sites</span></span></a>
@@ -334,5 +339,6 @@
 </script>
   <script src="https://unpkg.com/lucide@latest"></script>
   <script>lucide.createIcons();</script>
+<script src="/assets/promo-banner.js"></script>
 </body>
 </html>

--- a/terms-of-service/index.html
+++ b/terms-of-service/index.html
@@ -29,6 +29,11 @@
   </style>
 </head>
 <body class="font-sans text-brand-charcoal antialiased bg-white overflow-x-hidden">
+<div id="promoBanner" class="bg-brand-orange text-white text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
+  <span>Save 10% on your build — pay your deposit by Aug 30. Lock in your slot; go live before peak Q4 scrap season.</span>
+  <a href="https://book.stripe.com/eVqeVd8Vi9U45RbdJy73G00" class="btn-secondary whitespace-nowrap">Pay Deposit →</a>
+  <span data-days-left class="text-xs"></span>
+</div>
   <header class="fixed top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
     <nav class="max-w-7xl mx-auto relative flex items-center justify-between py-3 px-6">
       <a href="/" class="flex items-center gap-2"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-8 w-8"/><span class="site-title text-xl text-brand-charcoal"><span class="font-bold text-brand-orange">Scrapyard</span> <span class="font-bold">Sites</span></span></a>
@@ -122,5 +127,6 @@
   <script>
     document.getElementById('year').textContent = new Date().getFullYear();
   </script>
+<script src="/assets/promo-banner.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add JS helper for a limited-time promo banner
- show a promotional banner across all pages
- load the helper script site-wide

## Testing
- `grep -R "promo-banner.js" -n | wc -l`

------
https://chatgpt.com/codex/tasks/task_e_688392afd81c832981eed0264ca746e5