### PR TITLE
Remove CTA subtext from homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -556,7 +556,7 @@
       </div>
     </div>
     <div class="mt-10 text-center">
-      <a href="https://book.stripe.com/eVqeVd8Vi9U45RbdJy73G00" class="btn-primary">Pay Deposit & Reserve My Build Week <span class="cta-subtext">50% today • Balance at launch</span></a>
+      <a href="https://book.stripe.com/eVqeVd8Vi9U45RbdJy73G00" class="btn-primary">Pay Deposit & Reserve My Build Week</a>
       <p class="text-xs text-brand-steel mt-2">50% deposit now, balance at launch. <a href="/pricing" class="underline">90‑day ROI guarantee</a>.</p>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- remove the "50% today • Balance at launch" subtext from the pricing CTA on the homepage

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688405ceb19c8329b516f497511a2fdb