### PR TITLE
Fix mobile banner hide

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -156,6 +156,11 @@ header.fixed {
   }
 }
 
+/* Hide promo banner when mobile menu is open */
+body.overflow-hidden #promoBanner {
+  display: none;
+}
+
 /* Ensure mobile menu toggle icons remain visible */
 #menuToggle svg {
   color: #2b2b2b;


### PR DESCRIPTION
## Summary
- hide the promo banner via CSS when the mobile menu opens

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68840704db308329be0eaa0f46399165