### PR TITLE
Fix duplicate mobile menu close icons

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -173,14 +173,17 @@ body.overflow-hidden #promoBanner {
 /* Position the close button in the top-right corner */
 
 /* Center icons inside mobile menu toggle buttons */
-#menuToggle,
-#menuClose {
+#menuToggle {
   align-items: center;
   justify-content: center;
   display: inline-flex;
   pointer-events: auto;
   position: relative;
   z-index: 70;
+}
+
+#menuClose {
+  display: none;
 }
 
 @media (min-width: 1024px) {
@@ -200,6 +203,7 @@ body.overflow-hidden #promoBanner {
 #menuToggle.open .icon-close {
   display: inline;
 }
+
 
 /* Default charcoal text for navigation links */
 header nav ul a {


### PR DESCRIPTION
## Summary
- hide the dedicated mobile menu close button to keep only one X icon
- revert hiding the menu toggle

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_68841f11937483298661c9d452541ff1