### PR TITLE
Remove Pay Deposit button in promo banners

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -38,7 +38,6 @@
   <header class="fixed top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
 <div id="promoBanner" class="bg-brand-orange text-white text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
   <span>Save 10% on your build — pay your deposit by Aug 30. Lock in your slot; go live before peak Q4 scrap season.</span>
-  <a href="https://book.stripe.com/eVqeVd8Vi9U45RbdJy73G00" class="btn-secondary whitespace-nowrap">Pay Deposit →</a>
   <span data-days-left class="text-xs"></span>
   <span class="text-xs"><a href="/pricing" class="underline">50% today, balance at launch – 90‑day ROI guarantee</a></span>
 </div>

--- a/blog/index.html
+++ b/blog/index.html
@@ -29,7 +29,6 @@
   <header class="fixed top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
 <div id="promoBanner" class="bg-brand-orange text-white text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
   <span>Save 10% on your build — pay your deposit by Aug 30. Lock in your slot; go live before peak Q4 scrap season.</span>
-  <a href="https://book.stripe.com/eVqeVd8Vi9U45RbdJy73G00" class="btn-secondary whitespace-nowrap">Pay Deposit →</a>
   <span data-days-left class="text-xs"></span>
   <span class="text-xs"><a href="/pricing" class="underline">50% today, balance at launch – 90‑day ROI guarantee</a></span>
 </div>

--- a/blog/post-template.html
+++ b/blog/post-template.html
@@ -29,7 +29,6 @@
   <header class="fixed top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
 <div id="promoBanner" class="bg-brand-orange text-white text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
   <span>Save 10% on your build — pay your deposit by Aug 30. Lock in your slot; go live before peak Q4 scrap season.</span>
-  <a href="https://book.stripe.com/eVqeVd8Vi9U45RbdJy73G00" class="btn-secondary whitespace-nowrap">Pay Deposit →</a>
   <span data-days-left class="text-xs"></span>
   <span class="text-xs"><a href="/pricing" class="underline">50% today, balance at launch – 90‑day ROI guarantee</a></span>
 </div>

--- a/blog/posts/care-plan-essentials.html
+++ b/blog/posts/care-plan-essentials.html
@@ -29,7 +29,6 @@
   <header class="fixed top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
 <div id="promoBanner" class="bg-brand-orange text-white text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
   <span>Save 10% on your build — pay your deposit by Aug 30. Lock in your slot; go live before peak Q4 scrap season.</span>
-  <a href="https://book.stripe.com/eVqeVd8Vi9U45RbdJy73G00" class="btn-secondary whitespace-nowrap">Pay Deposit →</a>
   <span data-days-left class="text-xs"></span>
   <span class="text-xs"><a href="/pricing" class="underline">50% today, balance at launch – 90‑day ROI guarantee</a></span>
 </div>

--- a/blog/posts/pre-qualify-scrap-sellers.html
+++ b/blog/posts/pre-qualify-scrap-sellers.html
@@ -29,7 +29,6 @@
   <header class="fixed top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
 <div id="promoBanner" class="bg-brand-orange text-white text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
   <span>Save 10% on your build — pay your deposit by Aug 30. Lock in your slot; go live before peak Q4 scrap season.</span>
-  <a href="https://book.stripe.com/eVqeVd8Vi9U45RbdJy73G00" class="btn-secondary whitespace-nowrap">Pay Deposit →</a>
   <span data-days-left class="text-xs"></span>
   <span class="text-xs"><a href="/pricing" class="underline">50% today, balance at launch – 90‑day ROI guarantee</a></span>
 </div>

--- a/blog/posts/seo-basics-for-scrap-yards.html
+++ b/blog/posts/seo-basics-for-scrap-yards.html
@@ -29,7 +29,6 @@
   <header class="fixed top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
 <div id="promoBanner" class="bg-brand-orange text-white text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
   <span>Save 10% on your build — pay your deposit by Aug 30. Lock in your slot; go live before peak Q4 scrap season.</span>
-  <a href="https://book.stripe.com/eVqeVd8Vi9U45RbdJy73G00" class="btn-secondary whitespace-nowrap">Pay Deposit →</a>
   <span data-days-left class="text-xs"></span>
   <span class="text-xs"><a href="/pricing" class="underline">50% today, balance at launch – 90‑day ROI guarantee</a></span>
 </div>

--- a/contact/index.html
+++ b/contact/index.html
@@ -29,7 +29,6 @@
   <header class="fixed top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
 <div id="promoBanner" class="bg-brand-orange text-white text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
   <span>Save 10% on your build — pay your deposit by Aug 30. Lock in your slot; go live before peak Q4 scrap season.</span>
-  <a href="https://book.stripe.com/eVqeVd8Vi9U45RbdJy73G00" class="btn-secondary whitespace-nowrap">Pay Deposit →</a>
   <span data-days-left class="text-xs"></span>
   <span class="text-xs"><a href="/pricing" class="underline">50% today, balance at launch – 90‑day ROI guarantee</a></span>
 </div>

--- a/demos/demo-yard-1/index.html
+++ b/demos/demo-yard-1/index.html
@@ -28,7 +28,6 @@
   <header class="fixed top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
 <div id="promoBanner" class="bg-brand-orange text-white text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
   <span>Save 10% on your build — pay your deposit by Aug 30. Lock in your slot; go live before peak Q4 scrap season.</span>
-  <a href="https://book.stripe.com/eVqeVd8Vi9U45RbdJy73G00" class="btn-secondary whitespace-nowrap">Pay Deposit →</a>
   <span data-days-left class="text-xs"></span>
   <span class="text-xs"><a href="/pricing" class="underline">50% today, balance at launch – 90‑day ROI guarantee</a></span>
 </div>

--- a/demos/demo-yard-2/index.html
+++ b/demos/demo-yard-2/index.html
@@ -28,7 +28,6 @@
   <header class="fixed top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
 <div id="promoBanner" class="bg-brand-orange text-white text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
   <span>Save 10% on your build — pay your deposit by Aug 30. Lock in your slot; go live before peak Q4 scrap season.</span>
-  <a href="https://book.stripe.com/eVqeVd8Vi9U45RbdJy73G00" class="btn-secondary whitespace-nowrap">Pay Deposit →</a>
   <span data-days-left class="text-xs"></span>
   <span class="text-xs"><a href="/pricing" class="underline">50% today, balance at launch – 90‑day ROI guarantee</a></span>
 </div>

--- a/demos/demo-yard-3/index.html
+++ b/demos/demo-yard-3/index.html
@@ -28,7 +28,6 @@
   <header class="fixed top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
 <div id="promoBanner" class="bg-brand-orange text-white text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
   <span>Save 10% on your build — pay your deposit by Aug 30. Lock in your slot; go live before peak Q4 scrap season.</span>
-  <a href="https://book.stripe.com/eVqeVd8Vi9U45RbdJy73G00" class="btn-secondary whitespace-nowrap">Pay Deposit →</a>
   <span data-days-left class="text-xs"></span>
   <span class="text-xs"><a href="/pricing" class="underline">50% today, balance at launch – 90‑day ROI guarantee</a></span>
 </div>

--- a/demos/index.html
+++ b/demos/index.html
@@ -33,7 +33,6 @@
   <header class="fixed top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
 <div id="promoBanner" class="bg-brand-orange text-white text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
   <span>Save 10% on your build — pay your deposit by Aug 30. Lock in your slot; go live before peak Q4 scrap season.</span>
-  <a href="https://book.stripe.com/eVqeVd8Vi9U45RbdJy73G00" class="btn-secondary whitespace-nowrap">Pay Deposit →</a>
   <span data-days-left class="text-xs"></span>
   <span class="text-xs"><a href="/pricing" class="underline">50% today, balance at launch – 90‑day ROI guarantee</a></span>
 </div>

--- a/index.html
+++ b/index.html
@@ -174,7 +174,6 @@
   <header class="fixed top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
 <div id="promoBanner" class="bg-brand-orange text-white text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
   <span>Save 10% on your build — pay your deposit by Aug 30. Lock in your slot; go live before peak Q4 scrap season.</span>
-  <a href="https://book.stripe.com/eVqeVd8Vi9U45RbdJy73G00" class="btn-secondary whitespace-nowrap">Pay Deposit →</a>
   <span data-days-left class="text-xs"></span>
   <span class="text-xs"><a href="/pricing" class="underline">50% today, balance at launch – 90‑day ROI guarantee</a></span>
 </div>

--- a/pricing/index.html
+++ b/pricing/index.html
@@ -33,7 +33,6 @@
   <header class="fixed top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
 <div id="promoBanner" class="bg-brand-orange text-white text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
   <span>Save 10% on your build — pay your deposit by Aug 30. Lock in your slot; go live before peak Q4 scrap season.</span>
-  <a href="https://book.stripe.com/eVqeVd8Vi9U45RbdJy73G00" class="btn-secondary whitespace-nowrap">Pay Deposit →</a>
   <span data-days-left class="text-xs"></span>
   <span class="text-xs"><a href="/pricing" class="underline">50% today, balance at launch – 90‑day ROI guarantee</a></span>
 </div>

--- a/privacy/index.html
+++ b/privacy/index.html
@@ -94,7 +94,6 @@
   <header class="fixed top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
 <div id="promoBanner" class="bg-brand-orange text-white text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
   <span>Save 10% on your build — pay your deposit by Aug 30. Lock in your slot; go live before peak Q4 scrap season.</span>
-  <a href="https://book.stripe.com/eVqeVd8Vi9U45RbdJy73G00" class="btn-secondary whitespace-nowrap">Pay Deposit →</a>
   <span data-days-left class="text-xs"></span>
   <span class="text-xs"><a href="/pricing" class="underline">50% today, balance at launch – 90‑day ROI guarantee</a></span>
 </div>

--- a/process/index.html
+++ b/process/index.html
@@ -93,7 +93,6 @@
   <header class="fixed top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
 <div id="promoBanner" class="bg-brand-orange text-white text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
   <span>Save 10% on your build — pay your deposit by Aug 30. Lock in your slot; go live before peak Q4 scrap season.</span>
-  <a href="https://book.stripe.com/eVqeVd8Vi9U45RbdJy73G00" class="btn-secondary whitespace-nowrap">Pay Deposit →</a>
   <span data-days-left class="text-xs"></span>
   <span class="text-xs"><a href="/pricing" class="underline">50% today, balance at launch – 90‑day ROI guarantee</a></span>
 </div>

--- a/risk-calculator/index.html
+++ b/risk-calculator/index.html
@@ -92,7 +92,6 @@
     <header class="fixed top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
 <div id="promoBanner" class="bg-brand-orange text-white text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
   <span>Save 10% on your build — pay your deposit by Aug 30. Lock in your slot; go live before peak Q4 scrap season.</span>
-  <a href="https://book.stripe.com/eVqeVd8Vi9U45RbdJy73G00" class="btn-secondary whitespace-nowrap">Pay Deposit →</a>
   <span data-days-left class="text-xs"></span>
   <span class="text-xs"><a href="/pricing" class="underline">50% today, balance at launch – 90‑day ROI guarantee</a></span>
 </div>

--- a/services/index.html
+++ b/services/index.html
@@ -82,7 +82,6 @@
   <header class="fixed top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
 <div id="promoBanner" class="bg-brand-orange text-white text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
   <span>Save 10% on your build — pay your deposit by Aug 30. Lock in your slot; go live before peak Q4 scrap season.</span>
-  <a href="https://book.stripe.com/eVqeVd8Vi9U45RbdJy73G00" class="btn-secondary whitespace-nowrap">Pay Deposit →</a>
   <span data-days-left class="text-xs"></span>
   <span class="text-xs"><a href="/pricing" class="underline">50% today, balance at launch – 90‑day ROI guarantee</a></span>
 </div>

--- a/terms-of-service/index.html
+++ b/terms-of-service/index.html
@@ -33,7 +33,6 @@
   <header class="fixed top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
 <div id="promoBanner" class="bg-brand-orange text-white text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
   <span>Save 10% on your build — pay your deposit by Aug 30. Lock in your slot; go live before peak Q4 scrap season.</span>
-  <a href="https://book.stripe.com/eVqeVd8Vi9U45RbdJy73G00" class="btn-secondary whitespace-nowrap">Pay Deposit →</a>
   <span data-days-left class="text-xs"></span>
   <span class="text-xs"><a href="/pricing" class="underline">50% today, balance at launch – 90‑day ROI guarantee</a></span>
 </div>


### PR DESCRIPTION
## Summary
- remove "Pay Deposit" link from promotional banners on every page

## Testing
- `grep -R "Pay Deposit →" -n`

------
https://chatgpt.com/codex/tasks/task_e_6884005bac4c8329949ac65788996342