### PR TITLE
Add spacing before CTA subtext

### DIFF
--- a/index.html
+++ b/index.html
@@ -262,7 +262,7 @@
       Without that trust, you’re just another yard to avoid.
     </p>
     <div class="mt-8 flex flex-col sm:flex-row gap-4 justify-center">
-      <a href="/contact" class="btn-primary hero-cta">Book a Discovery Call<span class="cta-subtext">15&nbsp;min • No obligation</span></a>
+      <a href="/contact" class="btn-primary hero-cta">Book a Discovery Call <span class="cta-subtext">15&nbsp;min • No obligation</span></a>
       <a href="/pricing" class="btn-secondary hero-cta">See Pricing&nbsp;→</a>
     </div>
   </div>
@@ -557,7 +557,7 @@
       </div>
     </div>
     <div class="mt-10 text-center">
-      <a href="https://book.stripe.com/eVqeVd8Vi9U45RbdJy73G00" class="btn-primary">Pay Deposit & Reserve My Build Week<span class="cta-subtext">50% today • Balance at launch</span></a>
+      <a href="https://book.stripe.com/eVqeVd8Vi9U45RbdJy73G00" class="btn-primary">Pay Deposit & Reserve My Build Week <span class="cta-subtext">50% today • Balance at launch</span></a>
       <p class="text-xs text-brand-steel mt-2">50% deposit now, balance at launch. <a href="/pricing" class="underline">90‑day ROI guarantee</a>.</p>
     </div>
   </div>

--- a/pricing/index.html
+++ b/pricing/index.html
@@ -167,7 +167,7 @@
         </div>
           
 <div class="mt-6 pt-0.5 text-center">
-  <a href="/contact?plan=selected" class="btn-primary">Pay Deposit & Reserve My Build Week<span class="cta-subtext">50% today • Balance at launch</span></a>
+  <a href="/contact?plan=selected" class="btn-primary">Pay Deposit & Reserve My Build Week <span class="cta-subtext">50% today • Balance at launch</span></a>
 </div>
 </div>
       <!-- FAQ stays below packages -->
@@ -212,7 +212,7 @@
     <section class="mt-16 py-12 bg-brand-orange text-white text-center">
       <h2 class="text-2xl font-bold mb-4">Ready to protect your reputation? Lock in your build week now.</h2>
       <div class="flex flex-col sm:flex-row gap-4 justify-center items-center">
-        <a href="https://book.stripe.com/eVqeVd8Vi9U45RbdJy73G00" class="btn-secondary">Pay Deposit & Reserve My Build Week<span class="cta-subtext">50% today • Balance at launch</span></a>
+        <a href="https://book.stripe.com/eVqeVd8Vi9U45RbdJy73G00" class="btn-secondary">Pay Deposit & Reserve My Build Week <span class="cta-subtext">50% today • Balance at launch</span></a>
       </div>
     </section>
   </main>

--- a/risk-calculator/index.html
+++ b/risk-calculator/index.html
@@ -257,7 +257,7 @@
               <p class="text-sm mt-2">
                 A Standard Launch pays for itself in <strong id="roiDays">‑‑</strong> days.
               </p>
-              <a id="contactBtn" href="https://book.stripe.com/eVqeVd8Vi9U45RbdJy73G00" class="btn-primary mt-6 inline-block">Pay Deposit & Reserve My Build Week<span class="cta-subtext">50% today • Balance at launch</span></a>
+              <a id="contactBtn" href="https://book.stripe.com/eVqeVd8Vi9U45RbdJy73G00" class="btn-primary mt-6 inline-block">Pay Deposit & Reserve My Build Week <span class="cta-subtext">50% today • Balance at launch</span></a>
               <p class="text-xs text-brand-steel mt-2">50% deposit now, balance at launch. <a href="/pricing" class="underline">90‑day ROI guarantee</a>.</p>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- fix missing space before CTA subtext when inline

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6883f9d39e348329ae165654dcd2280c