### PR TITLE
Fix promo banner overlap

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -39,7 +39,7 @@
   <a href="https://book.stripe.com/eVqeVd8Vi9U45RbdJy73G00" class="btn-secondary whitespace-nowrap">Pay Deposit →</a>
   <span data-days-left class="text-xs"></span>
 </div>
-  <header class="fixed top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
+  <header class="sticky top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
     <nav class="max-w-7xl mx-auto relative flex items-center justify-between py-3 px-6">
       <a href="/" class="flex items-center gap-2"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-8 w-8"/><span class="site-title text-xl text-brand-charcoal"><span class="font-bold text-brand-orange">Scrapyard</span> <span class="font-bold">Sites</span></span></a>
       <!-- Mobile hamburger (≤ 768 px) -->
@@ -104,7 +104,7 @@
   });
 
   </script>
-  <main class="pt-16 pb-20 px-0">
+  <main class="pb-20 px-0">
 <section class="relative text-center flex items-center justify-center min-h-[60vh]">
   <img src="/assets/hero.jpg" alt="Scrapyard hero" class="absolute inset-0 w-full h-full object-cover" />
   <div class="absolute inset-0 bg-black/80"></div>

--- a/blog/index.html
+++ b/blog/index.html
@@ -30,7 +30,7 @@
   <a href="https://book.stripe.com/eVqeVd8Vi9U45RbdJy73G00" class="btn-secondary whitespace-nowrap">Pay Deposit →</a>
   <span data-days-left class="text-xs"></span>
 </div>
-  <header class="fixed top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
+  <header class="sticky top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
     <nav class="max-w-7xl mx-auto relative flex items-center justify-between py-3 px-6">
       <a href="/" class="flex items-center gap-2"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-8 w-8"/><span class="site-title text-xl text-brand-charcoal"><span class="font-bold text-brand-orange">Scrapyard</span> <span class="font-bold">Sites</span></span></a>
       <!-- Mobile hamburger (≤ 768 px) -->
@@ -93,7 +93,7 @@
     document.getElementById('menuClose')?.addEventListener('click', toggleMobileMenu);
   });
   </script>
-  <main class="pt-16 pb-20 px-6">
+  <main class="pb-20 px-6">
     <section class="hero py-16 text-center">
       <h1 class="text-3xl font-bold">Reputation &amp; Growth Insights</h1>
       <p class="text-sm max-w-xl mx-auto mt-2 text-brand-steel">

--- a/blog/post-template.html
+++ b/blog/post-template.html
@@ -30,7 +30,7 @@
   <a href="https://book.stripe.com/eVqeVd8Vi9U45RbdJy73G00" class="btn-secondary whitespace-nowrap">Pay Deposit →</a>
   <span data-days-left class="text-xs"></span>
 </div>
-  <header class="fixed top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
+  <header class="sticky top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
     <nav class="max-w-7xl mx-auto relative flex items-center justify-between py-3 px-6">
       <a href="/" class="flex items-center gap-2"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-8 w-8"/><span class="site-title text-xl text-brand-charcoal"><span class="font-bold text-brand-orange">Scrapyard</span> <span class="font-bold">Sites</span></span></a>
       <!-- Mobile hamburger (≤ 768 px) -->
@@ -93,7 +93,7 @@
     document.getElementById('menuClose')?.addEventListener('click', toggleMobileMenu);
   });
   </script>
-  <main class="pt-16 pb-20 px-6">
+  <main class="pb-20 px-6">
     <article class="max-w-3xl mx-auto prose prose-lg">
       <img src="/assets/hero.jpg" alt="Hero image" class="w-full h-64 object-cover rounded-md mb-4">
       <p class="text-xs uppercase text-brand-orange"><!-- POST CATEGORY --></p>

--- a/blog/posts/care-plan-essentials.html
+++ b/blog/posts/care-plan-essentials.html
@@ -30,7 +30,7 @@
   <a href="https://book.stripe.com/eVqeVd8Vi9U45RbdJy73G00" class="btn-secondary whitespace-nowrap">Pay Deposit →</a>
   <span data-days-left class="text-xs"></span>
 </div>
-  <header class="fixed top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
+  <header class="sticky top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
     <nav class="max-w-7xl mx-auto relative flex items-center justify-between py-3 px-6">
       <a href="/" class="flex items-center gap-2"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-8 w-8"/><span class="site-title text-xl text-brand-charcoal"><span class="font-bold text-brand-orange">Scrapyard</span> <span class="font-bold">Sites</span></span></a>
       <!-- Mobile hamburger (≤ 768 px) -->
@@ -93,7 +93,7 @@
     document.getElementById('menuClose')?.addEventListener('click', toggleMobileMenu);
   });
   </script>
-  <main class="pt-16 pb-20 px-6">
+  <main class="pb-20 px-6">
     <article class="max-w-3xl mx-auto prose prose-lg">
       <img src="/assets/hero.jpg" alt="Hero image" class="w-full h-64 object-cover rounded-md mb-4">
       <p class="text-xs uppercase text-brand-orange">Reliability</p>

--- a/blog/posts/pre-qualify-scrap-sellers.html
+++ b/blog/posts/pre-qualify-scrap-sellers.html
@@ -30,7 +30,7 @@
   <a href="https://book.stripe.com/eVqeVd8Vi9U45RbdJy73G00" class="btn-secondary whitespace-nowrap">Pay Deposit →</a>
   <span data-days-left class="text-xs"></span>
 </div>
-  <header class="fixed top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
+  <header class="sticky top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
     <nav class="max-w-7xl mx-auto relative flex items-center justify-between py-3 px-6">
       <a href="/" class="flex items-center gap-2"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-8 w-8"/><span class="site-title text-xl text-brand-charcoal"><span class="font-bold text-brand-orange">Scrapyard</span> <span class="font-bold">Sites</span></span></a>
       <!-- Mobile hamburger (≤ 768 px) -->
@@ -93,7 +93,7 @@
     document.getElementById('menuClose')?.addEventListener('click', toggleMobileMenu);
   });
   </script>
-  <main class="pt-16 pb-20 px-6">
+  <main class="pb-20 px-6">
     <article class="max-w-3xl mx-auto prose prose-lg">
       <img src="/assets/hero.jpg" alt="Hero image" class="w-full h-64 object-cover rounded-md mb-4">
       <p class="text-xs uppercase text-brand-orange">Qualification</p>

--- a/blog/posts/seo-basics-for-scrap-yards.html
+++ b/blog/posts/seo-basics-for-scrap-yards.html
@@ -30,7 +30,7 @@
   <a href="https://book.stripe.com/eVqeVd8Vi9U45RbdJy73G00" class="btn-secondary whitespace-nowrap">Pay Deposit →</a>
   <span data-days-left class="text-xs"></span>
 </div>
-  <header class="fixed top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
+  <header class="sticky top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
     <nav class="max-w-7xl mx-auto relative flex items-center justify-between py-3 px-6">
       <a href="/" class="flex items-center gap-2"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-8 w-8"/><span class="site-title text-xl text-brand-charcoal"><span class="font-bold text-brand-orange">Scrapyard</span> <span class="font-bold">Sites</span></span></a>
       <!-- Mobile hamburger (≤ 768 px) -->
@@ -93,7 +93,7 @@
     document.getElementById('menuClose')?.addEventListener('click', toggleMobileMenu);
   });
   </script>
-  <main class="pt-16 pb-20 px-6">
+  <main class="pb-20 px-6">
     <article class="max-w-3xl mx-auto prose prose-lg">
       <img src="/assets/hero.jpg" alt="Hero image" class="w-full h-64 object-cover rounded-md mb-4">
       <p class="text-xs uppercase text-brand-orange">Visibility</p>

--- a/contact/index.html
+++ b/contact/index.html
@@ -30,7 +30,7 @@
   <a href="https://book.stripe.com/eVqeVd8Vi9U45RbdJy73G00" class="btn-secondary whitespace-nowrap">Pay Deposit →</a>
   <span data-days-left class="text-xs"></span>
 </div>
-  <header class="fixed top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
+  <header class="sticky top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
     <nav class="max-w-7xl mx-auto relative flex items-center justify-between py-3 px-6">
       <a href="/" class="flex items-center gap-2"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-8 w-8"/><span class="site-title text-xl text-brand-charcoal"><span class="font-bold text-brand-orange">Scrapyard</span> <span class="font-bold">Sites</span></span></a>
       <!-- Mobile hamburger (≤ 768 px) -->
@@ -93,7 +93,7 @@
     document.getElementById('menuClose')?.addEventListener('click', toggleMobileMenu);
   });
   </script>
-  <main class="pt-16 pb-20 px-6">
+  <main class="pb-20 px-6">
     <h1 class="pt-16 text-3xl font-bold text-center mb-4">Book Your 15‑Minute Reputation Scan</h1>
     <div class="mx-auto max-w-4xl text-center">
       <p class="text-sm text-brand-steel max-w-2xl mx-auto">

--- a/demos/demo-yard-1/index.html
+++ b/demos/demo-yard-1/index.html
@@ -50,7 +50,7 @@
       </div>
     </div>
   </header>
-  <main class="pt-16 pb-20 px-6 max-w-3xl mx-auto">
+  <main class="pb-20 px-6 max-w-3xl mx-auto">
     <h1 class="text-3xl font-bold mb-6">Demo Yard 1</h1>
     <h2 class="text-xl font-semibold mt-4">Purpose</h2>
     <p class="text-brand-charcoal mb-4">A modern design for a busy urban scrapyard competing for attention against national brands.</p>

--- a/demos/demo-yard-2/index.html
+++ b/demos/demo-yard-2/index.html
@@ -50,7 +50,7 @@
       </div>
     </div>
   </header>
-  <main class="pt-16 pb-20 px-6 max-w-3xl mx-auto">
+  <main class="pb-20 px-6 max-w-3xl mx-auto">
     <h1 class="text-3xl font-bold mb-6">Demo Yard 2</h1>
     <h2 class="text-xl font-semibold mt-4">Purpose</h2>
     <p class="text-brand-charcoal mb-4">Mobile‑friendly layout built for quick quotes on the go.</p>

--- a/demos/demo-yard-3/index.html
+++ b/demos/demo-yard-3/index.html
@@ -50,7 +50,7 @@
       </div>
     </div>
   </header>
-  <main class="pt-16 pb-20 px-6 max-w-3xl mx-auto">
+  <main class="pb-20 px-6 max-w-3xl mx-auto">
     <h1 class="text-3xl font-bold mb-6">Demo Yard 3</h1>
     <h2 class="text-xl font-semibold mt-4">Purpose</h2>
     <p class="text-brand-charcoal mb-4">Service-focused design built for industrial accounts and multiple locations.</p>

--- a/demos/index.html
+++ b/demos/index.html
@@ -34,7 +34,7 @@
   <a href="https://book.stripe.com/eVqeVd8Vi9U45RbdJy73G00" class="btn-secondary whitespace-nowrap">Pay Deposit →</a>
   <span data-days-left class="text-xs"></span>
 </div>
-  <header class="fixed top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
+  <header class="sticky top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
     <nav class="max-w-7xl mx-auto relative flex items-center justify-between py-3 px-6">
       <a href="/" class="flex items-center gap-2"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-8 w-8"/><span class="site-title text-xl text-brand-charcoal"><span class="font-bold text-brand-orange">Scrapyard</span> <span class="font-bold">Sites</span></span></a>
       <!-- Mobile hamburger (≤ 768 px) -->
@@ -98,7 +98,7 @@
 });
   </script>
 
-  <main class="pt-16 pb-20">
+  <main class="pb-20">
     <section class="relative flex flex-col items-center justify-center min-h-[60vh] text-center">
       <img src="/assets/hero.jpg" alt="Scrapyard hero" class="absolute inset-0 w-full h-full object-cover">
       <div class="absolute inset-0 bg-black/80"></div>

--- a/index.html
+++ b/index.html
@@ -175,7 +175,7 @@
 </div>
 
 <!-- ── Header ─────────────────────────────────────────────── -->
-  <header class="fixed top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
+  <header class="sticky top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
     <nav class="max-w-7xl mx-auto relative flex items-center justify-between py-3 px-6">
       <a href="/" class="flex items-center gap-2"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-8 w-8"/><span class="site-title text-xl text-brand-charcoal"><span class="font-bold text-brand-orange">Scrapyard</span> <span class="font-bold">Sites</span></span></a>
       <!-- Mobile hamburger (≤ 768 px) -->
@@ -241,7 +241,7 @@
 
   </script>
 
-  <main class="pt-16">
+  <main class="">
 
 <!-- ── Hero ───────────────────────────────────────────────── -->
 <section class="relative text-center flex items-center justify-center min-h-[80vh]">

--- a/pricing/index.html
+++ b/pricing/index.html
@@ -34,7 +34,7 @@
   <a href="https://book.stripe.com/eVqeVd8Vi9U45RbdJy73G00" class="btn-secondary whitespace-nowrap">Pay Deposit →</a>
   <span data-days-left class="text-xs"></span>
 </div>
-  <header class="fixed top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
+  <header class="sticky top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
     <nav class="max-w-7xl mx-auto relative flex items-center justify-between py-3 px-6">
       <a href="/" class="flex items-center gap-2"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-8 w-8"/><span class="site-title text-xl text-brand-charcoal"><span class="font-bold text-brand-orange">Scrapyard</span> <span class="font-bold">Sites</span></span></a>
       <!-- Mobile hamburger (≤ 768 px) -->
@@ -98,7 +98,7 @@
   });
 
   </script>
-  <main class="pt-16 pb-20">
+  <main class="pb-20">
     <!-- Hero -->
     <section class="relative flex items-center justify-center min-h-[60vh] text-center">
       <img src="/assets/hero.jpg" alt="Scrapyard hero" class="absolute inset-0 w-full h-full object-cover" />

--- a/privacy/index.html
+++ b/privacy/index.html
@@ -95,7 +95,7 @@
   <a href="https://book.stripe.com/eVqeVd8Vi9U45RbdJy73G00" class="btn-secondary whitespace-nowrap">Pay Deposit →</a>
   <span data-days-left class="text-xs"></span>
 </div>
-  <header class="fixed top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
+  <header class="sticky top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
     <nav class="max-w-7xl mx-auto relative flex items-center justify-between py-3 px-6">
       <a href="/" class="flex items-center gap-2"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-8 w-8"/><span class="site-title text-xl text-brand-charcoal"><span class="font-bold text-brand-orange">Scrapyard</span> <span class="font-bold">Sites</span></span></a>
       <!-- Mobile hamburger (≤ 768 px) -->
@@ -159,7 +159,7 @@
   });
 
   </script>
-  <main class="max-w-3xl mx-auto pt-16 pb-20 px-6 prose prose-a:text-brand-orange">
+  <main class="max-w-3xl mx-auto pb-20 px-6 prose prose-a:text-brand-orange">
     <h1 class="text-3xl font-bold mb-4">Privacy Policy</h1>
     <p class="mb-4"><strong>Effective Date: 4&nbsp;July&nbsp;2025</strong></p>
     <p class="mb-4">Scrapyard Sites (“Company,” “we,” “our,” or “us”) is committed to protecting your privacy. This Privacy Policy explains how we collect, use, disclose, and safeguard your information when you visit scrapyardsites.com (the “Site”) or interact with any of our services, prototypes, or test sites hosted on GitHub or other platforms (collectively, the “Services”). By accessing or using our Services, you agree to the terms of this Privacy Policy.</p>

--- a/process/index.html
+++ b/process/index.html
@@ -94,7 +94,7 @@
   <a href="https://book.stripe.com/eVqeVd8Vi9U45RbdJy73G00" class="btn-secondary whitespace-nowrap">Pay Deposit →</a>
   <span data-days-left class="text-xs"></span>
 </div>
-  <header class="fixed top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
+  <header class="sticky top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
     <nav class="max-w-7xl w-full mx-auto relative flex items-center justify-between py-3 px-6">
       <a href="/" class="flex items-center gap-2"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-8 w-8"/><span class="site-title text-xl text-brand-charcoal"><span class="font-bold text-brand-orange">Scrapyard</span> <span class="font-bold">Sites</span></span></a>
       <!-- Mobile hamburger (≤ 768 px) -->
@@ -158,7 +158,7 @@
   });
 
   </script>
-  <main class="pt-16 pb-20">
+  <main class="pb-20">
     <section class="relative flex flex-col items-center justify-center min-h-[60vh] text-center">
       <img src="/assets/hero.jpg" alt="Scrapyard hero" class="absolute inset-0 w-full h-full object-cover">
       <div class="absolute inset-0 bg-black/80"></div>

--- a/risk-calculator/index.html
+++ b/risk-calculator/index.html
@@ -88,7 +88,7 @@
   <body
     class="font-sans text-brand-charcoal antialiased bg-white overflow-x-hidden"
   >
-    <header class="fixed top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
+    <header class="sticky top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
       <nav
         class="max-w-7xl mx-auto relative flex items-center justify-between py-3 px-6"
       >
@@ -211,7 +211,7 @@
           ?.addEventListener("click", toggleMobileMenu);
       });
     </script>
-    <main class="pt-16 px-6">
+    <main class="px-6">
       <section class="pt-12 pb-28 bg-gray-50 -mx-6">
         <div class="border border-brand-steel/20 rounded-xl p-6 bg-white mx-auto max-w-3xl px-6">
           <h1 class="text-2xl font-bold text-center">Reputation&nbsp;Risk&nbsp;Calculator</h1>

--- a/services/index.html
+++ b/services/index.html
@@ -83,7 +83,7 @@
   <a href="https://book.stripe.com/eVqeVd8Vi9U45RbdJy73G00" class="btn-secondary whitespace-nowrap">Pay Deposit →</a>
   <span data-days-left class="text-xs"></span>
 </div>
-  <header class="fixed top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
+  <header class="sticky top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
     <nav class="max-w-7xl mx-auto relative flex items-center justify-between py-3 px-6">
       <a href="/" class="flex items-center gap-2"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-8 w-8"/><span class="site-title text-xl text-brand-charcoal"><span class="font-bold text-brand-orange">Scrapyard</span> <span class="font-bold">Sites</span></span></a>
       <!-- Mobile hamburger (≤ 768 px) -->
@@ -124,7 +124,7 @@
   function toggleMobileMenu(){const menu=document.getElementById('mobileMenu');const btn=document.getElementById('menuToggle');menu.classList.toggle('hidden');const isOpen=!menu.classList.contains('hidden');document.body.classList.toggle('overflow-hidden',isOpen);btn.classList.toggle('open');}
   document.addEventListener('DOMContentLoaded',()=>{const currentPath=location.pathname.replace(/\/index.html$/,'').replace(/\/$/,'');document.querySelectorAll('#menu a:not(.no-highlight), #mobileMenu a:not(.no-highlight)').forEach(link=>{const linkPath=new URL(link.getAttribute('href'),location.origin).pathname.replace(/\/index.html$/,'').replace(/\/$/,'');if(linkPath===currentPath){link.classList.add('text-brand-orange');}});document.getElementById('menuToggle')?.addEventListener('click',toggleMobileMenu);document.getElementById('menuClose')?.addEventListener('click',toggleMobileMenu);});
   </script>
-  <main class="pt-16 pb-0 bg-gray-50">
+  <main class="pb-0 bg-gray-50">
     <!-- Hero -->
     <section class="relative flex flex-col items-center justify-center min-h-[60vh] text-center py-16 gap-8">
       <img src="/assets/hero.jpg" alt="Grapple loading shred" class="absolute inset-0 w-full h-full object-cover">

--- a/terms-of-service/index.html
+++ b/terms-of-service/index.html
@@ -34,7 +34,7 @@
   <a href="https://book.stripe.com/eVqeVd8Vi9U45RbdJy73G00" class="btn-secondary whitespace-nowrap">Pay Deposit →</a>
   <span data-days-left class="text-xs"></span>
 </div>
-  <header class="fixed top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
+  <header class="sticky top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
     <nav class="max-w-7xl mx-auto relative flex items-center justify-between py-3 px-6">
       <a href="/" class="flex items-center gap-2"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-8 w-8"/><span class="site-title text-xl text-brand-charcoal"><span class="font-bold text-brand-orange">Scrapyard</span> <span class="font-bold">Sites</span></span></a>
       <!-- Mobile hamburger (≤ 768 px) -->
@@ -98,7 +98,7 @@
   });
 
   </script>
-  <main class="max-w-3xl mx-auto pt-16 pb-20 px-6 prose prose-a:text-brand-orange">
+  <main class="max-w-3xl mx-auto pb-20 px-6 prose prose-a:text-brand-orange">
     <h1 class="text-3xl font-bold mb-4">Terms of Service</h1>
     <p class="mb-4">The terms of service will be posted here soon.</p>
   <section class="mt-16 py-12 bg-brand-orange text-white text-center">


### PR DESCRIPTION
## Summary
- let the nav bar scroll away from the promo banner by making headers `sticky`
- remove the padding that offset a fixed header

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6883ce9e82e48329be0e6f648add939d