### PR TITLE
Fix hero CTA text spacing

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -72,6 +72,9 @@
     border-color: transparent;
   }
 }
+.hero-cta {
+  flex-direction: column;
+}
 .cta-subtext {
   display: block;
   font-size: 0.75rem;


### PR DESCRIPTION
## Summary
- stack hero CTA text and subtext vertically by default so a space isn't needed when inline

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6883fd634b3c8329901a44dfb81a6f9e