### PR TITLE
Fix sticky nav and adjust promo banner

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -34,13 +34,13 @@
   </style>
 </head>
 <body class="font-sans text-brand-charcoal antialiased bg-white overflow-x-hidden">
-<div id="promoBanner" class="bg-brand-orange text-white text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
+<div id="promoBanner" class="bg-white text-brand-orange text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
   <span>Save 10% on your build — pay your deposit by Aug 30. Lock in your slot; go live before peak Q4 scrap season.</span>
   <a href="https://book.stripe.com/eVqeVd8Vi9U45RbdJy73G00" class="btn-secondary whitespace-nowrap">Pay Deposit →</a>
   <span data-days-left class="text-xs"></span>
   <span class="text-xs"><a href="/pricing" class="underline">50% today, balance at launch – 90‑day ROI guarantee</a></span>
 </div>
-  <header class="sticky top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
+  <header class="fixed top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
     <nav class="max-w-7xl mx-auto relative flex items-center justify-between py-3 px-6">
       <a href="/" class="flex items-center gap-2"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-8 w-8"/><span class="site-title text-xl text-brand-charcoal"><span class="font-bold text-brand-orange">Scrapyard</span> <span class="font-bold">Sites</span></span></a>
       <!-- Mobile hamburger (≤ 768 px) -->

--- a/assets/promo-banner.js
+++ b/assets/promo-banner.js
@@ -8,7 +8,7 @@
   if(diff <= 0){
     const btn = banner.querySelector('a');
     if(btn) btn.remove();
-    if(countdownEl) countdownEl.textContent = 'Slots now full';
+    if(countdownEl) countdownEl.remove();
   } else if(countdownEl){
     countdownEl.textContent = diff + ' day' + (diff === 1 ? '' : 's') + ' left';
   }

--- a/blog/index.html
+++ b/blog/index.html
@@ -25,13 +25,13 @@
   </style>
 </head>
 <body class="font-sans text-brand-charcoal antialiased bg-white overflow-x-hidden">
-<div id="promoBanner" class="bg-brand-orange text-white text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
+<div id="promoBanner" class="bg-white text-brand-orange text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
   <span>Save 10% on your build — pay your deposit by Aug 30. Lock in your slot; go live before peak Q4 scrap season.</span>
   <a href="https://book.stripe.com/eVqeVd8Vi9U45RbdJy73G00" class="btn-secondary whitespace-nowrap">Pay Deposit →</a>
   <span data-days-left class="text-xs"></span>
   <span class="text-xs"><a href="/pricing" class="underline">50% today, balance at launch – 90‑day ROI guarantee</a></span>
 </div>
-  <header class="sticky top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
+  <header class="fixed top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
     <nav class="max-w-7xl mx-auto relative flex items-center justify-between py-3 px-6">
       <a href="/" class="flex items-center gap-2"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-8 w-8"/><span class="site-title text-xl text-brand-charcoal"><span class="font-bold text-brand-orange">Scrapyard</span> <span class="font-bold">Sites</span></span></a>
       <!-- Mobile hamburger (≤ 768 px) -->

--- a/blog/post-template.html
+++ b/blog/post-template.html
@@ -25,13 +25,13 @@
   </style>
 </head>
 <body class="font-sans text-brand-charcoal antialiased bg-white overflow-x-hidden">
-<div id="promoBanner" class="bg-brand-orange text-white text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
+<div id="promoBanner" class="bg-white text-brand-orange text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
   <span>Save 10% on your build — pay your deposit by Aug 30. Lock in your slot; go live before peak Q4 scrap season.</span>
   <a href="https://book.stripe.com/eVqeVd8Vi9U45RbdJy73G00" class="btn-secondary whitespace-nowrap">Pay Deposit →</a>
   <span data-days-left class="text-xs"></span>
   <span class="text-xs"><a href="/pricing" class="underline">50% today, balance at launch – 90‑day ROI guarantee</a></span>
 </div>
-  <header class="sticky top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
+  <header class="fixed top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
     <nav class="max-w-7xl mx-auto relative flex items-center justify-between py-3 px-6">
       <a href="/" class="flex items-center gap-2"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-8 w-8"/><span class="site-title text-xl text-brand-charcoal"><span class="font-bold text-brand-orange">Scrapyard</span> <span class="font-bold">Sites</span></span></a>
       <!-- Mobile hamburger (≤ 768 px) -->

--- a/blog/posts/care-plan-essentials.html
+++ b/blog/posts/care-plan-essentials.html
@@ -25,13 +25,13 @@
   </style>
 </head>
 <body class="font-sans text-brand-charcoal antialiased bg-white overflow-x-hidden">
-<div id="promoBanner" class="bg-brand-orange text-white text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
+<div id="promoBanner" class="bg-white text-brand-orange text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
   <span>Save 10% on your build — pay your deposit by Aug 30. Lock in your slot; go live before peak Q4 scrap season.</span>
   <a href="https://book.stripe.com/eVqeVd8Vi9U45RbdJy73G00" class="btn-secondary whitespace-nowrap">Pay Deposit →</a>
   <span data-days-left class="text-xs"></span>
   <span class="text-xs"><a href="/pricing" class="underline">50% today, balance at launch – 90‑day ROI guarantee</a></span>
 </div>
-  <header class="sticky top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
+  <header class="fixed top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
     <nav class="max-w-7xl mx-auto relative flex items-center justify-between py-3 px-6">
       <a href="/" class="flex items-center gap-2"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-8 w-8"/><span class="site-title text-xl text-brand-charcoal"><span class="font-bold text-brand-orange">Scrapyard</span> <span class="font-bold">Sites</span></span></a>
       <!-- Mobile hamburger (≤ 768 px) -->

--- a/blog/posts/pre-qualify-scrap-sellers.html
+++ b/blog/posts/pre-qualify-scrap-sellers.html
@@ -25,13 +25,13 @@
   </style>
 </head>
 <body class="font-sans text-brand-charcoal antialiased bg-white overflow-x-hidden">
-<div id="promoBanner" class="bg-brand-orange text-white text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
+<div id="promoBanner" class="bg-white text-brand-orange text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
   <span>Save 10% on your build — pay your deposit by Aug 30. Lock in your slot; go live before peak Q4 scrap season.</span>
   <a href="https://book.stripe.com/eVqeVd8Vi9U45RbdJy73G00" class="btn-secondary whitespace-nowrap">Pay Deposit →</a>
   <span data-days-left class="text-xs"></span>
   <span class="text-xs"><a href="/pricing" class="underline">50% today, balance at launch – 90‑day ROI guarantee</a></span>
 </div>
-  <header class="sticky top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
+  <header class="fixed top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
     <nav class="max-w-7xl mx-auto relative flex items-center justify-between py-3 px-6">
       <a href="/" class="flex items-center gap-2"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-8 w-8"/><span class="site-title text-xl text-brand-charcoal"><span class="font-bold text-brand-orange">Scrapyard</span> <span class="font-bold">Sites</span></span></a>
       <!-- Mobile hamburger (≤ 768 px) -->

--- a/blog/posts/seo-basics-for-scrap-yards.html
+++ b/blog/posts/seo-basics-for-scrap-yards.html
@@ -25,13 +25,13 @@
   </style>
 </head>
 <body class="font-sans text-brand-charcoal antialiased bg-white overflow-x-hidden">
-<div id="promoBanner" class="bg-brand-orange text-white text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
+<div id="promoBanner" class="bg-white text-brand-orange text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
   <span>Save 10% on your build — pay your deposit by Aug 30. Lock in your slot; go live before peak Q4 scrap season.</span>
   <a href="https://book.stripe.com/eVqeVd8Vi9U45RbdJy73G00" class="btn-secondary whitespace-nowrap">Pay Deposit →</a>
   <span data-days-left class="text-xs"></span>
   <span class="text-xs"><a href="/pricing" class="underline">50% today, balance at launch – 90‑day ROI guarantee</a></span>
 </div>
-  <header class="sticky top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
+  <header class="fixed top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
     <nav class="max-w-7xl mx-auto relative flex items-center justify-between py-3 px-6">
       <a href="/" class="flex items-center gap-2"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-8 w-8"/><span class="site-title text-xl text-brand-charcoal"><span class="font-bold text-brand-orange">Scrapyard</span> <span class="font-bold">Sites</span></span></a>
       <!-- Mobile hamburger (≤ 768 px) -->

--- a/contact/index.html
+++ b/contact/index.html
@@ -25,13 +25,13 @@
   </style>
 </head>
 <body class="font-sans text-brand-charcoal antialiased bg-white overflow-x-hidden">
-<div id="promoBanner" class="bg-brand-orange text-white text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
+<div id="promoBanner" class="bg-white text-brand-orange text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
   <span>Save 10% on your build — pay your deposit by Aug 30. Lock in your slot; go live before peak Q4 scrap season.</span>
   <a href="https://book.stripe.com/eVqeVd8Vi9U45RbdJy73G00" class="btn-secondary whitespace-nowrap">Pay Deposit →</a>
   <span data-days-left class="text-xs"></span>
   <span class="text-xs"><a href="/pricing" class="underline">50% today, balance at launch – 90‑day ROI guarantee</a></span>
 </div>
-  <header class="sticky top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
+  <header class="fixed top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
     <nav class="max-w-7xl mx-auto relative flex items-center justify-between py-3 px-6">
       <a href="/" class="flex items-center gap-2"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-8 w-8"/><span class="site-title text-xl text-brand-charcoal"><span class="font-bold text-brand-orange">Scrapyard</span> <span class="font-bold">Sites</span></span></a>
       <!-- Mobile hamburger (≤ 768 px) -->

--- a/demos/demo-yard-1/index.html
+++ b/demos/demo-yard-1/index.html
@@ -25,13 +25,13 @@
   </style>
 </head>
 <body class="font-sans text-brand-charcoal antialiased bg-white overflow-x-hidden">
-<div id="promoBanner" class="bg-brand-orange text-white text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
+<div id="promoBanner" class="bg-white text-brand-orange text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
   <span>Save 10% on your build — pay your deposit by Aug 30. Lock in your slot; go live before peak Q4 scrap season.</span>
   <a href="https://book.stripe.com/eVqeVd8Vi9U45RbdJy73G00" class="btn-secondary whitespace-nowrap">Pay Deposit →</a>
   <span data-days-left class="text-xs"></span>
   <span class="text-xs"><a href="/pricing" class="underline">50% today, balance at launch – 90‑day ROI guarantee</a></span>
 </div>
-  <header class="sticky top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
+  <header class="fixed top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
     <div class="mx-auto max-w-7xl relative flex items-center justify-between px-6 py-3">
       <a href="/" class="flex items-center gap-2">
         <img src="/assets/logo.svg" alt="ScrapYardSites logo" class="h-6 w-6 md:h-8 md:w-8"/>

--- a/demos/demo-yard-2/index.html
+++ b/demos/demo-yard-2/index.html
@@ -25,13 +25,13 @@
   </style>
 </head>
 <body class="font-sans text-brand-charcoal antialiased bg-white overflow-x-hidden">
-<div id="promoBanner" class="bg-brand-orange text-white text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
+<div id="promoBanner" class="bg-white text-brand-orange text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
   <span>Save 10% on your build — pay your deposit by Aug 30. Lock in your slot; go live before peak Q4 scrap season.</span>
   <a href="https://book.stripe.com/eVqeVd8Vi9U45RbdJy73G00" class="btn-secondary whitespace-nowrap">Pay Deposit →</a>
   <span data-days-left class="text-xs"></span>
   <span class="text-xs"><a href="/pricing" class="underline">50% today, balance at launch – 90‑day ROI guarantee</a></span>
 </div>
-  <header class="sticky top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
+  <header class="fixed top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
     <div class="mx-auto max-w-7xl relative flex items-center justify-between px-6 py-3">
       <a href="/" class="flex items-center gap-2">
         <img src="/assets/logo.svg" alt="ScrapYardSites logo" class="h-6 w-6 md:h-8 md:w-8"/>

--- a/demos/demo-yard-3/index.html
+++ b/demos/demo-yard-3/index.html
@@ -25,13 +25,13 @@
   </style>
 </head>
 <body class="font-sans text-brand-charcoal antialiased bg-white overflow-x-hidden">
-<div id="promoBanner" class="bg-brand-orange text-white text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
+<div id="promoBanner" class="bg-white text-brand-orange text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
   <span>Save 10% on your build — pay your deposit by Aug 30. Lock in your slot; go live before peak Q4 scrap season.</span>
   <a href="https://book.stripe.com/eVqeVd8Vi9U45RbdJy73G00" class="btn-secondary whitespace-nowrap">Pay Deposit →</a>
   <span data-days-left class="text-xs"></span>
   <span class="text-xs"><a href="/pricing" class="underline">50% today, balance at launch – 90‑day ROI guarantee</a></span>
 </div>
-  <header class="sticky top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
+  <header class="fixed top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
     <div class="mx-auto max-w-7xl relative flex items-center justify-between px-6 py-3">
       <a href="/" class="flex items-center gap-2">
         <img src="/assets/logo.svg" alt="ScrapYardSites logo" class="h-6 w-6 md:h-8 md:w-8"/>

--- a/demos/index.html
+++ b/demos/index.html
@@ -29,13 +29,13 @@
   </style>
 </head>
 <body class="font-sans text-brand-charcoal antialiased bg-white overflow-x-hidden">
-<div id="promoBanner" class="bg-brand-orange text-white text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
+<div id="promoBanner" class="bg-white text-brand-orange text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
   <span>Save 10% on your build — pay your deposit by Aug 30. Lock in your slot; go live before peak Q4 scrap season.</span>
   <a href="https://book.stripe.com/eVqeVd8Vi9U45RbdJy73G00" class="btn-secondary whitespace-nowrap">Pay Deposit →</a>
   <span data-days-left class="text-xs"></span>
   <span class="text-xs"><a href="/pricing" class="underline">50% today, balance at launch – 90‑day ROI guarantee</a></span>
 </div>
-  <header class="sticky top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
+  <header class="fixed top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
     <nav class="max-w-7xl mx-auto relative flex items-center justify-between py-3 px-6">
       <a href="/" class="flex items-center gap-2"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-8 w-8"/><span class="site-title text-xl text-brand-charcoal"><span class="font-bold text-brand-orange">Scrapyard</span> <span class="font-bold">Sites</span></span></a>
       <!-- Mobile hamburger (≤ 768 px) -->

--- a/index.html
+++ b/index.html
@@ -168,7 +168,7 @@
 </head>
 
 <body class="font-sans text-brand-charcoal antialiased bg-white overflow-x-hidden">
-<div id="promoBanner" class="bg-brand-orange text-white text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
+<div id="promoBanner" class="bg-white text-brand-orange text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
   <span>Save 10% on your build — pay your deposit by Aug 30. Lock in your slot; go live before peak Q4 scrap season.</span>
   <a href="https://book.stripe.com/eVqeVd8Vi9U45RbdJy73G00" class="btn-secondary whitespace-nowrap">Pay Deposit →</a>
   <span data-days-left class="text-xs"></span>
@@ -176,7 +176,7 @@
 </div>
 
 <!-- ── Header ─────────────────────────────────────────────── -->
-  <header class="sticky top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
+  <header class="fixed top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
     <nav class="max-w-7xl mx-auto relative flex items-center justify-between py-3 px-6">
       <a href="/" class="flex items-center gap-2"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-8 w-8"/><span class="site-title text-xl text-brand-charcoal"><span class="font-bold text-brand-orange">Scrapyard</span> <span class="font-bold">Sites</span></span></a>
       <!-- Mobile hamburger (≤ 768 px) -->

--- a/pricing/index.html
+++ b/pricing/index.html
@@ -29,13 +29,13 @@
   </style>
 </head>
 <body class="font-sans text-brand-charcoal antialiased bg-white overflow-x-hidden">
-<div id="promoBanner" class="bg-brand-orange text-white text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
+<div id="promoBanner" class="bg-white text-brand-orange text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
   <span>Save 10% on your build — pay your deposit by Aug 30. Lock in your slot; go live before peak Q4 scrap season.</span>
   <a href="https://book.stripe.com/eVqeVd8Vi9U45RbdJy73G00" class="btn-secondary whitespace-nowrap">Pay Deposit →</a>
   <span data-days-left class="text-xs"></span>
   <span class="text-xs"><a href="/pricing" class="underline">50% today, balance at launch – 90‑day ROI guarantee</a></span>
 </div>
-  <header class="sticky top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
+  <header class="fixed top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
     <nav class="max-w-7xl mx-auto relative flex items-center justify-between py-3 px-6">
       <a href="/" class="flex items-center gap-2"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-8 w-8"/><span class="site-title text-xl text-brand-charcoal"><span class="font-bold text-brand-orange">Scrapyard</span> <span class="font-bold">Sites</span></span></a>
       <!-- Mobile hamburger (≤ 768 px) -->

--- a/privacy/index.html
+++ b/privacy/index.html
@@ -90,13 +90,13 @@
 </style>
 </head>
 <body class="font-sans text-brand-charcoal antialiased bg-white overflow-x-hidden">
-<div id="promoBanner" class="bg-brand-orange text-white text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
+<div id="promoBanner" class="bg-white text-brand-orange text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
   <span>Save 10% on your build — pay your deposit by Aug 30. Lock in your slot; go live before peak Q4 scrap season.</span>
   <a href="https://book.stripe.com/eVqeVd8Vi9U45RbdJy73G00" class="btn-secondary whitespace-nowrap">Pay Deposit →</a>
   <span data-days-left class="text-xs"></span>
   <span class="text-xs"><a href="/pricing" class="underline">50% today, balance at launch – 90‑day ROI guarantee</a></span>
 </div>
-  <header class="sticky top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
+  <header class="fixed top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
     <nav class="max-w-7xl mx-auto relative flex items-center justify-between py-3 px-6">
       <a href="/" class="flex items-center gap-2"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-8 w-8"/><span class="site-title text-xl text-brand-charcoal"><span class="font-bold text-brand-orange">Scrapyard</span> <span class="font-bold">Sites</span></span></a>
       <!-- Mobile hamburger (≤ 768 px) -->

--- a/process/index.html
+++ b/process/index.html
@@ -89,13 +89,13 @@
   </style>
 </head>
 <body class="font-sans text-brand-charcoal antialiased bg-white overflow-x-hidden">
-<div id="promoBanner" class="bg-brand-orange text-white text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
+<div id="promoBanner" class="bg-white text-brand-orange text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
   <span>Save 10% on your build — pay your deposit by Aug 30. Lock in your slot; go live before peak Q4 scrap season.</span>
   <a href="https://book.stripe.com/eVqeVd8Vi9U45RbdJy73G00" class="btn-secondary whitespace-nowrap">Pay Deposit →</a>
   <span data-days-left class="text-xs"></span>
   <span class="text-xs"><a href="/pricing" class="underline">50% today, balance at launch – 90‑day ROI guarantee</a></span>
 </div>
-  <header class="sticky top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
+  <header class="fixed top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
     <nav class="max-w-7xl w-full mx-auto relative flex items-center justify-between py-3 px-6">
       <a href="/" class="flex items-center gap-2"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-8 w-8"/><span class="site-title text-xl text-brand-charcoal"><span class="font-bold text-brand-orange">Scrapyard</span> <span class="font-bold">Sites</span></span></a>
       <!-- Mobile hamburger (≤ 768 px) -->

--- a/risk-calculator/index.html
+++ b/risk-calculator/index.html
@@ -88,7 +88,7 @@
   <body
     class="font-sans text-brand-charcoal antialiased bg-white overflow-x-hidden"
   >
-    <header class="sticky top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
+    <header class="fixed top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
       <nav
         class="max-w-7xl mx-auto relative flex items-center justify-between py-3 px-6"
       >

--- a/services/index.html
+++ b/services/index.html
@@ -78,12 +78,12 @@
   </style>
 </head>
 <body class="font-sans text-brand-charcoal antialiased bg-white overflow-x-hidden">
-<div id="promoBanner" class="bg-brand-orange text-white text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
+<div id="promoBanner" class="bg-white text-brand-orange text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
   <span>Save 10% on your build — pay your deposit by Aug 30. Lock in your slot; go live before peak Q4 scrap season.</span>
   <a href="https://book.stripe.com/eVqeVd8Vi9U45RbdJy73G00" class="btn-secondary whitespace-nowrap">Pay Deposit →</a>
   <span data-days-left class="text-xs"></span>
 </div>
-  <header class="sticky top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
+  <header class="fixed top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
     <nav class="max-w-7xl mx-auto relative flex items-center justify-between py-3 px-6">
       <a href="/" class="flex items-center gap-2"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-8 w-8"/><span class="site-title text-xl text-brand-charcoal"><span class="font-bold text-brand-orange">Scrapyard</span> <span class="font-bold">Sites</span></span></a>
       <!-- Mobile hamburger (≤ 768 px) -->

--- a/terms-of-service/index.html
+++ b/terms-of-service/index.html
@@ -29,13 +29,13 @@
   </style>
 </head>
 <body class="font-sans text-brand-charcoal antialiased bg-white overflow-x-hidden">
-<div id="promoBanner" class="bg-brand-orange text-white text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
+<div id="promoBanner" class="bg-white text-brand-orange text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
   <span>Save 10% on your build — pay your deposit by Aug 30. Lock in your slot; go live before peak Q4 scrap season.</span>
   <a href="https://book.stripe.com/eVqeVd8Vi9U45RbdJy73G00" class="btn-secondary whitespace-nowrap">Pay Deposit →</a>
   <span data-days-left class="text-xs"></span>
   <span class="text-xs"><a href="/pricing" class="underline">50% today, balance at launch – 90‑day ROI guarantee</a></span>
 </div>
-  <header class="sticky top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
+  <header class="fixed top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
     <nav class="max-w-7xl mx-auto relative flex items-center justify-between py-3 px-6">
       <a href="/" class="flex items-center gap-2"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-8 w-8"/><span class="site-title text-xl text-brand-charcoal"><span class="font-bold text-brand-orange">Scrapyard</span> <span class="font-bold">Sites</span></span></a>
       <!-- Mobile hamburger (≤ 768 px) -->


### PR DESCRIPTION
## Summary
- make header `fixed` so nav sticks at top
- switch promo banner to white with orange text
- remove "Slots now full" message from promo banner script

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6883d4d98b7483298d3a7d300ae5f796