### PR TITLE
Remove subtext from calculator CTA

### DIFF
--- a/risk-calculator/index.html
+++ b/risk-calculator/index.html
@@ -255,7 +255,7 @@
               <p class="text-sm mt-2">
                 A Standard Launch pays for itself in <strong id="roiDays">‑‑</strong> days.
               </p>
-              <a id="contactBtn" href="https://book.stripe.com/eVqeVd8Vi9U45RbdJy73G00" class="btn-primary mt-6 inline-block">Pay Deposit & Reserve My Build Week <span class="cta-subtext">50% today • Balance at launch</span></a>
+              <a id="contactBtn" href="https://book.stripe.com/eVqeVd8Vi9U45RbdJy73G00" class="btn-primary mt-6 inline-block">Pay Deposit & Reserve My Build Week</a>
               <p class="text-xs text-brand-steel mt-2">50% deposit now, balance at launch. <a href="/pricing" class="underline">90‑day ROI guarantee</a>.</p>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- remove subtext from the risk calculator deposit button

## Testing
- `grep -n "cta-subtext" -n risk-calculator/index.html`


------
https://chatgpt.com/codex/tasks/task_e_68844204362483299378c8270aed25c3