### PR TITLE
Fix nav layout and card grid

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -43,12 +43,12 @@
     <nav class="max-w-7xl mx-auto relative flex items-center justify-between py-3 px-6">
       <a href="/" class="flex items-center gap-2"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-8 w-8"/><span class="site-title text-xl text-brand-charcoal"><span class="font-bold text-brand-orange">Scrapyard</span> <span class="font-bold">Sites</span></span></a>
       <!-- Mobile hamburger (≤ 768 px) -->
-      <button id="menuToggle" class="md:hidden p-2">
+      <button id="menuToggle" class="lg:hidden p-2">
         <svg class="icon-open w-6 h-6" viewBox="0 0 24 24" fill="none"><path d="M3 6h18M3 12h18M3 18h18" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
         <svg class="icon-close w-6 h-6" viewBox="0 0 24 24" fill="none"><path d="M6 6l12 12M6 18L18 6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
       </button>
       <!-- Desktop links -->
-      <ul id="menu" class="text-brand-charcoal hidden md:flex md:absolute md:left-1/2 md:-translate-x-1/2 md:inset-y-0 md:items-center gap-6 text-sm font-medium">
+      <ul id="menu" class="text-brand-charcoal hidden lg:flex flex-1 justify-center items-center gap-6 text-sm font-medium">
         <li><a href="/services">Services</a></li>
         <li><a href="/process">Process</a></li>
         <li><a href="/demos">Demos</a></li>
@@ -56,12 +56,12 @@
         <li><a href="/risk-calculator">Calculator</a></li>
         <li><a href="/about">About</a></li>
         <li><a href="/contact">Contact</a></li>
-        <li class="md:hidden"><a href="/contact" class="btn-primary">Book a Discovery Call<span class="cta-subtext">15&nbsp;min • No obligation</span></a></li>
+        <li class="lg:hidden"><a href="/contact" class="btn-primary">Book a Discovery Call</a></li>
       </ul>
-      <a href="/contact" class="btn-primary hidden md:block">Book a Discovery Call<span class="cta-subtext">15&nbsp;min • No obligation</span></a>
+      <a href="/contact" class="btn-primary hidden lg:block">Book a Discovery Call</a>
     </nav>
     <!-- Full-screen mobile menu -->
-    <div id="mobileMenu" class="text-brand-charcoal md:hidden fixed inset-0 z-50 flex flex-col items-center justify-center gap-6 text-xl font-medium bg-white hidden">
+    <div id="mobileMenu" class="text-brand-charcoal lg:hidden fixed inset-0 z-50 flex flex-col items-center justify-center gap-6 text-xl font-medium bg-white hidden">
       <a href="/" class="absolute inset-x-0 top-0 flex justify-center items-center no-highlight"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-20 w-20"/></a>
       <button id="menuClose" class="absolute top-4 right-4 p-2">
         <svg class="w-6 h-6" viewBox="0 0 24 24" fill="none"><path d="M6 6l12 12M6 18L18 6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
@@ -73,7 +73,7 @@
       <a href="/risk-calculator">Calculator</a>
       <a href="/about">About</a>
       <a href="/contact">Contact</a>
-      <a href="/contact" class="btn-primary">Book a Discovery Call<span class="cta-subtext">15&nbsp;min • No obligation</span></a>
+      <a href="/contact" class="btn-primary">Book a Discovery Call</a>
     </div>
   </header>
   <script>
@@ -193,7 +193,6 @@
 </section>
 </main>
 <footer class="bg-white py-8 text-center text-xs text-gray-400">
-  <div class="mb-6"><a href="/contact" class="btn-primary">Book a Discovery Call<span class="cta-subtext">15&nbsp;min • No obligation</span></a></div>
   <nav class="mb-2 flex flex-wrap justify-center gap-x-2 gap-y-1">
     <a href="/">Home</a>
     <a href="/about">About</a>

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -146,7 +146,7 @@ header.fixed {
   display: inline-flex;
 }
 
-@media (min-width: 768px) {
+@media (min-width: 1024px) {
   /* Hide hamburger on desktop */
   #menuToggle { display: none; }
 }
@@ -202,7 +202,7 @@ details summary::marker {
 }
 
 
-@media (max-width: 767px) {
+@media (max-width: 1023px) {
   header nav ul a::after,
   #mobileMenu a:not(.bg-yellow-500)::after,
   .site-title::after {

--- a/blog/index.html
+++ b/blog/index.html
@@ -34,12 +34,12 @@
     <nav class="max-w-7xl mx-auto relative flex items-center justify-between py-3 px-6">
       <a href="/" class="flex items-center gap-2"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-8 w-8"/><span class="site-title text-xl text-brand-charcoal"><span class="font-bold text-brand-orange">Scrapyard</span> <span class="font-bold">Sites</span></span></a>
       <!-- Mobile hamburger (≤ 768 px) -->
-      <button id="menuToggle" class="md:hidden p-2">
+      <button id="menuToggle" class="lg:hidden p-2">
         <svg class="icon-open w-6 h-6" viewBox="0 0 24 24" fill="none"><path d="M3 6h18M3 12h18M3 18h18" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
         <svg class="icon-close w-6 h-6" viewBox="0 0 24 24" fill="none"><path d="M6 6l12 12M6 18L18 6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
       </button>
       <!-- Desktop links -->
-      <ul id="menu" class="text-brand-charcoal hidden md:flex md:absolute md:left-1/2 md:-translate-x-1/2 md:inset-y-0 md:items-center gap-6 text-sm font-medium">
+      <ul id="menu" class="text-brand-charcoal hidden lg:flex flex-1 justify-center items-center gap-6 text-sm font-medium">
         <li><a href="/services">Services</a></li>
         <li><a href="/process">Process</a></li>
         <li><a href="/demos">Demos</a></li>
@@ -48,10 +48,10 @@
         <li><a href="/about">About</a></li>
         <li><a href="/contact">Contact</a></li>
       </ul>
-      <a href="/contact" class="btn-primary hidden md:block">Book a Discovery Call<span class="cta-subtext">15&nbsp;min • No obligation</span></a>
+      <a href="/contact" class="btn-primary hidden lg:block">Book a Discovery Call</a>
     </nav>
     <!-- Full-screen mobile menu -->
-    <div id="mobileMenu" class="text-brand-charcoal md:hidden fixed inset-0 z-50 flex flex-col items-center justify-center gap-6 text-xl font-medium bg-white hidden">
+    <div id="mobileMenu" class="text-brand-charcoal lg:hidden fixed inset-0 z-50 flex flex-col items-center justify-center gap-6 text-xl font-medium bg-white hidden">
       <a href="/" class="absolute inset-x-0 top-0 flex justify-center items-center no-highlight"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-20 w-20"/></a>
       <button id="menuClose" class="absolute top-4 right-4 p-2">
         <svg class="w-6 h-6" viewBox="0 0 24 24" fill="none"><path d="M6 6l12 12M6 18L18 6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
@@ -63,7 +63,7 @@
       <a href="/risk-calculator">Calculator</a>
       <a href="/about">About</a>
       <a href="/contact">Contact</a>
-      <a href="/contact" class="btn-primary">Book a Discovery Call<span class="cta-subtext">15&nbsp;min • No obligation</span></a>
+      <a href="/contact" class="btn-primary">Book a Discovery Call</a>
     </div>
   </header>
   <script>
@@ -145,7 +145,6 @@
     </section>
   </main>
 <footer class="bg-white py-8 text-center text-xs text-gray-400">
-  <div class="mb-6"><a href="/contact" class="btn-primary">Book a Discovery Call<span class="cta-subtext">15&nbsp;min • No obligation</span></a></div>
   <nav class="mb-2 flex flex-wrap justify-center gap-x-2 gap-y-1">
     <a href="/">Home</a>
     <a href="/about">About</a>

--- a/blog/post-template.html
+++ b/blog/post-template.html
@@ -34,12 +34,12 @@
     <nav class="max-w-7xl mx-auto relative flex items-center justify-between py-3 px-6">
       <a href="/" class="flex items-center gap-2"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-8 w-8"/><span class="site-title text-xl text-brand-charcoal"><span class="font-bold text-brand-orange">Scrapyard</span> <span class="font-bold">Sites</span></span></a>
       <!-- Mobile hamburger (≤ 768 px) -->
-      <button id="menuToggle" class="md:hidden p-2">
+      <button id="menuToggle" class="lg:hidden p-2">
         <svg class="icon-open w-6 h-6" viewBox="0 0 24 24" fill="none"><path d="M3 6h18M3 12h18M3 18h18" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
         <svg class="icon-close w-6 h-6" viewBox="0 0 24 24" fill="none"><path d="M6 6l12 12M6 18L18 6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
       </button>
       <!-- Desktop links -->
-      <ul id="menu" class="text-brand-charcoal hidden md:flex md:absolute md:left-1/2 md:-translate-x-1/2 md:inset-y-0 md:items-center gap-6 text-sm font-medium">
+      <ul id="menu" class="text-brand-charcoal hidden lg:flex flex-1 justify-center items-center gap-6 text-sm font-medium">
         <li><a href="/services">Services</a></li>
         <li><a href="/process">Process</a></li>
         <li><a href="/demos">Demos</a></li>
@@ -48,10 +48,10 @@
         <li><a href="/about">About</a></li>
         <li><a href="/contact">Contact</a></li>
       </ul>
-      <a href="/contact" class="btn-primary hidden md:block">Book a Discovery Call<span class="cta-subtext">15&nbsp;min • No obligation</span></a>
+      <a href="/contact" class="btn-primary hidden lg:block">Book a Discovery Call</a>
     </nav>
     <!-- Full-screen mobile menu -->
-    <div id="mobileMenu" class="text-brand-charcoal md:hidden fixed inset-0 z-50 flex flex-col items-center justify-center gap-6 text-xl font-medium bg-white hidden">
+    <div id="mobileMenu" class="text-brand-charcoal lg:hidden fixed inset-0 z-50 flex flex-col items-center justify-center gap-6 text-xl font-medium bg-white hidden">
       <a href="/" class="absolute inset-x-0 top-0 flex justify-center items-center no-highlight"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-20 w-20"/></a>
       <button id="menuClose" class="absolute top-4 right-4 p-2">
         <svg class="w-6 h-6" viewBox="0 0 24 24" fill="none"><path d="M6 6l12 12M6 18L18 6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
@@ -63,7 +63,7 @@
       <a href="/risk-calculator">Calculator</a>
       <a href="/about">About</a>
       <a href="/contact">Contact</a>
-      <a href="/contact" class="btn-primary">Book a Discovery Call<span class="cta-subtext">15&nbsp;min • No obligation</span></a>
+      <a href="/contact" class="btn-primary">Book a Discovery Call</a>
     </div>
   </header>
   <script>
@@ -107,7 +107,6 @@
     </article>
   </main>
 <footer class="bg-white py-8 text-center text-xs text-gray-400">
-  <div class="mb-6"><a href="/contact" class="btn-primary">Book a Discovery Call<span class="cta-subtext">15&nbsp;min • No obligation</span></a></div>
   <nav class="mb-2 flex flex-wrap justify-center gap-x-2 gap-y-1">
     <a href="/">Home</a>
     <a href="/about">About</a>

--- a/blog/posts/care-plan-essentials.html
+++ b/blog/posts/care-plan-essentials.html
@@ -34,12 +34,12 @@
     <nav class="max-w-7xl mx-auto relative flex items-center justify-between py-3 px-6">
       <a href="/" class="flex items-center gap-2"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-8 w-8"/><span class="site-title text-xl text-brand-charcoal"><span class="font-bold text-brand-orange">Scrapyard</span> <span class="font-bold">Sites</span></span></a>
       <!-- Mobile hamburger (≤ 768 px) -->
-      <button id="menuToggle" class="md:hidden p-2">
+      <button id="menuToggle" class="lg:hidden p-2">
         <svg class="icon-open w-6 h-6" viewBox="0 0 24 24" fill="none"><path d="M3 6h18M3 12h18M3 18h18" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
         <svg class="icon-close w-6 h-6" viewBox="0 0 24 24" fill="none"><path d="M6 6l12 12M6 18L18 6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
       </button>
       <!-- Desktop links -->
-      <ul id="menu" class="text-brand-charcoal hidden md:flex md:absolute md:left-1/2 md:-translate-x-1/2 md:inset-y-0 md:items-center gap-6 text-sm font-medium">
+      <ul id="menu" class="text-brand-charcoal hidden lg:flex flex-1 justify-center items-center gap-6 text-sm font-medium">
         <li><a href="/services">Services</a></li>
         <li><a href="/process">Process</a></li>
         <li><a href="/demos">Demos</a></li>
@@ -48,10 +48,10 @@
         <li><a href="/about">About</a></li>
         <li><a href="/contact">Contact</a></li>
       </ul>
-      <a href="/contact" class="btn-primary hidden md:block">Book a Discovery Call<span class="cta-subtext">15&nbsp;min • No obligation</span></a>
+      <a href="/contact" class="btn-primary hidden lg:block">Book a Discovery Call</a>
     </nav>
     <!-- Full-screen mobile menu -->
-    <div id="mobileMenu" class="text-brand-charcoal md:hidden fixed inset-0 z-50 flex flex-col items-center justify-center gap-6 text-xl font-medium bg-white hidden">
+    <div id="mobileMenu" class="text-brand-charcoal lg:hidden fixed inset-0 z-50 flex flex-col items-center justify-center gap-6 text-xl font-medium bg-white hidden">
       <a href="/" class="absolute inset-x-0 top-0 flex justify-center items-center no-highlight"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-20 w-20"/></a>
       <button id="menuClose" class="absolute top-4 right-4 p-2">
         <svg class="w-6 h-6" viewBox="0 0 24 24" fill="none"><path d="M6 6l12 12M6 18L18 6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
@@ -63,7 +63,7 @@
       <a href="/risk-calculator">Calculator</a>
       <a href="/about">About</a>
       <a href="/contact">Contact</a>
-      <a href="/contact" class="btn-primary">Book a Discovery Call<span class="cta-subtext">15&nbsp;min • No obligation</span></a>
+      <a href="/contact" class="btn-primary">Book a Discovery Call</a>
     </div>
   </header>
   <script>
@@ -107,7 +107,6 @@
     </article>
   </main>
 <footer class="bg-white py-8 text-center text-xs text-gray-400">
-  <div class="mb-6"><a href="/contact" class="btn-primary">Book a Discovery Call<span class="cta-subtext">15&nbsp;min • No obligation</span></a></div>
   <nav class="mb-2 flex flex-wrap justify-center gap-x-2 gap-y-1">
     <a href="/">Home</a>
     <a href="/about">About</a>

--- a/blog/posts/pre-qualify-scrap-sellers.html
+++ b/blog/posts/pre-qualify-scrap-sellers.html
@@ -34,12 +34,12 @@
     <nav class="max-w-7xl mx-auto relative flex items-center justify-between py-3 px-6">
       <a href="/" class="flex items-center gap-2"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-8 w-8"/><span class="site-title text-xl text-brand-charcoal"><span class="font-bold text-brand-orange">Scrapyard</span> <span class="font-bold">Sites</span></span></a>
       <!-- Mobile hamburger (≤ 768 px) -->
-      <button id="menuToggle" class="md:hidden p-2">
+      <button id="menuToggle" class="lg:hidden p-2">
         <svg class="icon-open w-6 h-6" viewBox="0 0 24 24" fill="none"><path d="M3 6h18M3 12h18M3 18h18" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
         <svg class="icon-close w-6 h-6" viewBox="0 0 24 24" fill="none"><path d="M6 6l12 12M6 18L18 6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
       </button>
       <!-- Desktop links -->
-      <ul id="menu" class="text-brand-charcoal hidden md:flex md:absolute md:left-1/2 md:-translate-x-1/2 md:inset-y-0 md:items-center gap-6 text-sm font-medium">
+      <ul id="menu" class="text-brand-charcoal hidden lg:flex flex-1 justify-center items-center gap-6 text-sm font-medium">
         <li><a href="/services">Services</a></li>
         <li><a href="/process">Process</a></li>
         <li><a href="/demos">Demos</a></li>
@@ -48,10 +48,10 @@
         <li><a href="/about">About</a></li>
         <li><a href="/contact">Contact</a></li>
       </ul>
-      <a href="/contact" class="btn-primary hidden md:block">Book a Discovery Call<span class="cta-subtext">15&nbsp;min • No obligation</span></a>
+      <a href="/contact" class="btn-primary hidden lg:block">Book a Discovery Call</a>
     </nav>
     <!-- Full-screen mobile menu -->
-    <div id="mobileMenu" class="text-brand-charcoal md:hidden fixed inset-0 z-50 flex flex-col items-center justify-center gap-6 text-xl font-medium bg-white hidden">
+    <div id="mobileMenu" class="text-brand-charcoal lg:hidden fixed inset-0 z-50 flex flex-col items-center justify-center gap-6 text-xl font-medium bg-white hidden">
       <a href="/" class="absolute inset-x-0 top-0 flex justify-center items-center no-highlight"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-20 w-20"/></a>
       <button id="menuClose" class="absolute top-4 right-4 p-2">
         <svg class="w-6 h-6" viewBox="0 0 24 24" fill="none"><path d="M6 6l12 12M6 18L18 6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
@@ -63,7 +63,7 @@
       <a href="/risk-calculator">Calculator</a>
       <a href="/about">About</a>
       <a href="/contact">Contact</a>
-      <a href="/contact" class="btn-primary">Book a Discovery Call<span class="cta-subtext">15&nbsp;min • No obligation</span></a>
+      <a href="/contact" class="btn-primary">Book a Discovery Call</a>
     </div>
   </header>
   <script>
@@ -107,7 +107,6 @@
     </article>
   </main>
 <footer class="bg-white py-8 text-center text-xs text-gray-400">
-  <div class="mb-6"><a href="/contact" class="btn-primary">Book a Discovery Call<span class="cta-subtext">15&nbsp;min • No obligation</span></a></div>
   <nav class="mb-2 flex flex-wrap justify-center gap-x-2 gap-y-1">
     <a href="/">Home</a>
     <a href="/about">About</a>

--- a/blog/posts/seo-basics-for-scrap-yards.html
+++ b/blog/posts/seo-basics-for-scrap-yards.html
@@ -34,12 +34,12 @@
     <nav class="max-w-7xl mx-auto relative flex items-center justify-between py-3 px-6">
       <a href="/" class="flex items-center gap-2"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-8 w-8"/><span class="site-title text-xl text-brand-charcoal"><span class="font-bold text-brand-orange">Scrapyard</span> <span class="font-bold">Sites</span></span></a>
       <!-- Mobile hamburger (≤ 768 px) -->
-      <button id="menuToggle" class="md:hidden p-2">
+      <button id="menuToggle" class="lg:hidden p-2">
         <svg class="icon-open w-6 h-6" viewBox="0 0 24 24" fill="none"><path d="M3 6h18M3 12h18M3 18h18" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
         <svg class="icon-close w-6 h-6" viewBox="0 0 24 24" fill="none"><path d="M6 6l12 12M6 18L18 6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
       </button>
       <!-- Desktop links -->
-      <ul id="menu" class="text-brand-charcoal hidden md:flex md:absolute md:left-1/2 md:-translate-x-1/2 md:inset-y-0 md:items-center gap-6 text-sm font-medium">
+      <ul id="menu" class="text-brand-charcoal hidden lg:flex flex-1 justify-center items-center gap-6 text-sm font-medium">
         <li><a href="/services">Services</a></li>
         <li><a href="/process">Process</a></li>
         <li><a href="/demos">Demos</a></li>
@@ -48,10 +48,10 @@
         <li><a href="/about">About</a></li>
         <li><a href="/contact">Contact</a></li>
       </ul>
-      <a href="/contact" class="btn-primary hidden md:block">Book a Discovery Call<span class="cta-subtext">15&nbsp;min • No obligation</span></a>
+      <a href="/contact" class="btn-primary hidden lg:block">Book a Discovery Call</a>
     </nav>
     <!-- Full-screen mobile menu -->
-    <div id="mobileMenu" class="text-brand-charcoal md:hidden fixed inset-0 z-50 flex flex-col items-center justify-center gap-6 text-xl font-medium bg-white hidden">
+    <div id="mobileMenu" class="text-brand-charcoal lg:hidden fixed inset-0 z-50 flex flex-col items-center justify-center gap-6 text-xl font-medium bg-white hidden">
       <a href="/" class="absolute inset-x-0 top-0 flex justify-center items-center no-highlight"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-20 w-20"/></a>
       <button id="menuClose" class="absolute top-4 right-4 p-2">
         <svg class="w-6 h-6" viewBox="0 0 24 24" fill="none"><path d="M6 6l12 12M6 18L18 6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
@@ -63,7 +63,7 @@
       <a href="/risk-calculator">Calculator</a>
       <a href="/about">About</a>
       <a href="/contact">Contact</a>
-      <a href="/contact" class="btn-primary">Book a Discovery Call<span class="cta-subtext">15&nbsp;min • No obligation</span></a>
+      <a href="/contact" class="btn-primary">Book a Discovery Call</a>
     </div>
   </header>
   <script>
@@ -107,7 +107,6 @@
     </article>
   </main>
 <footer class="bg-white py-8 text-center text-xs text-gray-400">
-  <div class="mb-6"><a href="/contact" class="btn-primary">Book a Discovery Call<span class="cta-subtext">15&nbsp;min • No obligation</span></a></div>
   <nav class="mb-2 flex flex-wrap justify-center gap-x-2 gap-y-1">
     <a href="/">Home</a>
     <a href="/about">About</a>

--- a/contact/index.html
+++ b/contact/index.html
@@ -34,12 +34,12 @@
     <nav class="max-w-7xl mx-auto relative flex items-center justify-between py-3 px-6">
       <a href="/" class="flex items-center gap-2"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-8 w-8"/><span class="site-title text-xl text-brand-charcoal"><span class="font-bold text-brand-orange">Scrapyard</span> <span class="font-bold">Sites</span></span></a>
       <!-- Mobile hamburger (≤ 768 px) -->
-      <button id="menuToggle" class="md:hidden p-2">
+      <button id="menuToggle" class="lg:hidden p-2">
         <svg class="icon-open w-6 h-6" viewBox="0 0 24 24" fill="none"><path d="M3 6h18M3 12h18M3 18h18" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
         <svg class="icon-close w-6 h-6" viewBox="0 0 24 24" fill="none"><path d="M6 6l12 12M6 18L18 6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
       </button>
       <!-- Desktop links -->
-      <ul id="menu" class="text-brand-charcoal hidden md:flex md:absolute md:left-1/2 md:-translate-x-1/2 md:inset-y-0 md:items-center gap-6 text-sm font-medium">
+      <ul id="menu" class="text-brand-charcoal hidden lg:flex flex-1 justify-center items-center gap-6 text-sm font-medium">
         <li><a href="/services">Services</a></li>
         <li><a href="/process">Process</a></li>
         <li><a href="/demos">Demos</a></li>
@@ -48,10 +48,10 @@
         <li><a href="/about">About</a></li>
         <li><a href="/contact">Contact</a></li>
       </ul>
-      <a href="/contact" class="btn-primary hidden md:block">Book a Discovery Call<span class="cta-subtext">15&nbsp;min • No obligation</span></a>
+      <a href="/contact" class="btn-primary hidden lg:block">Book a Discovery Call</a>
     </nav>
     <!-- Full-screen mobile menu -->
-    <div id="mobileMenu" class="text-brand-charcoal md:hidden fixed inset-0 z-50 flex flex-col items-center justify-center gap-6 text-xl font-medium bg-white hidden">
+    <div id="mobileMenu" class="text-brand-charcoal lg:hidden fixed inset-0 z-50 flex flex-col items-center justify-center gap-6 text-xl font-medium bg-white hidden">
       <a href="/" class="absolute inset-x-0 top-0 flex justify-center items-center no-highlight"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-20 w-20"/></a>
       <button id="menuClose" class="absolute top-4 right-4 p-2">
         <svg class="w-6 h-6" viewBox="0 0 24 24" fill="none"><path d="M6 6l12 12M6 18L18 6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
@@ -63,7 +63,7 @@
       <a href="/risk-calculator">Calculator</a>
       <a href="/about">About</a>
       <a href="/contact">Contact</a>
-      <a href="/contact" class="btn-primary">Book a Discovery Call<span class="cta-subtext">15&nbsp;min • No obligation</span></a>
+      <a href="/contact" class="btn-primary">Book a Discovery Call</a>
     </div>
   </header>
   <script>
@@ -163,7 +163,6 @@
     </section>
     </main>
 <footer class="bg-white py-8 text-center text-xs text-gray-400">
-  <div class="mb-6"><a href="/contact" class="btn-primary">Book a Discovery Call<span class="cta-subtext">15&nbsp;min • No obligation</span></a></div>
   <nav class="mb-2 flex flex-wrap justify-center gap-x-2 gap-y-1">
     <a href="/">Home</a>
     <a href="/about">About</a>

--- a/demos/demo-yard-1/index.html
+++ b/demos/demo-yard-1/index.html
@@ -36,7 +36,7 @@
         <img src="/assets/logo.svg" alt="ScrapYardSites logo" class="h-6 w-6 md:h-8 md:w-8"/>
         <span class="site-title text-xl md:text-2xl tracking-tight"><span class="font-bold text-brand-orange">Scrapyard</span> <span class="font-bold">Sites</span></span>
       </a>
-      <nav class="hidden md:flex absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 justify-center items-center gap-8 text-sm font-medium">
+      <nav class="hidden lg:flex absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 justify-center items-center gap-8 text-sm font-medium">
         <a href="/#why" class="text-brand-charcoal hover:text-brand-orange" title="Leaking here? ->">Why Us</a>
         <a href="/demos" class="text-brand-charcoal hover:text-brand-orange" title="Leaking here? ->">Demos</a>
         <a href="/pricing" class="text-brand-charcoal hover:text-brand-orange" title="Leaking here? ->">Pricing</a>

--- a/demos/demo-yard-2/index.html
+++ b/demos/demo-yard-2/index.html
@@ -36,7 +36,7 @@
         <img src="/assets/logo.svg" alt="ScrapYardSites logo" class="h-6 w-6 md:h-8 md:w-8"/>
         <span class="site-title text-xl md:text-2xl tracking-tight"><span class="font-bold text-brand-orange">Scrapyard</span> <span class="font-bold">Sites</span></span>
       </a>
-      <nav class="hidden md:flex absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 justify-center items-center gap-8 text-sm font-medium">
+      <nav class="hidden lg:flex absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 justify-center items-center gap-8 text-sm font-medium">
         <a href="/#why" class="text-brand-charcoal hover:text-brand-orange" title="Leaking here? ->">Why Us</a>
         <a href="/demos" class="text-brand-charcoal hover:text-brand-orange" title="Leaking here? ->">Demos</a>
         <a href="/pricing" class="text-brand-charcoal hover:text-brand-orange" title="Leaking here? ->">Pricing</a>

--- a/demos/demo-yard-3/index.html
+++ b/demos/demo-yard-3/index.html
@@ -36,7 +36,7 @@
         <img src="/assets/logo.svg" alt="ScrapYardSites logo" class="h-6 w-6 md:h-8 md:w-8"/>
         <span class="site-title text-xl md:text-2xl tracking-tight"><span class="font-bold text-brand-orange">Scrapyard</span> <span class="font-bold">Sites</span></span>
       </a>
-      <nav class="hidden md:flex absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 justify-center items-center gap-8 text-sm font-medium">
+      <nav class="hidden lg:flex absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 justify-center items-center gap-8 text-sm font-medium">
         <a href="/#why" class="text-brand-charcoal hover:text-brand-orange" title="Leaking here? ->">Why Us</a>
         <a href="/demos" class="text-brand-charcoal hover:text-brand-orange" title="Leaking here? ->">Demos</a>
         <a href="/pricing" class="text-brand-charcoal hover:text-brand-orange" title="Leaking here? ->">Pricing</a>

--- a/demos/index.html
+++ b/demos/index.html
@@ -38,12 +38,12 @@
     <nav class="max-w-7xl mx-auto relative flex items-center justify-between py-3 px-6">
       <a href="/" class="flex items-center gap-2"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-8 w-8"/><span class="site-title text-xl text-brand-charcoal"><span class="font-bold text-brand-orange">Scrapyard</span> <span class="font-bold">Sites</span></span></a>
       <!-- Mobile hamburger (≤ 768 px) -->
-      <button id="menuToggle" class="md:hidden p-2">
+      <button id="menuToggle" class="lg:hidden p-2">
         <svg class="icon-open w-6 h-6" viewBox="0 0 24 24" fill="none"><path d="M3 6h18M3 12h18M3 18h18" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
         <svg class="icon-close w-6 h-6" viewBox="0 0 24 24" fill="none"><path d="M6 6l12 12M6 18L18 6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
       </button>
       <!-- Desktop links -->
-      <ul id="menu" class="text-brand-charcoal hidden md:flex md:absolute md:left-1/2 md:-translate-x-1/2 md:inset-y-0 md:items-center gap-6 text-sm font-medium">
+      <ul id="menu" class="text-brand-charcoal hidden lg:flex flex-1 justify-center items-center gap-6 text-sm font-medium">
         <li><a href="/services">Services</a></li>
         <li><a href="/process">Process</a></li>
         <li><a href="/demos">Demos</a></li>
@@ -52,10 +52,10 @@
         <li><a href="/about">About</a></li>
         <li><a href="/contact">Contact</a></li>
       </ul>
-      <a href="/contact" class="btn-primary hidden md:block">Book a Discovery Call<span class="cta-subtext">15&nbsp;min • No obligation</span></a>
+      <a href="/contact" class="btn-primary hidden lg:block">Book a Discovery Call</a>
     </nav>
     <!-- Full-screen mobile menu -->
-    <div id="mobileMenu" class="text-brand-charcoal md:hidden fixed inset-0 z-50 flex flex-col items-center justify-center gap-6 text-xl font-medium bg-white hidden">
+    <div id="mobileMenu" class="text-brand-charcoal lg:hidden fixed inset-0 z-50 flex flex-col items-center justify-center gap-6 text-xl font-medium bg-white hidden">
       <a href="/" class="absolute inset-x-0 top-0 flex justify-center items-center no-highlight"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-20 w-20"/></a>
       <button id="menuClose" class="absolute top-4 right-4 p-2">
         <svg class="w-6 h-6" viewBox="0 0 24 24" fill="none"><path d="M6 6l12 12M6 18L18 6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
@@ -67,7 +67,7 @@
       <a href="/risk-calculator">Calculator</a>
       <a href="/about">About</a>
       <a href="/contact">Contact</a>
-      <a href="/contact" class="btn-primary">Book a Discovery Call<span class="cta-subtext">15&nbsp;min • No obligation</span></a>
+      <a href="/contact" class="btn-primary">Book a Discovery Call</a>
     </div>
   </header>
   <script>
@@ -166,7 +166,6 @@
       </section>
     </main>
 <footer class="bg-white py-8 text-center text-xs text-gray-400">
-  <div class="mb-6"><a href="/contact" class="btn-primary">Book a Discovery Call<span class="cta-subtext">15&nbsp;min • No obligation</span></a></div>
   <nav class="mb-2 flex flex-wrap justify-center gap-x-2 gap-y-1">
     <a href="/">Home</a>
     <a href="/about">About</a>

--- a/index.html
+++ b/index.html
@@ -179,12 +179,12 @@
     <nav class="max-w-7xl mx-auto relative flex items-center justify-between py-3 px-6">
       <a href="/" class="flex items-center gap-2"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-8 w-8"/><span class="site-title text-xl text-brand-charcoal"><span class="font-bold text-brand-orange">Scrapyard</span> <span class="font-bold">Sites</span></span></a>
       <!-- Mobile hamburger (≤ 768 px) -->
-      <button id="menuToggle" class="md:hidden p-2">
+      <button id="menuToggle" class="lg:hidden p-2">
         <svg class="icon-open w-6 h-6" viewBox="0 0 24 24" fill="none"><path d="M3 6h18M3 12h18M3 18h18" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
         <svg class="icon-close w-6 h-6" viewBox="0 0 24 24" fill="none"><path d="M6 6l12 12M6 18L18 6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
       </button>
       <!-- Desktop links -->
-      <ul id="menu" class="text-brand-charcoal hidden md:flex md:absolute md:left-1/2 md:-translate-x-1/2 md:inset-y-0 md:items-center gap-6 text-sm font-medium">
+      <ul id="menu" class="text-brand-charcoal hidden lg:flex flex-1 justify-center items-center gap-6 text-sm font-medium">
         <li><a href="/services">Services</a></li>
         <li><a href="/process">Process</a></li>
         <li><a href="/demos">Demos</a></li>
@@ -193,10 +193,10 @@
         <li><a href="/about">About</a></li>
         <li><a href="/contact">Contact</a></li>
       </ul>
-      <a href="/contact" class="btn-primary hidden md:block">Book a Discovery Call<span class="cta-subtext">15&nbsp;min • No obligation</span></a>
+      <a href="/contact" class="btn-primary hidden lg:block">Book a Discovery Call</a>
     </nav>
     <!-- Full-screen mobile menu -->
-    <div id="mobileMenu" class="text-brand-charcoal md:hidden fixed inset-0 z-50 flex flex-col items-center justify-center gap-6 text-xl font-medium bg-white hidden">
+    <div id="mobileMenu" class="text-brand-charcoal lg:hidden fixed inset-0 z-50 flex flex-col items-center justify-center gap-6 text-xl font-medium bg-white hidden">
       <a href="/" class="absolute inset-x-0 top-0 flex justify-center items-center no-highlight"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-20 w-20"/></a>
       <button id="menuClose" class="absolute top-4 right-4 p-2">
         <svg class="w-6 h-6" viewBox="0 0 24 24" fill="none"><path d="M6 6l12 12M6 18L18 6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
@@ -208,7 +208,7 @@
       <a href="/risk-calculator">Calculator</a>
       <a href="/about">About</a>
       <a href="/contact">Contact</a>
-      <a href="/contact" class="btn-primary">Book a Discovery Call<span class="cta-subtext">15&nbsp;min • No obligation</span></a>
+      <a href="/contact" class="btn-primary">Book a Discovery Call</a>
     </div>
   </header>
   <script>
@@ -333,7 +333,7 @@
   </div>
 </section>
 <!-- ── Reputation Section ──────────────────────────────────────────────── -->
-<section class="py-20 bg-gray-50 hidden md:block">
+<section class="py-20 bg-gray-50 hidden lg:block">
   <div class="max-w-6xl mx-auto px-6 text-center">
     <!-- Headline and intro -->
     <h2 class="text-4xl md:text-5xl font-extrabold text-gray-900 mb-4" data-aos="fade-up">
@@ -434,7 +434,7 @@
           </div>
         </div>
       </div>
-      <div class="hidden md:flex md:col-span-2 text-center mt-12 flex-col items-center justify-center py-4">
+      <div class="hidden lg:flex md:col-span-2 text-center mt-12 flex-col items-center justify-center py-4">
         <p class="mt-6 text-lg text-gray-700 max-w-3xl mx-auto mb-6" data-aos="fade-up">
           When your reputation is reinforced online, trust goes up and so do your loads. Engage visitors, collect quotes, and become the yard drivers choose every time.
         </p>
@@ -448,7 +448,7 @@
 <section id="work" class="scroll-mt-16 bg-white py-20">
   <div class="mx-auto max-w-6xl px-6 text-center">
     <h2 class="text-3xl font-bold mb-10">Demo Yards</h2>
-    <div id="portfolio-carousel" class="carousel-track flex px-4 md:grid md:grid-cols-1 lg:grid-cols-3 gap-8">
+    <div id="portfolio-carousel" class="carousel-track flex px-4 md:grid md:grid-cols-3 lg:grid-cols-3 gap-8">
       <!-- Demo project cards -->
       <a href="#contact" class="carousel-item block bg-gray-50 border border-brand-steel/10 rounded-xl shadow-sm p-10 flex flex-col items-center text-center hover:bg-gray-100 hover:shadow-lg transition transform hover:-translate-y-1 hover:cursor-pointer">
         <div class="w-full rounded-xl overflow-hidden border border-brand-steel/10">
@@ -507,11 +507,11 @@
       No hidden fees, no “call for quote”. You’ll know the cost before we write a line of code.
     </p>
 
-    <div id="pricing-carousel" class="carousel-track flex gap-10 px-4 mt-14 md:grid md:grid-cols-1 lg:grid-cols-3 relative z-40">
+    <div id="pricing-carousel" class="carousel-track flex gap-10 px-4 mt-14 md:grid md:grid-cols-3 relative z-40">
       <!-- Launch -->
       <div class="carousel-item relative z-30 overflow-visible bg-gray-50 border border-brand-steel/10 rounded-xl shadow-sm transition transform hover:-translate-y-1 px-6 py-10 md:p-10">
         <span
-          class="hidden md:block mx-auto mb-4 md:absolute md:mb-0 md:-top-3 md:left-1/2 md:-translate-x-1/2 transform bg-brand-orange text-white text-xs font-semibold px-3 py-1 rounded-full shadow whitespace-nowrap z-10 pointer-events-none"
+          class="hidden lg:block mx-auto mb-4 md:absolute md:mb-0 md:-top-3 md:left-1/2 md:-translate-x-1/2 transform bg-brand-orange text-white text-xs font-semibold px-3 py-1 rounded-full shadow whitespace-nowrap z-10 pointer-events-none"
           style="background-color:#D75E02">
           Most yards start here
         </span>
@@ -661,7 +661,6 @@
 
 <!-- ── Footer ──────────────────────────────────────────────── -->
 <footer class="bg-white py-8 text-center text-xs text-gray-400">
-  <div class="mb-6"><a href="/contact" class="btn-primary">Book a Discovery Call<span class="cta-subtext">15&nbsp;min • No obligation</span></a></div>
   <nav class="mb-2 flex flex-wrap justify-center gap-x-2 gap-y-1">
     <a href="/">Home</a>
     <a href="/about">About</a>

--- a/pricing/index.html
+++ b/pricing/index.html
@@ -38,12 +38,12 @@
     <nav class="max-w-7xl mx-auto relative flex items-center justify-between py-3 px-6">
       <a href="/" class="flex items-center gap-2"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-8 w-8"/><span class="site-title text-xl text-brand-charcoal"><span class="font-bold text-brand-orange">Scrapyard</span> <span class="font-bold">Sites</span></span></a>
       <!-- Mobile hamburger (≤ 768 px) -->
-      <button id="menuToggle" class="md:hidden p-2">
+      <button id="menuToggle" class="lg:hidden p-2">
         <svg class="icon-open w-6 h-6" viewBox="0 0 24 24" fill="none"><path d="M3 6h18M3 12h18M3 18h18" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
         <svg class="icon-close w-6 h-6" viewBox="0 0 24 24" fill="none"><path d="M6 6l12 12M6 18L18 6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
       </button>
       <!-- Desktop links -->
-      <ul id="menu" class="text-brand-charcoal hidden md:flex md:absolute md:left-1/2 md:-translate-x-1/2 md:inset-y-0 md:items-center gap-6 text-sm font-medium">
+      <ul id="menu" class="text-brand-charcoal hidden lg:flex flex-1 justify-center items-center gap-6 text-sm font-medium">
         <li><a href="/services">Services</a></li>
         <li><a href="/process">Process</a></li>
         <li><a href="/demos">Demos</a></li>
@@ -52,10 +52,10 @@
         <li><a href="/about">About</a></li>
         <li><a href="/contact">Contact</a></li>
       </ul>
-      <a href="/contact" class="btn-primary hidden md:block">Book a Discovery Call<span class="cta-subtext">15&nbsp;min • No obligation</span></a>
+      <a href="/contact" class="btn-primary hidden lg:block">Book a Discovery Call</a>
     </nav>
     <!-- Full-screen mobile menu -->
-    <div id="mobileMenu" class="text-brand-charcoal md:hidden fixed inset-0 z-50 flex flex-col items-center justify-center gap-6 text-xl font-medium bg-white hidden">
+    <div id="mobileMenu" class="text-brand-charcoal lg:hidden fixed inset-0 z-50 flex flex-col items-center justify-center gap-6 text-xl font-medium bg-white hidden">
       <a href="/" class="absolute inset-x-0 top-0 flex justify-center items-center no-highlight"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-20 w-20"/></a>
       <button id="menuClose" class="absolute top-4 right-4 p-2">
         <svg class="w-6 h-6" viewBox="0 0 24 24" fill="none"><path d="M6 6l12 12M6 18L18 6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
@@ -67,7 +67,7 @@
       <a href="/risk-calculator">Calculator</a>
       <a href="/about">About</a>
       <a href="/contact">Contact</a>
-      <a href="/contact" class="btn-primary">Book a Discovery Call<span class="cta-subtext">15&nbsp;min • No obligation</span></a>
+      <a href="/contact" class="btn-primary">Book a Discovery Call</a>
     </div>
   </header>
   <script>
@@ -115,11 +115,11 @@
     <section class="pt-20 pb-0 bg-white" id="packages">
       <div class="mx-auto max-w-6xl px-6 text-center">
         <h2 class="text-3xl font-bold mb-8">Service Pricing</h2>
-        <div id="pricing-carousel" class="carousel-track flex gap-10 px-4 mt-14 md:grid md:grid-cols-1 lg:grid-cols-3 relative z-40">
+        <div id="pricing-carousel" class="carousel-track flex gap-10 px-4 mt-14 md:grid md:grid-cols-3 relative z-40">
           <!-- Launch -->
           <div class="carousel-item relative z-30 overflow-visible bg-gray-50 border border-brand-steel/10 rounded-xl shadow-sm transition transform hover:-translate-y-1 px-6 py-10 md:p-10 flex flex-col">
             <span
-              class="hidden md:block mx-auto mb-4 md:absolute md:mb-0 md:-top-3 md:left-1/2 md:-translate-x-1/2 transform bg-brand-orange text-white text-xs font-semibold px-3 py-1 rounded-full shadow whitespace-nowrap z-10 pointer-events-none"
+              class="hidden lg:block mx-auto mb-4 md:absolute md:mb-0 md:-top-3 md:left-1/2 md:-translate-x-1/2 transform bg-brand-orange text-white text-xs font-semibold px-3 py-1 rounded-full shadow whitespace-nowrap z-10 pointer-events-none"
               style="background-color:#D75E02">
               Most yards start here
             </span>
@@ -212,7 +212,6 @@
     </section>
   </main>
 <footer class="bg-white py-8 text-center text-xs text-gray-400">
-  <div class="mb-6"><a href="/contact" class="btn-primary">Book a Discovery Call<span class="cta-subtext">15&nbsp;min • No obligation</span></a></div>
   <nav class="mb-2 flex flex-wrap justify-center gap-x-2 gap-y-1">
     <a href="/">Home</a>
     <a href="/about">About</a>

--- a/privacy/index.html
+++ b/privacy/index.html
@@ -99,12 +99,12 @@
     <nav class="max-w-7xl mx-auto relative flex items-center justify-between py-3 px-6">
       <a href="/" class="flex items-center gap-2"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-8 w-8"/><span class="site-title text-xl text-brand-charcoal"><span class="font-bold text-brand-orange">Scrapyard</span> <span class="font-bold">Sites</span></span></a>
       <!-- Mobile hamburger (≤ 768 px) -->
-      <button id="menuToggle" class="md:hidden p-2">
+      <button id="menuToggle" class="lg:hidden p-2">
         <svg class="icon-open w-6 h-6" viewBox="0 0 24 24" fill="none"><path d="M3 6h18M3 12h18M3 18h18" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
         <svg class="icon-close w-6 h-6" viewBox="0 0 24 24" fill="none"><path d="M6 6l12 12M6 18L18 6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
       </button>
       <!-- Desktop links -->
-      <ul id="menu" class="text-brand-charcoal hidden md:flex md:absolute md:left-1/2 md:-translate-x-1/2 md:inset-y-0 md:items-center gap-6 text-sm font-medium">
+      <ul id="menu" class="text-brand-charcoal hidden lg:flex flex-1 justify-center items-center gap-6 text-sm font-medium">
         <li><a href="/services">Services</a></li>
         <li><a href="/process">Process</a></li>
         <li><a href="/demos">Demos</a></li>
@@ -113,10 +113,10 @@
         <li><a href="/about">About</a></li>
         <li><a href="/contact">Contact</a></li>
       </ul>
-      <a href="/contact" class="btn-primary hidden md:block">Book a Discovery Call<span class="cta-subtext">15&nbsp;min • No obligation</span></a>
+      <a href="/contact" class="btn-primary hidden lg:block">Book a Discovery Call</a>
     </nav>
     <!-- Full-screen mobile menu -->
-    <div id="mobileMenu" class="text-brand-charcoal md:hidden fixed inset-0 z-50 flex flex-col items-center justify-center gap-6 text-xl font-medium bg-white hidden">
+    <div id="mobileMenu" class="text-brand-charcoal lg:hidden fixed inset-0 z-50 flex flex-col items-center justify-center gap-6 text-xl font-medium bg-white hidden">
       <a href="/" class="absolute inset-x-0 top-0 flex justify-center items-center no-highlight"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-20 w-20"/></a>
       <button id="menuClose" class="absolute top-4 right-4 p-2">
         <svg class="w-6 h-6" viewBox="0 0 24 24" fill="none"><path d="M6 6l12 12M6 18L18 6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
@@ -128,7 +128,7 @@
       <a href="/risk-calculator">Calculator</a>
       <a href="/about">About</a>
       <a href="/contact">Contact</a>
-      <a href="/contact" class="btn-primary">Book a Discovery Call<span class="cta-subtext">15&nbsp;min • No obligation</span></a>
+      <a href="/contact" class="btn-primary">Book a Discovery Call</a>
     </div>
   </header>
   <script>
@@ -299,7 +299,6 @@
   </main>
 
 <footer class="bg-white py-8 text-center text-xs text-gray-400">
-  <div class="mb-6"><a href="/contact" class="btn-primary">Book a Discovery Call<span class="cta-subtext">15&nbsp;min • No obligation</span></a></div>
   <nav class="mb-2 flex flex-wrap justify-center gap-x-2 gap-y-1">
     <a href="/">Home</a>
     <a href="/about">About</a>

--- a/process/index.html
+++ b/process/index.html
@@ -98,12 +98,12 @@
     <nav class="max-w-7xl w-full mx-auto relative flex items-center justify-between py-3 px-6">
       <a href="/" class="flex items-center gap-2"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-8 w-8"/><span class="site-title text-xl text-brand-charcoal"><span class="font-bold text-brand-orange">Scrapyard</span> <span class="font-bold">Sites</span></span></a>
       <!-- Mobile hamburger (≤ 768 px) -->
-      <button id="menuToggle" class="md:hidden p-2">
+      <button id="menuToggle" class="lg:hidden p-2">
         <svg class="icon-open w-6 h-6" viewBox="0 0 24 24" fill="none"><path d="M3 6h18M3 12h18M3 18h18" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
         <svg class="icon-close w-6 h-6" viewBox="0 0 24 24" fill="none"><path d="M6 6l12 12M6 18L18 6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
       </button>
       <!-- Desktop links -->
-      <ul id="menu" class="text-brand-charcoal hidden md:flex md:absolute md:left-1/2 md:-translate-x-1/2 md:inset-y-0 md:items-center gap-6 text-sm font-medium">
+      <ul id="menu" class="text-brand-charcoal hidden lg:flex flex-1 justify-center items-center gap-6 text-sm font-medium">
         <li><a href="/services">Services</a></li>
         <li><a href="/process">Process</a></li>
         <li><a href="/demos">Demos</a></li>
@@ -112,10 +112,10 @@
         <li><a href="/about">About</a></li>
         <li><a href="/contact">Contact</a></li>
       </ul>
-      <a href="/contact" class="btn-primary hidden md:block">Book a Discovery Call<span class="cta-subtext">15&nbsp;min • No obligation</span></a>
+      <a href="/contact" class="btn-primary hidden lg:block">Book a Discovery Call</a>
     </nav>
     <!-- Full-screen mobile menu -->
-    <div id="mobileMenu" class="text-brand-charcoal md:hidden fixed inset-0 z-50 flex flex-col items-center justify-center gap-6 text-xl font-medium bg-white hidden">
+    <div id="mobileMenu" class="text-brand-charcoal lg:hidden fixed inset-0 z-50 flex flex-col items-center justify-center gap-6 text-xl font-medium bg-white hidden">
       <a href="/" class="absolute inset-x-0 top-0 flex justify-center items-center no-highlight"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-20 w-20"/></a>
       <button id="menuClose" class="absolute top-4 right-4 p-2">
         <svg class="w-6 h-6" viewBox="0 0 24 24" fill="none"><path d="M6 6l12 12M6 18L18 6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
@@ -127,7 +127,7 @@
       <a href="/risk-calculator">Calculator</a>
       <a href="/about">About</a>
       <a href="/contact">Contact</a>
-      <a href="/contact" class="btn-primary">Book a Discovery Call<span class="cta-subtext">15&nbsp;min • No obligation</span></a>
+      <a href="/contact" class="btn-primary">Book a Discovery Call</a>
     </div>
   </header>
   <script>
@@ -339,7 +339,6 @@
     </section>
   </main>
 <footer class="bg-white py-8 text-center text-xs text-gray-400">
-  <div class="mb-6"><a href="/contact" class="btn-primary">Book a Discovery Call<span class="cta-subtext">15&nbsp;min • No obligation</span></a></div>
   <nav class="mb-2 flex flex-wrap justify-center gap-x-2 gap-y-1">
     <a href="/">Home</a>
     <a href="/about">About</a>

--- a/risk-calculator/index.html
+++ b/risk-calculator/index.html
@@ -103,7 +103,7 @@
           ></a
         >
         <!-- Mobile hamburger (≤ 768 px) -->
-        <button id="menuToggle" class="md:hidden p-2">
+        <button id="menuToggle" class="lg:hidden p-2">
           <svg class="icon-open w-6 h-6" viewBox="0 0 24 24" fill="none">
             <path
               d="M3 6h18M3 12h18M3 18h18"
@@ -126,7 +126,7 @@
         <!-- Desktop links -->
         <ul
           id="menu"
-          class="text-brand-charcoal hidden md:flex md:absolute md:left-1/2 md:-translate-x-1/2 md:inset-y-0 md:items-center gap-6 text-sm font-medium"
+          class="text-brand-charcoal hidden lg:flex flex-1 justify-center items-center gap-6 text-sm font-medium"
         >
           <li><a href="/services">Services</a></li>
           <li><a href="/process">Process</a></li>
@@ -136,12 +136,12 @@
           <li><a href="/about">About</a></li>
           <li><a href="/contact">Contact</a></li>
         </ul>
-        <a href="/contact" class="btn-primary hidden md:block">Book a Discovery Call<span class="cta-subtext">15&nbsp;min • No obligation</span></a>
+        <a href="/contact" class="btn-primary hidden lg:block">Book a Discovery Call</a>
       </nav>
       <!-- Full-screen mobile menu -->
       <div
         id="mobileMenu"
-        class="text-brand-charcoal md:hidden fixed inset-0 z-50 flex flex-col items-center justify-center gap-6 text-xl font-medium bg-white hidden"
+        class="text-brand-charcoal lg:hidden fixed inset-0 z-50 flex flex-col items-center justify-center gap-6 text-xl font-medium bg-white hidden"
       >
         <a
           href="/"
@@ -169,7 +169,7 @@
         <a href="/risk-calculator">Calculator</a>
         <a href="/about">About</a>
         <a href="/contact">Contact</a>
-        <a href="/contact" class="btn-primary">Book a Discovery Call<span class="cta-subtext">15&nbsp;min • No obligation</span></a>
+        <a href="/contact" class="btn-primary">Book a Discovery Call</a>
       </div>
     </header>
     <script>
@@ -259,7 +259,6 @@
       </section>
     </main>
     <footer class="bg-white py-8 text-center text-xs text-gray-400">
-  <div class="mb-6"><a href="/contact" class="btn-primary">Book a Discovery Call<span class="cta-subtext">15&nbsp;min • No obligation</span></a></div>
       <nav class="mb-2 flex flex-wrap justify-center gap-x-2 gap-y-1">
         <a href="/">Home</a>
         <a href="/about">About</a>

--- a/services/index.html
+++ b/services/index.html
@@ -87,12 +87,12 @@
     <nav class="max-w-7xl mx-auto relative flex items-center justify-between py-3 px-6">
       <a href="/" class="flex items-center gap-2"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-8 w-8"/><span class="site-title text-xl text-brand-charcoal"><span class="font-bold text-brand-orange">Scrapyard</span> <span class="font-bold">Sites</span></span></a>
       <!-- Mobile hamburger (≤ 768 px) -->
-      <button id="menuToggle" class="md:hidden p-2">
+      <button id="menuToggle" class="lg:hidden p-2">
         <svg class="icon-open w-6 h-6" viewBox="0 0 24 24" fill="none"><path d="M3 6h18M3 12h18M3 18h18" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
         <svg class="icon-close w-6 h-6" viewBox="0 0 24 24" fill="none"><path d="M6 6l12 12M6 18L18 6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
       </button>
       <!-- Desktop links -->
-      <ul id="menu" class="text-brand-charcoal hidden md:flex md:absolute md:left-1/2 md:-translate-x-1/2 md:inset-y-0 md:items-center gap-6 text-sm font-medium">
+      <ul id="menu" class="text-brand-charcoal hidden lg:flex flex-1 justify-center items-center gap-6 text-sm font-medium">
         <li><a href="/services">Services</a></li>
         <li><a href="/process">Process</a></li>
         <li><a href="/demos">Demos</a></li>
@@ -101,10 +101,10 @@
         <li><a href="/about">About</a></li>
         <li><a href="/contact">Contact</a></li>
       </ul>
-      <a href="/contact" class="btn-primary hidden md:block">Book a Discovery Call<span class="cta-subtext">15&nbsp;min • No obligation</span></a>
+      <a href="/contact" class="btn-primary hidden lg:block">Book a Discovery Call</a>
     </nav>
     <!-- Full-screen mobile menu -->
-    <div id="mobileMenu" class="text-brand-charcoal md:hidden fixed inset-0 z-50 flex flex-col items-center justify-center gap-6 text-xl font-medium bg-white hidden">
+    <div id="mobileMenu" class="text-brand-charcoal lg:hidden fixed inset-0 z-50 flex flex-col items-center justify-center gap-6 text-xl font-medium bg-white hidden">
       <a href="/" class="absolute inset-x-0 top-0 flex justify-center items-center no-highlight"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-20 w-20"/></a>
       <button id="menuClose" class="absolute top-4 right-4 p-2">
         <svg class="w-6 h-6" viewBox="0 0 24 24" fill="none"><path d="M6 6l12 12M6 18L18 6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
@@ -116,7 +116,7 @@
       <a href="/risk-calculator">Calculator</a>
       <a href="/about">About</a>
       <a href="/contact">Contact</a>
-      <a href="/contact" class="btn-primary">Book a Discovery Call<span class="cta-subtext">15&nbsp;min • No obligation</span></a>
+      <a href="/contact" class="btn-primary">Book a Discovery Call</a>
     </div>
   </header>
   <script>
@@ -272,7 +272,6 @@
     </section>
   </main>
   <footer class="bg-white py-8 text-center text-xs text-gray-400">
-  <div class="mb-6"><a href="/contact" class="btn-primary">Book a Discovery Call<span class="cta-subtext">15&nbsp;min • No obligation</span></a></div>
       <nav class="mb-2 flex flex-wrap justify-center gap-x-2 gap-y-1">
       <a href="/">Home</a>
       <a href="/about">About</a>

--- a/terms-of-service/index.html
+++ b/terms-of-service/index.html
@@ -38,12 +38,12 @@
     <nav class="max-w-7xl mx-auto relative flex items-center justify-between py-3 px-6">
       <a href="/" class="flex items-center gap-2"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-8 w-8"/><span class="site-title text-xl text-brand-charcoal"><span class="font-bold text-brand-orange">Scrapyard</span> <span class="font-bold">Sites</span></span></a>
       <!-- Mobile hamburger (≤ 768 px) -->
-      <button id="menuToggle" class="md:hidden p-2">
+      <button id="menuToggle" class="lg:hidden p-2">
         <svg class="icon-open w-6 h-6" viewBox="0 0 24 24" fill="none"><path d="M3 6h18M3 12h18M3 18h18" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
         <svg class="icon-close w-6 h-6" viewBox="0 0 24 24" fill="none"><path d="M6 6l12 12M6 18L18 6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
       </button>
       <!-- Desktop links -->
-      <ul id="menu" class="text-brand-charcoal hidden md:flex md:absolute md:left-1/2 md:-translate-x-1/2 md:inset-y-0 md:items-center gap-6 text-sm font-medium">
+      <ul id="menu" class="text-brand-charcoal hidden lg:flex flex-1 justify-center items-center gap-6 text-sm font-medium">
         <li><a href="/services">Services</a></li>
         <li><a href="/process">Process</a></li>
         <li><a href="/demos">Demos</a></li>
@@ -52,10 +52,10 @@
         <li><a href="/about">About</a></li>
         <li><a href="/contact">Contact</a></li>
       </ul>
-      <a href="/contact" class="btn-primary hidden md:block">Book a Discovery Call<span class="cta-subtext">15&nbsp;min • No obligation</span></a>
+      <a href="/contact" class="btn-primary hidden lg:block">Book a Discovery Call</a>
     </nav>
     <!-- Full-screen mobile menu -->
-    <div id="mobileMenu" class="text-brand-charcoal md:hidden fixed inset-0 z-50 flex flex-col items-center justify-center gap-6 text-xl font-medium bg-white hidden">
+    <div id="mobileMenu" class="text-brand-charcoal lg:hidden fixed inset-0 z-50 flex flex-col items-center justify-center gap-6 text-xl font-medium bg-white hidden">
       <a href="/" class="absolute inset-x-0 top-0 flex justify-center items-center no-highlight"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-20 w-20"/></a>
       <button id="menuClose" class="absolute top-4 right-4 p-2">
         <svg class="w-6 h-6" viewBox="0 0 24 24" fill="none"><path d="M6 6l12 12M6 18L18 6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
@@ -67,7 +67,7 @@
       <a href="/risk-calculator">Calculator</a>
       <a href="/about">About</a>
       <a href="/contact">Contact</a>
-      <a href="/contact" class="btn-primary">Book a Discovery Call<span class="cta-subtext">15&nbsp;min • No obligation</span></a>
+      <a href="/contact" class="btn-primary">Book a Discovery Call</a>
     </div>
   </header>
   <script>
@@ -108,7 +108,6 @@
   </main>
 
 <footer class="bg-white py-8 text-center text-xs text-gray-400">
-  <div class="mb-6"><a href="/contact" class="btn-primary">Book a Discovery Call<span class="cta-subtext">15&nbsp;min • No obligation</span></a></div>
   <nav class="mb-2 flex flex-wrap justify-center gap-x-2 gap-y-1">
     <a href="/">Home</a>
     <a href="/about">About</a>


### PR DESCRIPTION
## Summary
- adjust nav link classes for consistent alignment
- remove CTA subtext from the nav bar
- remove footer CTAs
- keep grid layout for home page cards
- bump hamburger breakpoint to `lg`

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6883ac50a88c8329abd9c1e0a55c430c