### PR TITLE
Add theme color meta tag and update on menu toggle

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8"/>
   <meta name="viewport" content="width=device-width,initial-scale=1">
+  <meta name="theme-color" content="#D75E02"/>
   <link rel="preload" href="/assets/fonts/Inter-Variable.woff2" as="font" type="font/woff2" crossorigin>
   <title>About | Scrapyard Sites</title>
   <link rel="icon" href="../favicon.svg"> <!-- prevents 404s on mobile -->
@@ -86,6 +87,8 @@
     const isOpen = !menu.classList.contains('hidden');
     document.body.classList.toggle('overflow-hidden', isOpen);if(banner) banner.classList.toggle('hidden', isOpen);
     btn.classList.toggle('open');
+    const themeMeta=document.querySelector('meta[name=theme-color]');
+    if(themeMeta) themeMeta.setAttribute('content', isOpen ? '#ffffff' : '#D75E02');
   window.dispatchEvent(new Event('resize'));
   }
   document.addEventListener('DOMContentLoaded', () => {

--- a/blog/index.html
+++ b/blog/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8"/>
   <meta name="viewport" content="width=device-width,initial-scale=1">
+  <meta name="theme-color" content="#D75E02"/>
   <link rel="preload" href="/assets/fonts/Inter-Variable.woff2" as="font" type="font/woff2" crossorigin>
   <title>Blog | Scrapyard Sites</title>
   <link rel="icon" href="../favicon.svg"> <!-- prevents 404s on mobile -->
@@ -76,6 +77,8 @@
     const isOpen = !menu.classList.contains('hidden');
     document.body.classList.toggle('overflow-hidden', isOpen);if(banner) banner.classList.toggle('hidden', isOpen);
     btn.classList.toggle('open');
+    const themeMeta=document.querySelector('meta[name=theme-color]');
+    if(themeMeta) themeMeta.setAttribute('content', isOpen ? '#ffffff' : '#D75E02');
   window.dispatchEvent(new Event('resize'));
   }
   document.addEventListener('DOMContentLoaded', () => {

--- a/blog/post-template.html
+++ b/blog/post-template.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8"/>
   <meta name="viewport" content="width=device-width,initial-scale=1">
+  <meta name="theme-color" content="#D75E02"/>
   <link rel="preload" href="/assets/fonts/Inter-Variable.woff2" as="font" type="font/woff2" crossorigin>
   <title><!-- POST TITLE --> | Scrapyard Sites</title>
   <link rel="icon" href="../favicon.svg"> <!-- prevents 404s on mobile -->
@@ -76,6 +77,8 @@
     const isOpen = !menu.classList.contains('hidden');
     document.body.classList.toggle('overflow-hidden', isOpen);if(banner) banner.classList.toggle('hidden', isOpen);
     btn.classList.toggle('open');
+    const themeMeta=document.querySelector('meta[name=theme-color]');
+    if(themeMeta) themeMeta.setAttribute('content', isOpen ? '#ffffff' : '#D75E02');
   window.dispatchEvent(new Event('resize'));
   }
   document.addEventListener('DOMContentLoaded', () => {

--- a/blog/posts/care-plan-essentials.html
+++ b/blog/posts/care-plan-essentials.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8"/>
   <meta name="viewport" content="width=device-width,initial-scale=1">
+  <meta name="theme-color" content="#D75E02"/>
   <link rel="preload" href="/assets/fonts/Inter-Variable.woff2" as="font" type="font/woff2" crossorigin>
   <title>Care Plan Essentials | Scrapyard Sites</title>
   <link rel="icon" href="../favicon.svg"> <!-- prevents 404s on mobile -->
@@ -76,6 +77,8 @@
     const isOpen = !menu.classList.contains('hidden');
     document.body.classList.toggle('overflow-hidden', isOpen);if(banner) banner.classList.toggle('hidden', isOpen);
     btn.classList.toggle('open');
+    const themeMeta=document.querySelector('meta[name=theme-color]');
+    if(themeMeta) themeMeta.setAttribute('content', isOpen ? '#ffffff' : '#D75E02');
   window.dispatchEvent(new Event('resize'));
   }
   document.addEventListener('DOMContentLoaded', () => {

--- a/blog/posts/pre-qualify-scrap-sellers.html
+++ b/blog/posts/pre-qualify-scrap-sellers.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8"/>
   <meta name="viewport" content="width=device-width,initial-scale=1">
+  <meta name="theme-color" content="#D75E02"/>
   <link rel="preload" href="/assets/fonts/Inter-Variable.woff2" as="font" type="font/woff2" crossorigin>
   <title>Pre-Qualify Scrap Sellers | Scrapyard Sites</title>
   <link rel="icon" href="../favicon.svg"> <!-- prevents 404s on mobile -->
@@ -76,6 +77,8 @@
     const isOpen = !menu.classList.contains('hidden');
     document.body.classList.toggle('overflow-hidden', isOpen);if(banner) banner.classList.toggle('hidden', isOpen);
     btn.classList.toggle('open');
+    const themeMeta=document.querySelector('meta[name=theme-color]');
+    if(themeMeta) themeMeta.setAttribute('content', isOpen ? '#ffffff' : '#D75E02');
   window.dispatchEvent(new Event('resize'));
   }
   document.addEventListener('DOMContentLoaded', () => {

--- a/blog/posts/seo-basics-for-scrap-yards.html
+++ b/blog/posts/seo-basics-for-scrap-yards.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8"/>
   <meta name="viewport" content="width=device-width,initial-scale=1">
+  <meta name="theme-color" content="#D75E02"/>
   <link rel="preload" href="/assets/fonts/Inter-Variable.woff2" as="font" type="font/woff2" crossorigin>
   <title>SEO Basics for Scrap Yards | Scrapyard Sites</title>
   <link rel="icon" href="../favicon.svg"> <!-- prevents 404s on mobile -->
@@ -76,6 +77,8 @@
     const isOpen = !menu.classList.contains('hidden');
     document.body.classList.toggle('overflow-hidden', isOpen);if(banner) banner.classList.toggle('hidden', isOpen);
     btn.classList.toggle('open');
+    const themeMeta=document.querySelector('meta[name=theme-color]');
+    if(themeMeta) themeMeta.setAttribute('content', isOpen ? '#ffffff' : '#D75E02');
   window.dispatchEvent(new Event('resize'));
   }
   document.addEventListener('DOMContentLoaded', () => {

--- a/contact/index.html
+++ b/contact/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8"/>
   <meta name="viewport" content="width=device-width,initial-scale=1">
+  <meta name="theme-color" content="#D75E02"/>
   <link rel="preload" href="/assets/fonts/Inter-Variable.woff2" as="font" type="font/woff2" crossorigin>
   <title>Contact | Scrapyard Sites</title>
   <link rel="icon" href="../favicon.svg"> <!-- prevents 404s on mobile -->
@@ -76,6 +77,8 @@
     const isOpen = !menu.classList.contains('hidden');
     document.body.classList.toggle('overflow-hidden', isOpen);if(banner) banner.classList.toggle('hidden', isOpen);
     btn.classList.toggle('open');
+    const themeMeta=document.querySelector('meta[name=theme-color]');
+    if(themeMeta) themeMeta.setAttribute('content', isOpen ? '#ffffff' : '#D75E02');
   window.dispatchEvent(new Event('resize'));
   }
   document.addEventListener('DOMContentLoaded', () => {

--- a/demos/index.html
+++ b/demos/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8"/>
   <meta name="viewport" content="width=device-width,initial-scale=1">
+  <meta name="theme-color" content="#D75E02"/>
   <link rel="preload" href="/assets/fonts/Inter-Variable.woff2" as="font" type="font/woff2" crossorigin>
   <title>Demos | Scrapyard Sites</title>
   <link rel="icon" href="../favicon.svg"> <!-- prevents 404s on mobile -->
@@ -80,6 +81,8 @@
     const isOpen = !menu.classList.contains('hidden');
     document.body.classList.toggle('overflow-hidden', isOpen);if(banner) banner.classList.toggle('hidden', isOpen);
     btn.classList.toggle('open');
+    const themeMeta=document.querySelector('meta[name=theme-color]');
+    if(themeMeta) themeMeta.setAttribute('content', isOpen ? '#ffffff' : '#D75E02');
   window.dispatchEvent(new Event('resize'));
   }
   document.addEventListener('DOMContentLoaded', () => {

--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8"/>
   <meta name="viewport" content="width=device-width,initial-scale=1">
+  <meta name="theme-color" content="#D75E02"/>
   <link rel="preload" href="/assets/fonts/Inter-Variable.woff2" as="font" type="font/woff2" crossorigin>
   <title>Scrapyard Sites | More leads. More loads.</title>
   <meta name="description"
@@ -221,6 +222,8 @@
     const isOpen = !menu.classList.contains('hidden');
     document.body.classList.toggle('overflow-hidden', isOpen);if(banner) banner.classList.toggle('hidden', isOpen);
     btn.classList.toggle('open');
+    const themeMeta=document.querySelector('meta[name=theme-color]');
+    if(themeMeta) themeMeta.setAttribute('content', isOpen ? '#ffffff' : '#D75E02');
   window.dispatchEvent(new Event('resize'));
   }
 

--- a/pricing/index.html
+++ b/pricing/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8"/>
   <meta name="viewport" content="width=device-width,initial-scale=1">
+  <meta name="theme-color" content="#D75E02"/>
   <link rel="preload" href="/assets/fonts/Inter-Variable.woff2" as="font" type="font/woff2" crossorigin>
   <title>Pricing | Scrapyard Sites</title>
   <link rel="icon" href="../favicon.svg"> <!-- prevents 404s on mobile -->
@@ -80,6 +81,8 @@
     const isOpen = !menu.classList.contains('hidden');
     document.body.classList.toggle('overflow-hidden', isOpen);if(banner) banner.classList.toggle('hidden', isOpen);
     btn.classList.toggle('open');
+    const themeMeta=document.querySelector('meta[name=theme-color]');
+    if(themeMeta) themeMeta.setAttribute('content', isOpen ? '#ffffff' : '#D75E02');
   window.dispatchEvent(new Event('resize'));
   }
   document.addEventListener('DOMContentLoaded', () => {

--- a/privacy/index.html
+++ b/privacy/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8"/>
   <meta name="viewport" content="width=device-width,initial-scale=1">
+  <meta name="theme-color" content="#D75E02"/>
   <link rel="preload" href="/assets/fonts/Inter-Variable.woff2" as="font" type="font/woff2" crossorigin>
   <title>Privacy Policy | Scrapyard Sites</title>
   <link rel="icon" href="../favicon.svg"> <!-- prevents 404s on mobile -->
@@ -141,6 +142,8 @@
     const isOpen = !menu.classList.contains('hidden');
     document.body.classList.toggle('overflow-hidden', isOpen);if(banner) banner.classList.toggle('hidden', isOpen);
     btn.classList.toggle('open');
+    const themeMeta=document.querySelector('meta[name=theme-color]');
+    if(themeMeta) themeMeta.setAttribute('content', isOpen ? '#ffffff' : '#D75E02');
   window.dispatchEvent(new Event('resize'));
   }
   document.addEventListener('DOMContentLoaded', () => {

--- a/process/index.html
+++ b/process/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8"/>
   <meta name="viewport" content="width=device-width,initial-scale=1">
+  <meta name="theme-color" content="#D75E02"/>
   <link rel="preload" href="/assets/fonts/Inter-Variable.woff2" as="font" type="font/woff2" crossorigin>
   <title>Our Process | Scrapyard Sites</title>
   <link rel="icon" href="../favicon.svg"> <!-- prevents 404s on mobile -->
@@ -140,6 +141,8 @@
     const isOpen = !menu.classList.contains('hidden');
     document.body.classList.toggle('overflow-hidden', isOpen);if(banner) banner.classList.toggle('hidden', isOpen);
     btn.classList.toggle('open');
+    const themeMeta=document.querySelector('meta[name=theme-color]');
+    if(themeMeta) themeMeta.setAttribute('content', isOpen ? '#ffffff' : '#D75E02');
   window.dispatchEvent(new Event('resize'));
   }
   document.addEventListener('DOMContentLoaded', () => {

--- a/risk-calculator/index.html
+++ b/risk-calculator/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <meta name="theme-color" content="#D75E02"/>
     <link
       rel="preload"
       href="/assets/fonts/Inter-Variable.woff2"
@@ -187,6 +188,8 @@
         const isOpen = !menu.classList.contains("hidden");
         document.body.classList.toggle("overflow-hidden", isOpen);if(banner) banner.classList.toggle("hidden", isOpen);
         btn.classList.toggle("open");
+        const themeMeta = document.querySelector('meta[name=theme-color]');
+        if(themeMeta) themeMeta.setAttribute("content", isOpen ? "#ffffff" : "#D75E02");
         window.dispatchEvent(new Event('resize'));
       }
 

--- a/services/index.html
+++ b/services/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8"/>
   <meta name="viewport" content="width=device-width,initial-scale=1">
+  <meta name="theme-color" content="#D75E02"/>
   <link rel="preload" href="/assets/fonts/Inter-Variable.woff2" as="font" type="font/woff2" crossorigin>
   <title>Services | Scrapyard Sites</title>
   <link rel="icon" href="../favicon.svg"> <!-- prevents 404s on mobile -->
@@ -123,6 +124,8 @@
   <script>
   /* full-screen mobile toggle */
   function toggleMobileMenu(){const menu=document.getElementById('mobileMenu');const btn=document.getElementById('menuToggle');const banner=document.getElementById('promoBanner');menu.classList.toggle('hidden');const isOpen=!menu.classList.contains('hidden');document.body.classList.toggle('overflow-hidden', isOpen);if(banner) banner.classList.toggle('hidden', isOpen);btn.classList.toggle('open');}
+    const themeMeta=document.querySelector('meta[name=theme-color]');
+    if(themeMeta) themeMeta.setAttribute('content', isOpen ? '#ffffff' : '#D75E02');
   window.dispatchEvent(new Event('resize'));
   document.addEventListener('DOMContentLoaded',()=>{const currentPath=location.pathname.replace(/\/index.html$/,'').replace(/\/$/,'');document.querySelectorAll('#menu a:not(.no-highlight), #mobileMenu a:not(.no-highlight)').forEach(link=>{const linkPath=new URL(link.getAttribute('href'),location.origin).pathname.replace(/\/index.html$/,'').replace(/\/$/,'');if(linkPath===currentPath){link.classList.add('text-brand-orange');}});document.getElementById('menuToggle')?.addEventListener('click',toggleMobileMenu);document.getElementById('menuClose')?.addEventListener('click',toggleMobileMenu);});
   </script>

--- a/terms-of-service/index.html
+++ b/terms-of-service/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8"/>
   <meta name="viewport" content="width=device-width,initial-scale=1">
+  <meta name="theme-color" content="#D75E02"/>
   <link rel="preload" href="/assets/fonts/Inter-Variable.woff2" as="font" type="font/woff2" crossorigin>
   <title>Terms of Service | Scrapyard Sites</title>
   <link rel="icon" href="../favicon.svg"> <!-- prevents 404s on mobile -->
@@ -80,6 +81,8 @@
     const isOpen = !menu.classList.contains('hidden');
     document.body.classList.toggle('overflow-hidden', isOpen);if(banner) banner.classList.toggle('hidden', isOpen);
     btn.classList.toggle('open');
+    const themeMeta=document.querySelector('meta[name=theme-color]');
+    if(themeMeta) themeMeta.setAttribute('content', isOpen ? '#ffffff' : '#D75E02');
   window.dispatchEvent(new Event('resize'));
   }
   document.addEventListener('DOMContentLoaded', () => {


### PR DESCRIPTION
## Summary
- set `<meta name="theme-color" content="#D75E02">` on all pages
- update `toggleMobileMenu()` to restore orange theme color when the mobile menu closes

## Testing
- `git diff --stat`


------
https://chatgpt.com/codex/tasks/task_e_6883f42c564c8329b571e565aef3145f