### PR TITLE
Update promo banner style and hide on mobile menu

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -35,7 +35,7 @@
 </head>
 <body class="font-sans text-brand-charcoal antialiased bg-white overflow-x-hidden">
   <header class="fixed top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
-<div id="promoBanner" class="bg-white text-brand-orange text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
+<div id="promoBanner" class="bg-brand-orange text-white text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
   <span>Save 10% on your build — pay your deposit by Aug 30. Lock in your slot; go live before peak Q4 scrap season.</span>
   <a href="https://book.stripe.com/eVqeVd8Vi9U45RbdJy73G00" class="btn-secondary whitespace-nowrap">Pay Deposit →</a>
   <span data-days-left class="text-xs"></span>
@@ -81,10 +81,10 @@
   /* full-screen mobile toggle */
   function toggleMobileMenu() {
     const menu = document.getElementById('mobileMenu');
-    const btn = document.getElementById('menuToggle');
+    const btn = document.getElementById('menuToggle');const banner=document.getElementById('promoBanner');
     menu.classList.toggle('hidden');
     const isOpen = !menu.classList.contains('hidden');
-    document.body.classList.toggle('overflow-hidden', isOpen);
+    document.body.classList.toggle('overflow-hidden', isOpen);if(banner) banner.classList.toggle('hidden', isOpen);
     btn.classList.toggle('open');
   }
   document.addEventListener('DOMContentLoaded', () => {

--- a/blog/index.html
+++ b/blog/index.html
@@ -26,7 +26,7 @@
 </head>
 <body class="font-sans text-brand-charcoal antialiased bg-white overflow-x-hidden">
   <header class="fixed top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
-<div id="promoBanner" class="bg-white text-brand-orange text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
+<div id="promoBanner" class="bg-brand-orange text-white text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
   <span>Save 10% on your build — pay your deposit by Aug 30. Lock in your slot; go live before peak Q4 scrap season.</span>
   <a href="https://book.stripe.com/eVqeVd8Vi9U45RbdJy73G00" class="btn-secondary whitespace-nowrap">Pay Deposit →</a>
   <span data-days-left class="text-xs"></span>
@@ -71,10 +71,10 @@
   /* full-screen mobile toggle */
   function toggleMobileMenu() {
     const menu = document.getElementById('mobileMenu');
-    const btn = document.getElementById('menuToggle');
+    const btn = document.getElementById('menuToggle');const banner=document.getElementById('promoBanner');
     menu.classList.toggle('hidden');
     const isOpen = !menu.classList.contains('hidden');
-    document.body.classList.toggle('overflow-hidden', isOpen);
+    document.body.classList.toggle('overflow-hidden', isOpen);if(banner) banner.classList.toggle('hidden', isOpen);
     btn.classList.toggle('open');
   }
   document.addEventListener('DOMContentLoaded', () => {

--- a/blog/post-template.html
+++ b/blog/post-template.html
@@ -26,7 +26,7 @@
 </head>
 <body class="font-sans text-brand-charcoal antialiased bg-white overflow-x-hidden">
   <header class="fixed top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
-<div id="promoBanner" class="bg-white text-brand-orange text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
+<div id="promoBanner" class="bg-brand-orange text-white text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
   <span>Save 10% on your build — pay your deposit by Aug 30. Lock in your slot; go live before peak Q4 scrap season.</span>
   <a href="https://book.stripe.com/eVqeVd8Vi9U45RbdJy73G00" class="btn-secondary whitespace-nowrap">Pay Deposit →</a>
   <span data-days-left class="text-xs"></span>
@@ -71,10 +71,10 @@
   /* full-screen mobile toggle */
   function toggleMobileMenu() {
     const menu = document.getElementById('mobileMenu');
-    const btn = document.getElementById('menuToggle');
+    const btn = document.getElementById('menuToggle');const banner=document.getElementById('promoBanner');
     menu.classList.toggle('hidden');
     const isOpen = !menu.classList.contains('hidden');
-    document.body.classList.toggle('overflow-hidden', isOpen);
+    document.body.classList.toggle('overflow-hidden', isOpen);if(banner) banner.classList.toggle('hidden', isOpen);
     btn.classList.toggle('open');
   }
   document.addEventListener('DOMContentLoaded', () => {

--- a/blog/posts/care-plan-essentials.html
+++ b/blog/posts/care-plan-essentials.html
@@ -26,7 +26,7 @@
 </head>
 <body class="font-sans text-brand-charcoal antialiased bg-white overflow-x-hidden">
   <header class="fixed top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
-<div id="promoBanner" class="bg-white text-brand-orange text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
+<div id="promoBanner" class="bg-brand-orange text-white text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
   <span>Save 10% on your build — pay your deposit by Aug 30. Lock in your slot; go live before peak Q4 scrap season.</span>
   <a href="https://book.stripe.com/eVqeVd8Vi9U45RbdJy73G00" class="btn-secondary whitespace-nowrap">Pay Deposit →</a>
   <span data-days-left class="text-xs"></span>
@@ -71,10 +71,10 @@
   /* full-screen mobile toggle */
   function toggleMobileMenu() {
     const menu = document.getElementById('mobileMenu');
-    const btn = document.getElementById('menuToggle');
+    const btn = document.getElementById('menuToggle');const banner=document.getElementById('promoBanner');
     menu.classList.toggle('hidden');
     const isOpen = !menu.classList.contains('hidden');
-    document.body.classList.toggle('overflow-hidden', isOpen);
+    document.body.classList.toggle('overflow-hidden', isOpen);if(banner) banner.classList.toggle('hidden', isOpen);
     btn.classList.toggle('open');
   }
   document.addEventListener('DOMContentLoaded', () => {

--- a/blog/posts/pre-qualify-scrap-sellers.html
+++ b/blog/posts/pre-qualify-scrap-sellers.html
@@ -26,7 +26,7 @@
 </head>
 <body class="font-sans text-brand-charcoal antialiased bg-white overflow-x-hidden">
   <header class="fixed top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
-<div id="promoBanner" class="bg-white text-brand-orange text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
+<div id="promoBanner" class="bg-brand-orange text-white text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
   <span>Save 10% on your build — pay your deposit by Aug 30. Lock in your slot; go live before peak Q4 scrap season.</span>
   <a href="https://book.stripe.com/eVqeVd8Vi9U45RbdJy73G00" class="btn-secondary whitespace-nowrap">Pay Deposit →</a>
   <span data-days-left class="text-xs"></span>
@@ -71,10 +71,10 @@
   /* full-screen mobile toggle */
   function toggleMobileMenu() {
     const menu = document.getElementById('mobileMenu');
-    const btn = document.getElementById('menuToggle');
+    const btn = document.getElementById('menuToggle');const banner=document.getElementById('promoBanner');
     menu.classList.toggle('hidden');
     const isOpen = !menu.classList.contains('hidden');
-    document.body.classList.toggle('overflow-hidden', isOpen);
+    document.body.classList.toggle('overflow-hidden', isOpen);if(banner) banner.classList.toggle('hidden', isOpen);
     btn.classList.toggle('open');
   }
   document.addEventListener('DOMContentLoaded', () => {

--- a/blog/posts/seo-basics-for-scrap-yards.html
+++ b/blog/posts/seo-basics-for-scrap-yards.html
@@ -26,7 +26,7 @@
 </head>
 <body class="font-sans text-brand-charcoal antialiased bg-white overflow-x-hidden">
   <header class="fixed top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
-<div id="promoBanner" class="bg-white text-brand-orange text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
+<div id="promoBanner" class="bg-brand-orange text-white text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
   <span>Save 10% on your build — pay your deposit by Aug 30. Lock in your slot; go live before peak Q4 scrap season.</span>
   <a href="https://book.stripe.com/eVqeVd8Vi9U45RbdJy73G00" class="btn-secondary whitespace-nowrap">Pay Deposit →</a>
   <span data-days-left class="text-xs"></span>
@@ -71,10 +71,10 @@
   /* full-screen mobile toggle */
   function toggleMobileMenu() {
     const menu = document.getElementById('mobileMenu');
-    const btn = document.getElementById('menuToggle');
+    const btn = document.getElementById('menuToggle');const banner=document.getElementById('promoBanner');
     menu.classList.toggle('hidden');
     const isOpen = !menu.classList.contains('hidden');
-    document.body.classList.toggle('overflow-hidden', isOpen);
+    document.body.classList.toggle('overflow-hidden', isOpen);if(banner) banner.classList.toggle('hidden', isOpen);
     btn.classList.toggle('open');
   }
   document.addEventListener('DOMContentLoaded', () => {

--- a/contact/index.html
+++ b/contact/index.html
@@ -26,7 +26,7 @@
 </head>
 <body class="font-sans text-brand-charcoal antialiased bg-white overflow-x-hidden">
   <header class="fixed top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
-<div id="promoBanner" class="bg-white text-brand-orange text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
+<div id="promoBanner" class="bg-brand-orange text-white text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
   <span>Save 10% on your build — pay your deposit by Aug 30. Lock in your slot; go live before peak Q4 scrap season.</span>
   <a href="https://book.stripe.com/eVqeVd8Vi9U45RbdJy73G00" class="btn-secondary whitespace-nowrap">Pay Deposit →</a>
   <span data-days-left class="text-xs"></span>
@@ -71,10 +71,10 @@
   /* full-screen mobile toggle */
   function toggleMobileMenu() {
     const menu = document.getElementById('mobileMenu');
-    const btn = document.getElementById('menuToggle');
+    const btn = document.getElementById('menuToggle');const banner=document.getElementById('promoBanner');
     menu.classList.toggle('hidden');
     const isOpen = !menu.classList.contains('hidden');
-    document.body.classList.toggle('overflow-hidden', isOpen);
+    document.body.classList.toggle('overflow-hidden', isOpen);if(banner) banner.classList.toggle('hidden', isOpen);
     btn.classList.toggle('open');
   }
   document.addEventListener('DOMContentLoaded', () => {

--- a/demos/demo-yard-1/index.html
+++ b/demos/demo-yard-1/index.html
@@ -26,7 +26,7 @@
 </head>
 <body class="font-sans text-brand-charcoal antialiased bg-white overflow-x-hidden">
   <header class="fixed top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
-<div id="promoBanner" class="bg-white text-brand-orange text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
+<div id="promoBanner" class="bg-brand-orange text-white text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
   <span>Save 10% on your build — pay your deposit by Aug 30. Lock in your slot; go live before peak Q4 scrap season.</span>
   <a href="https://book.stripe.com/eVqeVd8Vi9U45RbdJy73G00" class="btn-secondary whitespace-nowrap">Pay Deposit →</a>
   <span data-days-left class="text-xs"></span>

--- a/demos/demo-yard-2/index.html
+++ b/demos/demo-yard-2/index.html
@@ -26,7 +26,7 @@
 </head>
 <body class="font-sans text-brand-charcoal antialiased bg-white overflow-x-hidden">
   <header class="fixed top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
-<div id="promoBanner" class="bg-white text-brand-orange text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
+<div id="promoBanner" class="bg-brand-orange text-white text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
   <span>Save 10% on your build — pay your deposit by Aug 30. Lock in your slot; go live before peak Q4 scrap season.</span>
   <a href="https://book.stripe.com/eVqeVd8Vi9U45RbdJy73G00" class="btn-secondary whitespace-nowrap">Pay Deposit →</a>
   <span data-days-left class="text-xs"></span>

--- a/demos/demo-yard-3/index.html
+++ b/demos/demo-yard-3/index.html
@@ -26,7 +26,7 @@
 </head>
 <body class="font-sans text-brand-charcoal antialiased bg-white overflow-x-hidden">
   <header class="fixed top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
-<div id="promoBanner" class="bg-white text-brand-orange text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
+<div id="promoBanner" class="bg-brand-orange text-white text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
   <span>Save 10% on your build — pay your deposit by Aug 30. Lock in your slot; go live before peak Q4 scrap season.</span>
   <a href="https://book.stripe.com/eVqeVd8Vi9U45RbdJy73G00" class="btn-secondary whitespace-nowrap">Pay Deposit →</a>
   <span data-days-left class="text-xs"></span>

--- a/demos/index.html
+++ b/demos/index.html
@@ -30,7 +30,7 @@
 </head>
 <body class="font-sans text-brand-charcoal antialiased bg-white overflow-x-hidden">
   <header class="fixed top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
-<div id="promoBanner" class="bg-white text-brand-orange text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
+<div id="promoBanner" class="bg-brand-orange text-white text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
   <span>Save 10% on your build — pay your deposit by Aug 30. Lock in your slot; go live before peak Q4 scrap season.</span>
   <a href="https://book.stripe.com/eVqeVd8Vi9U45RbdJy73G00" class="btn-secondary whitespace-nowrap">Pay Deposit →</a>
   <span data-days-left class="text-xs"></span>
@@ -75,10 +75,10 @@
   /* full-screen mobile toggle */
   function toggleMobileMenu() {
     const menu = document.getElementById('mobileMenu');
-    const btn = document.getElementById('menuToggle');
+    const btn = document.getElementById('menuToggle');const banner=document.getElementById('promoBanner');
     menu.classList.toggle('hidden');
     const isOpen = !menu.classList.contains('hidden');
-    document.body.classList.toggle('overflow-hidden', isOpen);
+    document.body.classList.toggle('overflow-hidden', isOpen);if(banner) banner.classList.toggle('hidden', isOpen);
     btn.classList.toggle('open');
   }
   document.addEventListener('DOMContentLoaded', () => {

--- a/index.html
+++ b/index.html
@@ -171,7 +171,7 @@
 
 <!-- ── Header ─────────────────────────────────────────────── -->
   <header class="fixed top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
-<div id="promoBanner" class="bg-white text-brand-orange text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
+<div id="promoBanner" class="bg-brand-orange text-white text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
   <span>Save 10% on your build — pay your deposit by Aug 30. Lock in your slot; go live before peak Q4 scrap season.</span>
   <a href="https://book.stripe.com/eVqeVd8Vi9U45RbdJy73G00" class="btn-secondary whitespace-nowrap">Pay Deposit →</a>
   <span data-days-left class="text-xs"></span>
@@ -216,10 +216,10 @@
   /* full-screen mobile toggle */
   function toggleMobileMenu() {
     const menu = document.getElementById('mobileMenu');
-    const btn = document.getElementById('menuToggle');
+    const btn = document.getElementById('menuToggle');const banner=document.getElementById('promoBanner');
     menu.classList.toggle('hidden');
     const isOpen = !menu.classList.contains('hidden');
-    document.body.classList.toggle('overflow-hidden', isOpen);
+    document.body.classList.toggle('overflow-hidden', isOpen);if(banner) banner.classList.toggle('hidden', isOpen);
     btn.classList.toggle('open');
   }
 

--- a/pricing/index.html
+++ b/pricing/index.html
@@ -30,7 +30,7 @@
 </head>
 <body class="font-sans text-brand-charcoal antialiased bg-white overflow-x-hidden">
   <header class="fixed top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
-<div id="promoBanner" class="bg-white text-brand-orange text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
+<div id="promoBanner" class="bg-brand-orange text-white text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
   <span>Save 10% on your build — pay your deposit by Aug 30. Lock in your slot; go live before peak Q4 scrap season.</span>
   <a href="https://book.stripe.com/eVqeVd8Vi9U45RbdJy73G00" class="btn-secondary whitespace-nowrap">Pay Deposit →</a>
   <span data-days-left class="text-xs"></span>
@@ -75,10 +75,10 @@
   /* full-screen mobile toggle */
   function toggleMobileMenu() {
     const menu = document.getElementById('mobileMenu');
-    const btn = document.getElementById('menuToggle');
+    const btn = document.getElementById('menuToggle');const banner=document.getElementById('promoBanner');
     menu.classList.toggle('hidden');
     const isOpen = !menu.classList.contains('hidden');
-    document.body.classList.toggle('overflow-hidden', isOpen);
+    document.body.classList.toggle('overflow-hidden', isOpen);if(banner) banner.classList.toggle('hidden', isOpen);
     btn.classList.toggle('open');
   }
   document.addEventListener('DOMContentLoaded', () => {

--- a/privacy/index.html
+++ b/privacy/index.html
@@ -91,7 +91,7 @@
 </head>
 <body class="font-sans text-brand-charcoal antialiased bg-white overflow-x-hidden">
   <header class="fixed top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
-<div id="promoBanner" class="bg-white text-brand-orange text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
+<div id="promoBanner" class="bg-brand-orange text-white text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
   <span>Save 10% on your build — pay your deposit by Aug 30. Lock in your slot; go live before peak Q4 scrap season.</span>
   <a href="https://book.stripe.com/eVqeVd8Vi9U45RbdJy73G00" class="btn-secondary whitespace-nowrap">Pay Deposit →</a>
   <span data-days-left class="text-xs"></span>
@@ -136,10 +136,10 @@
   /* full-screen mobile toggle */
   function toggleMobileMenu() {
     const menu = document.getElementById('mobileMenu');
-    const btn = document.getElementById('menuToggle');
+    const btn = document.getElementById('menuToggle');const banner=document.getElementById('promoBanner');
     menu.classList.toggle('hidden');
     const isOpen = !menu.classList.contains('hidden');
-    document.body.classList.toggle('overflow-hidden', isOpen);
+    document.body.classList.toggle('overflow-hidden', isOpen);if(banner) banner.classList.toggle('hidden', isOpen);
     btn.classList.toggle('open');
   }
   document.addEventListener('DOMContentLoaded', () => {

--- a/process/index.html
+++ b/process/index.html
@@ -90,7 +90,7 @@
 </head>
 <body class="font-sans text-brand-charcoal antialiased bg-white overflow-x-hidden">
   <header class="fixed top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
-<div id="promoBanner" class="bg-white text-brand-orange text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
+<div id="promoBanner" class="bg-brand-orange text-white text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
   <span>Save 10% on your build — pay your deposit by Aug 30. Lock in your slot; go live before peak Q4 scrap season.</span>
   <a href="https://book.stripe.com/eVqeVd8Vi9U45RbdJy73G00" class="btn-secondary whitespace-nowrap">Pay Deposit →</a>
   <span data-days-left class="text-xs"></span>
@@ -135,10 +135,10 @@
   /* full-screen mobile toggle */
   function toggleMobileMenu() {
     const menu = document.getElementById('mobileMenu');
-    const btn = document.getElementById('menuToggle');
+    const btn = document.getElementById('menuToggle');const banner=document.getElementById('promoBanner');
     menu.classList.toggle('hidden');
     const isOpen = !menu.classList.contains('hidden');
-    document.body.classList.toggle('overflow-hidden', isOpen);
+    document.body.classList.toggle('overflow-hidden', isOpen);if(banner) banner.classList.toggle('hidden', isOpen);
     btn.classList.toggle('open');
   }
   document.addEventListener('DOMContentLoaded', () => {

--- a/risk-calculator/index.html
+++ b/risk-calculator/index.html
@@ -89,7 +89,7 @@
     class="font-sans text-brand-charcoal antialiased bg-white overflow-x-hidden"
   >
     <header class="fixed top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
-<div id="promoBanner" class="bg-white text-brand-orange text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
+<div id="promoBanner" class="bg-brand-orange text-white text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
   <span>Save 10% on your build — pay your deposit by Aug 30. Lock in your slot; go live before peak Q4 scrap season.</span>
   <a href="https://book.stripe.com/eVqeVd8Vi9U45RbdJy73G00" class="btn-secondary whitespace-nowrap">Pay Deposit →</a>
   <span data-days-left class="text-xs"></span>
@@ -182,10 +182,10 @@
       /* full-screen mobile toggle */
       function toggleMobileMenu() {
         const menu = document.getElementById("mobileMenu");
-        const btn = document.getElementById("menuToggle");
+        const btn = document.getElementById("menuToggle");const banner=document.getElementById("promoBanner");
         menu.classList.toggle("hidden");
         const isOpen = !menu.classList.contains("hidden");
-        document.body.classList.toggle("overflow-hidden", isOpen);
+        document.body.classList.toggle("overflow-hidden", isOpen);if(banner) banner.classList.toggle("hidden", isOpen);
         btn.classList.toggle("open");
       }
 

--- a/services/index.html
+++ b/services/index.html
@@ -79,7 +79,7 @@
 </head>
 <body class="font-sans text-brand-charcoal antialiased bg-white overflow-x-hidden">
   <header class="fixed top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
-<div id="promoBanner" class="bg-white text-brand-orange text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
+<div id="promoBanner" class="bg-brand-orange text-white text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
   <span>Save 10% on your build — pay your deposit by Aug 30. Lock in your slot; go live before peak Q4 scrap season.</span>
   <a href="https://book.stripe.com/eVqeVd8Vi9U45RbdJy73G00" class="btn-secondary whitespace-nowrap">Pay Deposit →</a>
   <span data-days-left class="text-xs"></span>
@@ -122,7 +122,7 @@
   </header>
   <script>
   /* full-screen mobile toggle */
-  function toggleMobileMenu(){const menu=document.getElementById('mobileMenu');const btn=document.getElementById('menuToggle');menu.classList.toggle('hidden');const isOpen=!menu.classList.contains('hidden');document.body.classList.toggle('overflow-hidden',isOpen);btn.classList.toggle('open');}
+  function toggleMobileMenu(){const menu=document.getElementById('mobileMenu');const btn=document.getElementById('menuToggle');const banner=document.getElementById('promoBanner');menu.classList.toggle('hidden');const isOpen=!menu.classList.contains('hidden');document.body.classList.toggle('overflow-hidden', isOpen);if(banner) banner.classList.toggle('hidden', isOpen);btn.classList.toggle('open');}
   document.addEventListener('DOMContentLoaded',()=>{const currentPath=location.pathname.replace(/\/index.html$/,'').replace(/\/$/,'');document.querySelectorAll('#menu a:not(.no-highlight), #mobileMenu a:not(.no-highlight)').forEach(link=>{const linkPath=new URL(link.getAttribute('href'),location.origin).pathname.replace(/\/index.html$/,'').replace(/\/$/,'');if(linkPath===currentPath){link.classList.add('text-brand-orange');}});document.getElementById('menuToggle')?.addEventListener('click',toggleMobileMenu);document.getElementById('menuClose')?.addEventListener('click',toggleMobileMenu);});
   </script>
   <main class="pb-0 bg-gray-50">

--- a/terms-of-service/index.html
+++ b/terms-of-service/index.html
@@ -30,7 +30,7 @@
 </head>
 <body class="font-sans text-brand-charcoal antialiased bg-white overflow-x-hidden">
   <header class="fixed top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
-<div id="promoBanner" class="bg-white text-brand-orange text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
+<div id="promoBanner" class="bg-brand-orange text-white text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
   <span>Save 10% on your build — pay your deposit by Aug 30. Lock in your slot; go live before peak Q4 scrap season.</span>
   <a href="https://book.stripe.com/eVqeVd8Vi9U45RbdJy73G00" class="btn-secondary whitespace-nowrap">Pay Deposit →</a>
   <span data-days-left class="text-xs"></span>
@@ -75,10 +75,10 @@
   /* full-screen mobile toggle */
   function toggleMobileMenu() {
     const menu = document.getElementById('mobileMenu');
-    const btn = document.getElementById('menuToggle');
+    const btn = document.getElementById('menuToggle');const banner=document.getElementById('promoBanner');
     menu.classList.toggle('hidden');
     const isOpen = !menu.classList.contains('hidden');
-    document.body.classList.toggle('overflow-hidden', isOpen);
+    document.body.classList.toggle('overflow-hidden', isOpen);if(banner) banner.classList.toggle('hidden', isOpen);
     btn.classList.toggle('open');
   }
   document.addEventListener('DOMContentLoaded', () => {


### PR DESCRIPTION
## Summary
- adjust promo banner to use orange background with white text
- hide promo banner when the mobile menu is open

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6883e55b047883298e1df3d0bd3075bf