### PR TITLE
Fix promo banner spacing

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -143,7 +143,7 @@ header.fixed {
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 0.5rem;
+  gap: 0.25rem;
   padding: 0.5rem 1rem;
   background-color: #d75e02;
   color: #fff;


### PR DESCRIPTION
## Summary
- adjust gap between text and subtext in the promo banner

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68840982b194832984addea636ca5906