### PR TITLE
Enhance pricing callouts

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -38,7 +38,7 @@
   <header class="fixed top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
 <div id="promoBanner" class="bg-brand-orange text-white text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
   <span>Save 10% on your build — pay your deposit by Aug 30.</span>
-  <span class="text-xs"><a href="/pricing" class="underline">50% today, balance at launch – 90‑day ROI guarantee</a></span>
+  <span class="text-xs"><a href="/pricing#roi" class="underline">50% today, balance at launch – 90‑day ROI guarantee</a></span>
 </div>
     <nav class="max-w-7xl mx-auto relative flex items-center justify-between py-3 px-6">
       <a href="/" class="flex items-center gap-2"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-8 w-8"/><span class="site-title text-xl text-brand-charcoal"><span class="font-bold text-brand-orange">Scrapyard</span> <span class="font-bold">Sites</span></span></a>
@@ -52,7 +52,7 @@
         <li><a href="/services">Services</a></li>
         <li><a href="/process">Process</a></li>
         <li><a href="/demos">Demos</a></li>
-        <li><a href="/pricing">Pricing</a></li>
+        <li><a href="/pricing#roi">Pricing</a></li>
         <li><a href="/risk-calculator">Calculator</a></li>
         <li><a href="/about">About</a></li>
         <li><a href="/contact">Contact</a></li>
@@ -69,7 +69,7 @@
       <a href="/services">Services</a>
       <a href="/process">Process</a>
       <a href="/demos">Demos</a>
-      <a href="/pricing">Pricing</a>
+      <a href="/pricing#roi">Pricing</a>
       <a href="/risk-calculator">Calculator</a>
       <a href="/about">About</a>
       <a href="/contact">Contact</a>
@@ -202,7 +202,7 @@
     <a href="/services">Services</a>
     <a href="/process">Process</a>
     <a href="/demos">Demos</a>
-    <a href="/pricing">Pricing</a>
+    <a href="/pricing#roi">Pricing</a>
     <a href="/risk-calculator">Calculator</a>
     <a href="/blog">Blog</a>
     <a href="/contact">Contact</a>

--- a/blog/index.html
+++ b/blog/index.html
@@ -29,7 +29,7 @@
   <header class="fixed top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
 <div id="promoBanner" class="bg-brand-orange text-white text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
   <span>Save 10% on your build — pay your deposit by Aug 30.</span>
-  <span class="text-xs"><a href="/pricing" class="underline">50% today, balance at launch – 90‑day ROI guarantee</a></span>
+  <span class="text-xs"><a href="/pricing#roi" class="underline">50% today, balance at launch – 90‑day ROI guarantee</a></span>
 </div>
     <nav class="max-w-7xl mx-auto relative flex items-center justify-between py-3 px-6">
       <a href="/" class="flex items-center gap-2"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-8 w-8"/><span class="site-title text-xl text-brand-charcoal"><span class="font-bold text-brand-orange">Scrapyard</span> <span class="font-bold">Sites</span></span></a>
@@ -43,7 +43,7 @@
         <li><a href="/services">Services</a></li>
         <li><a href="/process">Process</a></li>
         <li><a href="/demos">Demos</a></li>
-        <li><a href="/pricing">Pricing</a></li>
+        <li><a href="/pricing#roi">Pricing</a></li>
         <li><a href="/risk-calculator">Calculator</a></li>
         <li><a href="/about">About</a></li>
         <li><a href="/contact">Contact</a></li>
@@ -59,7 +59,7 @@
       <a href="/services">Services</a>
       <a href="/process">Process</a>
       <a href="/demos">Demos</a>
-      <a href="/pricing">Pricing</a>
+      <a href="/pricing#roi">Pricing</a>
       <a href="/risk-calculator">Calculator</a>
       <a href="/about">About</a>
       <a href="/contact">Contact</a>
@@ -154,7 +154,7 @@
     <a href="/services">Services</a>
     <a href="/process">Process</a>
     <a href="/demos">Demos</a>
-    <a href="/pricing">Pricing</a>
+    <a href="/pricing#roi">Pricing</a>
     <a href="/risk-calculator">Calculator</a>
     <a href="/blog">Blog</a>
     <a href="/contact">Contact</a>

--- a/blog/post-template.html
+++ b/blog/post-template.html
@@ -29,7 +29,7 @@
   <header class="fixed top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
 <div id="promoBanner" class="bg-brand-orange text-white text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
   <span>Save 10% on your build — pay your deposit by Aug 30.</span>
-  <span class="text-xs"><a href="/pricing" class="underline">50% today, balance at launch – 90‑day ROI guarantee</a></span>
+  <span class="text-xs"><a href="/pricing#roi" class="underline">50% today, balance at launch – 90‑day ROI guarantee</a></span>
 </div>
     <nav class="max-w-7xl mx-auto relative flex items-center justify-between py-3 px-6">
       <a href="/" class="flex items-center gap-2"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-8 w-8"/><span class="site-title text-xl text-brand-charcoal"><span class="font-bold text-brand-orange">Scrapyard</span> <span class="font-bold">Sites</span></span></a>
@@ -43,7 +43,7 @@
         <li><a href="/services">Services</a></li>
         <li><a href="/process">Process</a></li>
         <li><a href="/demos">Demos</a></li>
-        <li><a href="/pricing">Pricing</a></li>
+        <li><a href="/pricing#roi">Pricing</a></li>
         <li><a href="/risk-calculator">Calculator</a></li>
         <li><a href="/about">About</a></li>
         <li><a href="/contact">Contact</a></li>
@@ -59,7 +59,7 @@
       <a href="/services">Services</a>
       <a href="/process">Process</a>
       <a href="/demos">Demos</a>
-      <a href="/pricing">Pricing</a>
+      <a href="/pricing#roi">Pricing</a>
       <a href="/risk-calculator">Calculator</a>
       <a href="/about">About</a>
       <a href="/contact">Contact</a>
@@ -116,7 +116,7 @@
     <a href="/services">Services</a>
     <a href="/process">Process</a>
     <a href="/demos">Demos</a>
-    <a href="/pricing">Pricing</a>
+    <a href="/pricing#roi">Pricing</a>
     <a href="/risk-calculator">Calculator</a>
     <a href="/blog">Blog</a>
     <a href="/contact">Contact</a>

--- a/blog/posts/care-plan-essentials.html
+++ b/blog/posts/care-plan-essentials.html
@@ -29,7 +29,7 @@
   <header class="fixed top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
 <div id="promoBanner" class="bg-brand-orange text-white text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
   <span>Save 10% on your build — pay your deposit by Aug 30.</span>
-  <span class="text-xs"><a href="/pricing" class="underline">50% today, balance at launch – 90‑day ROI guarantee</a></span>
+  <span class="text-xs"><a href="/pricing#roi" class="underline">50% today, balance at launch – 90‑day ROI guarantee</a></span>
 </div>
     <nav class="max-w-7xl mx-auto relative flex items-center justify-between py-3 px-6">
       <a href="/" class="flex items-center gap-2"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-8 w-8"/><span class="site-title text-xl text-brand-charcoal"><span class="font-bold text-brand-orange">Scrapyard</span> <span class="font-bold">Sites</span></span></a>
@@ -43,7 +43,7 @@
         <li><a href="/services">Services</a></li>
         <li><a href="/process">Process</a></li>
         <li><a href="/demos">Demos</a></li>
-        <li><a href="/pricing">Pricing</a></li>
+        <li><a href="/pricing#roi">Pricing</a></li>
         <li><a href="/risk-calculator">Calculator</a></li>
         <li><a href="/about">About</a></li>
         <li><a href="/contact">Contact</a></li>
@@ -59,7 +59,7 @@
       <a href="/services">Services</a>
       <a href="/process">Process</a>
       <a href="/demos">Demos</a>
-      <a href="/pricing">Pricing</a>
+      <a href="/pricing#roi">Pricing</a>
       <a href="/risk-calculator">Calculator</a>
       <a href="/about">About</a>
       <a href="/contact">Contact</a>
@@ -116,7 +116,7 @@
     <a href="/services">Services</a>
     <a href="/process">Process</a>
     <a href="/demos">Demos</a>
-    <a href="/pricing">Pricing</a>
+    <a href="/pricing#roi">Pricing</a>
     <a href="/risk-calculator">Calculator</a>
     <a href="/blog">Blog</a>
     <a href="/contact">Contact</a>

--- a/blog/posts/pre-qualify-scrap-sellers.html
+++ b/blog/posts/pre-qualify-scrap-sellers.html
@@ -29,7 +29,7 @@
   <header class="fixed top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
 <div id="promoBanner" class="bg-brand-orange text-white text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
   <span>Save 10% on your build — pay your deposit by Aug 30.</span>
-  <span class="text-xs"><a href="/pricing" class="underline">50% today, balance at launch – 90‑day ROI guarantee</a></span>
+  <span class="text-xs"><a href="/pricing#roi" class="underline">50% today, balance at launch – 90‑day ROI guarantee</a></span>
 </div>
     <nav class="max-w-7xl mx-auto relative flex items-center justify-between py-3 px-6">
       <a href="/" class="flex items-center gap-2"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-8 w-8"/><span class="site-title text-xl text-brand-charcoal"><span class="font-bold text-brand-orange">Scrapyard</span> <span class="font-bold">Sites</span></span></a>
@@ -43,7 +43,7 @@
         <li><a href="/services">Services</a></li>
         <li><a href="/process">Process</a></li>
         <li><a href="/demos">Demos</a></li>
-        <li><a href="/pricing">Pricing</a></li>
+        <li><a href="/pricing#roi">Pricing</a></li>
         <li><a href="/risk-calculator">Calculator</a></li>
         <li><a href="/about">About</a></li>
         <li><a href="/contact">Contact</a></li>
@@ -59,7 +59,7 @@
       <a href="/services">Services</a>
       <a href="/process">Process</a>
       <a href="/demos">Demos</a>
-      <a href="/pricing">Pricing</a>
+      <a href="/pricing#roi">Pricing</a>
       <a href="/risk-calculator">Calculator</a>
       <a href="/about">About</a>
       <a href="/contact">Contact</a>
@@ -116,7 +116,7 @@
     <a href="/services">Services</a>
     <a href="/process">Process</a>
     <a href="/demos">Demos</a>
-    <a href="/pricing">Pricing</a>
+    <a href="/pricing#roi">Pricing</a>
     <a href="/risk-calculator">Calculator</a>
     <a href="/blog">Blog</a>
     <a href="/contact">Contact</a>

--- a/blog/posts/seo-basics-for-scrap-yards.html
+++ b/blog/posts/seo-basics-for-scrap-yards.html
@@ -29,7 +29,7 @@
   <header class="fixed top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
 <div id="promoBanner" class="bg-brand-orange text-white text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
   <span>Save 10% on your build — pay your deposit by Aug 30.</span>
-  <span class="text-xs"><a href="/pricing" class="underline">50% today, balance at launch – 90‑day ROI guarantee</a></span>
+  <span class="text-xs"><a href="/pricing#roi" class="underline">50% today, balance at launch – 90‑day ROI guarantee</a></span>
 </div>
     <nav class="max-w-7xl mx-auto relative flex items-center justify-between py-3 px-6">
       <a href="/" class="flex items-center gap-2"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-8 w-8"/><span class="site-title text-xl text-brand-charcoal"><span class="font-bold text-brand-orange">Scrapyard</span> <span class="font-bold">Sites</span></span></a>
@@ -43,7 +43,7 @@
         <li><a href="/services">Services</a></li>
         <li><a href="/process">Process</a></li>
         <li><a href="/demos">Demos</a></li>
-        <li><a href="/pricing">Pricing</a></li>
+        <li><a href="/pricing#roi">Pricing</a></li>
         <li><a href="/risk-calculator">Calculator</a></li>
         <li><a href="/about">About</a></li>
         <li><a href="/contact">Contact</a></li>
@@ -59,7 +59,7 @@
       <a href="/services">Services</a>
       <a href="/process">Process</a>
       <a href="/demos">Demos</a>
-      <a href="/pricing">Pricing</a>
+      <a href="/pricing#roi">Pricing</a>
       <a href="/risk-calculator">Calculator</a>
       <a href="/about">About</a>
       <a href="/contact">Contact</a>
@@ -116,7 +116,7 @@
     <a href="/services">Services</a>
     <a href="/process">Process</a>
     <a href="/demos">Demos</a>
-    <a href="/pricing">Pricing</a>
+    <a href="/pricing#roi">Pricing</a>
     <a href="/risk-calculator">Calculator</a>
     <a href="/blog">Blog</a>
     <a href="/contact">Contact</a>

--- a/contact/index.html
+++ b/contact/index.html
@@ -29,7 +29,7 @@
   <header class="fixed top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
 <div id="promoBanner" class="bg-brand-orange text-white text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
   <span>Save 10% on your build — pay your deposit by Aug 30.</span>
-  <span class="text-xs"><a href="/pricing" class="underline">50% today, balance at launch – 90‑day ROI guarantee</a></span>
+  <span class="text-xs"><a href="/pricing#roi" class="underline">50% today, balance at launch – 90‑day ROI guarantee</a></span>
 </div>
     <nav class="max-w-7xl mx-auto relative flex items-center justify-between py-3 px-6">
       <a href="/" class="flex items-center gap-2"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-8 w-8"/><span class="site-title text-xl text-brand-charcoal"><span class="font-bold text-brand-orange">Scrapyard</span> <span class="font-bold">Sites</span></span></a>
@@ -43,7 +43,7 @@
         <li><a href="/services">Services</a></li>
         <li><a href="/process">Process</a></li>
         <li><a href="/demos">Demos</a></li>
-        <li><a href="/pricing">Pricing</a></li>
+        <li><a href="/pricing#roi">Pricing</a></li>
         <li><a href="/risk-calculator">Calculator</a></li>
         <li><a href="/about">About</a></li>
         <li><a href="/contact">Contact</a></li>
@@ -59,7 +59,7 @@
       <a href="/services">Services</a>
       <a href="/process">Process</a>
       <a href="/demos">Demos</a>
-      <a href="/pricing">Pricing</a>
+      <a href="/pricing#roi">Pricing</a>
       <a href="/risk-calculator">Calculator</a>
       <a href="/about">About</a>
       <a href="/contact">Contact</a>
@@ -172,7 +172,7 @@
     <a href="/services">Services</a>
     <a href="/process">Process</a>
     <a href="/demos">Demos</a>
-    <a href="/pricing">Pricing</a>
+    <a href="/pricing#roi">Pricing</a>
     <a href="/risk-calculator">Calculator</a>
     <a href="/blog">Blog</a>
     <a href="/contact">Contact</a>

--- a/demos/demo-yard-1/index.html
+++ b/demos/demo-yard-1/index.html
@@ -28,7 +28,7 @@
   <header class="fixed top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
 <div id="promoBanner" class="bg-brand-orange text-white text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
   <span>Save 10% on your build — pay your deposit by Aug 30.</span>
-  <span class="text-xs"><a href="/pricing" class="underline">50% today, balance at launch – 90‑day ROI guarantee</a></span>
+  <span class="text-xs"><a href="/pricing#roi" class="underline">50% today, balance at launch – 90‑day ROI guarantee</a></span>
 </div>
     <div class="mx-auto max-w-7xl relative flex items-center justify-between px-6 py-3">
       <a href="/" class="flex items-center gap-2">
@@ -38,7 +38,7 @@
       <nav class="hidden lg:flex absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 justify-center items-center gap-8 text-sm font-medium">
         <a href="/#why" class="text-brand-charcoal hover:text-brand-orange" title="Leaking here? ->">Why Us</a>
         <a href="/demos" class="text-brand-charcoal hover:text-brand-orange" title="Leaking here? ->">Demos</a>
-        <a href="/pricing" class="text-brand-charcoal hover:text-brand-orange" title="Leaking here? ->">Pricing</a>
+        <a href="/pricing#roi" class="text-brand-charcoal hover:text-brand-orange" title="Leaking here? ->">Pricing</a>
         <a href="/services" class="text-brand-charcoal hover:text-brand-orange" title="Leaking here? ->">Services</a>
         <a href="/process" class="text-brand-charcoal hover:text-brand-orange" title="Leaking here? ->">Process</a>
         <a href="/contact" class="text-brand-charcoal hover:text-brand-orange" title="Leaking here? ->">Contact</a>
@@ -76,7 +76,7 @@
     <a href="/services">Services</a>
     <a href="/process">Process</a>
     <a href="/demos">Demos</a>
-    <a href="/pricing">Pricing</a>
+    <a href="/pricing#roi">Pricing</a>
     <a href="/risk-calculator">Calculator</a>
     <a href="/blog">Blog</a>
     <a href="/contact">Contact</a>

--- a/demos/demo-yard-2/index.html
+++ b/demos/demo-yard-2/index.html
@@ -28,7 +28,7 @@
   <header class="fixed top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
 <div id="promoBanner" class="bg-brand-orange text-white text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
   <span>Save 10% on your build — pay your deposit by Aug 30.</span>
-  <span class="text-xs"><a href="/pricing" class="underline">50% today, balance at launch – 90‑day ROI guarantee</a></span>
+  <span class="text-xs"><a href="/pricing#roi" class="underline">50% today, balance at launch – 90‑day ROI guarantee</a></span>
 </div>
     <div class="mx-auto max-w-7xl relative flex items-center justify-between px-6 py-3">
       <a href="/" class="flex items-center gap-2">
@@ -38,7 +38,7 @@
       <nav class="hidden lg:flex absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 justify-center items-center gap-8 text-sm font-medium">
         <a href="/#why" class="text-brand-charcoal hover:text-brand-orange" title="Leaking here? ->">Why Us</a>
         <a href="/demos" class="text-brand-charcoal hover:text-brand-orange" title="Leaking here? ->">Demos</a>
-        <a href="/pricing" class="text-brand-charcoal hover:text-brand-orange" title="Leaking here? ->">Pricing</a>
+        <a href="/pricing#roi" class="text-brand-charcoal hover:text-brand-orange" title="Leaking here? ->">Pricing</a>
         <a href="/services" class="text-brand-charcoal hover:text-brand-orange" title="Leaking here? ->">Services</a>
         <a href="/process" class="text-brand-charcoal hover:text-brand-orange" title="Leaking here? ->">Process</a>
         <a href="/contact" class="text-brand-charcoal hover:text-brand-orange" title="Leaking here? ->">Contact</a>
@@ -75,7 +75,7 @@
     <a href="/services">Services</a>
     <a href="/process">Process</a>
     <a href="/demos">Demos</a>
-    <a href="/pricing">Pricing</a>
+    <a href="/pricing#roi">Pricing</a>
     <a href="/risk-calculator">Calculator</a>
     <a href="/blog">Blog</a>
     <a href="/contact">Contact</a>

--- a/demos/demo-yard-3/index.html
+++ b/demos/demo-yard-3/index.html
@@ -28,7 +28,7 @@
   <header class="fixed top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
 <div id="promoBanner" class="bg-brand-orange text-white text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
   <span>Save 10% on your build — pay your deposit by Aug 30.</span>
-  <span class="text-xs"><a href="/pricing" class="underline">50% today, balance at launch – 90‑day ROI guarantee</a></span>
+  <span class="text-xs"><a href="/pricing#roi" class="underline">50% today, balance at launch – 90‑day ROI guarantee</a></span>
 </div>
     <div class="mx-auto max-w-7xl relative flex items-center justify-between px-6 py-3">
       <a href="/" class="flex items-center gap-2">
@@ -38,7 +38,7 @@
       <nav class="hidden lg:flex absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 justify-center items-center gap-8 text-sm font-medium">
         <a href="/#why" class="text-brand-charcoal hover:text-brand-orange" title="Leaking here? ->">Why Us</a>
         <a href="/demos" class="text-brand-charcoal hover:text-brand-orange" title="Leaking here? ->">Demos</a>
-        <a href="/pricing" class="text-brand-charcoal hover:text-brand-orange" title="Leaking here? ->">Pricing</a>
+        <a href="/pricing#roi" class="text-brand-charcoal hover:text-brand-orange" title="Leaking here? ->">Pricing</a>
         <a href="/services" class="text-brand-charcoal hover:text-brand-orange" title="Leaking here? ->">Services</a>
         <a href="/process" class="text-brand-charcoal hover:text-brand-orange" title="Leaking here? ->">Process</a>
         <a href="/contact" class="text-brand-charcoal hover:text-brand-orange" title="Leaking here? ->">Contact</a>
@@ -76,7 +76,7 @@
     <a href="/services">Services</a>
     <a href="/process">Process</a>
     <a href="/demos">Demos</a>
-    <a href="/pricing">Pricing</a>
+    <a href="/pricing#roi">Pricing</a>
     <a href="/risk-calculator">Calculator</a>
     <a href="/blog">Blog</a>
     <a href="/contact">Contact</a>

--- a/demos/index.html
+++ b/demos/index.html
@@ -33,7 +33,7 @@
   <header class="fixed top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
 <div id="promoBanner" class="bg-brand-orange text-white text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
   <span>Save 10% on your build — pay your deposit by Aug 30.</span>
-  <span class="text-xs"><a href="/pricing" class="underline">50% today, balance at launch – 90‑day ROI guarantee</a></span>
+  <span class="text-xs"><a href="/pricing#roi" class="underline">50% today, balance at launch – 90‑day ROI guarantee</a></span>
 </div>
     <nav class="max-w-7xl mx-auto relative flex items-center justify-between py-3 px-6">
       <a href="/" class="flex items-center gap-2"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-8 w-8"/><span class="site-title text-xl text-brand-charcoal"><span class="font-bold text-brand-orange">Scrapyard</span> <span class="font-bold">Sites</span></span></a>
@@ -47,7 +47,7 @@
         <li><a href="/services">Services</a></li>
         <li><a href="/process">Process</a></li>
         <li><a href="/demos">Demos</a></li>
-        <li><a href="/pricing">Pricing</a></li>
+        <li><a href="/pricing#roi">Pricing</a></li>
         <li><a href="/risk-calculator">Calculator</a></li>
         <li><a href="/about">About</a></li>
         <li><a href="/contact">Contact</a></li>
@@ -63,7 +63,7 @@
       <a href="/services">Services</a>
       <a href="/process">Process</a>
       <a href="/demos">Demos</a>
-      <a href="/pricing">Pricing</a>
+      <a href="/pricing#roi">Pricing</a>
       <a href="/risk-calculator">Calculator</a>
       <a href="/about">About</a>
       <a href="/contact">Contact</a>
@@ -175,7 +175,7 @@
     <a href="/services">Services</a>
     <a href="/process">Process</a>
     <a href="/demos">Demos</a>
-    <a href="/pricing">Pricing</a>
+    <a href="/pricing#roi">Pricing</a>
     <a href="/risk-calculator">Calculator</a>
     <a href="/blog">Blog</a>
     <a href="/contact">Contact</a>

--- a/index.html
+++ b/index.html
@@ -174,7 +174,7 @@
   <header class="fixed top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
 <div id="promoBanner" class="bg-brand-orange text-white text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
   <span>Save 10% on your build — pay your deposit by Aug 30.</span>
-  <span class="text-xs"><a href="/pricing" class="underline">50% today, balance at launch – 90‑day ROI guarantee</a></span>
+  <span class="text-xs"><a href="/pricing#roi" class="underline">50% today, balance at launch – 90‑day ROI guarantee</a></span>
 </div>
     <nav class="max-w-7xl mx-auto relative flex items-center justify-between py-3 px-6">
       <a href="/" class="flex items-center gap-2"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-8 w-8"/><span class="site-title text-xl text-brand-charcoal"><span class="font-bold text-brand-orange">Scrapyard</span> <span class="font-bold">Sites</span></span></a>
@@ -188,7 +188,7 @@
         <li><a href="/services">Services</a></li>
         <li><a href="/process">Process</a></li>
         <li><a href="/demos">Demos</a></li>
-        <li><a href="/pricing">Pricing</a></li>
+        <li><a href="/pricing#roi">Pricing</a></li>
         <li><a href="/risk-calculator">Calculator</a></li>
         <li><a href="/about">About</a></li>
         <li><a href="/contact">Contact</a></li>
@@ -204,7 +204,7 @@
       <a href="/services">Services</a>
       <a href="/process">Process</a>
       <a href="/demos">Demos</a>
-      <a href="/pricing">Pricing</a>
+      <a href="/pricing#roi">Pricing</a>
       <a href="/risk-calculator">Calculator</a>
       <a href="/about">About</a>
       <a href="/contact">Contact</a>
@@ -261,7 +261,7 @@
     </p>
     <div class="mt-8 flex flex-col gap-4 justify-center">
       <a href="/contact" class="btn-primary hero-cta">Book a Discovery Call <span class="cta-subtext">15&nbsp;min • No obligation</span></a>
-      <a href="/pricing" class="btn-secondary hero-cta">See Pricing&nbsp;→</a>
+      <a href="/pricing#roi" class="btn-secondary hero-cta">See Pricing&nbsp;→</a>
     </div>
   </div>
 </section>
@@ -332,7 +332,7 @@
     <p class="text-gray-700 mb-6" data-aos="fade-up">
       When your reputation is reinforced online, trust goes up and so do your loads. Engage visitors, collect quotes, and become the yard drivers choose every time.
     </p>
-    <a href="/pricing" class="btn-primary btn-invert-hover inline-block" data-aos="fade-up">See&nbsp;Pricing&nbsp;→</a>
+    <a href="/pricing#roi" class="btn-primary btn-invert-hover inline-block" data-aos="fade-up">See&nbsp;Pricing&nbsp;→</a>
   </div>
 </section>
 <!-- ── Reputation Section ──────────────────────────────────────────────── -->
@@ -441,7 +441,7 @@
         <p class="mt-6 text-lg text-gray-700 max-w-3xl mx-auto mb-6" data-aos="fade-up">
           When your reputation is reinforced online, trust goes up and so do your loads. Engage visitors, collect quotes, and become the yard drivers choose every time.
         </p>
-        <a href="/pricing" class="btn-primary btn-invert-hover inline-block" data-aos="fade-up">See&nbsp;Pricing&nbsp;→</a>
+        <a href="/pricing#roi" class="btn-primary btn-invert-hover inline-block" data-aos="fade-up">See&nbsp;Pricing&nbsp;→</a>
       </div>
     </div>
   </div>
@@ -556,7 +556,7 @@
     </div>
     <div class="mt-10 text-center">
       <a href="https://book.stripe.com/eVqeVd8Vi9U45RbdJy73G00" class="btn-primary">Pay Deposit & Reserve My Build Week</a>
-      <p class="text-xs text-brand-steel mt-2">50% deposit now, balance at launch. <a href="/pricing" class="underline">90‑day ROI guarantee</a>.</p>
+      <p class="text-xs text-brand-steel mt-2">50% deposit now, balance at launch. <a href="/pricing#roi" class="underline">90‑day ROI guarantee</a>.</p>
     </div>
   </div>
 </section>
@@ -671,7 +671,7 @@
     <a href="/services">Services</a>
     <a href="/process">Process</a>
     <a href="/demos">Demos</a>
-    <a href="/pricing">Pricing</a>
+    <a href="/pricing#roi">Pricing</a>
     <a href="/risk-calculator">Calculator</a>
     <a href="/blog">Blog</a>
     <a href="/contact">Contact</a>

--- a/pricing/index.html
+++ b/pricing/index.html
@@ -33,7 +33,7 @@
   <header class="fixed top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
 <div id="promoBanner" class="bg-brand-orange text-white text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
   <span>Save 10% on your build — pay your deposit by Aug 30.</span>
-  <span class="text-xs"><a href="/pricing" class="underline">50% today, balance at launch – 90‑day ROI guarantee</a></span>
+  <span class="text-xs"><a href="/pricing#roi" class="underline">50% today, balance at launch – 90‑day ROI guarantee</a></span>
 </div>
     <nav class="max-w-7xl mx-auto relative flex items-center justify-between py-3 px-6">
       <a href="/" class="flex items-center gap-2"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-8 w-8"/><span class="site-title text-xl text-brand-charcoal"><span class="font-bold text-brand-orange">Scrapyard</span> <span class="font-bold">Sites</span></span></a>
@@ -166,7 +166,7 @@
           
 <div class="mt-10 text-center">
   <a href="https://book.stripe.com/eVqeVd8Vi9U45RbdJy73G00" class="btn-primary">Pay Deposit & Reserve My Build Week</a>
-  <p class="text-xs text-brand-steel mt-2">50% deposit now, balance at launch. <a href="/pricing" class="underline">90‑day ROI guarantee</a>.</p>
+  <p class="text-xs text-brand-steel mt-2">50% deposit now, balance at launch. <a href="#roi" class="underline">90‑day ROI guarantee</a>.</p>
 </div>
 </div>
       <!-- FAQ stays below packages -->
@@ -178,7 +178,7 @@
       <li><strong>Book your build week:</strong> Pay a 50% deposit to secure your slot.</li>
       <li><strong>Launch your site:</strong> Remaining 50% due when your new site goes live.</li>
       <li><strong>Payment methods:</strong> Cards, ACH, or check—no hidden fees.</li>
-      <li><strong>Our promise:</strong> If your site doesn’t pay for itself within 90 days, we refund the build fee.</li>
+      <li id="roi"><strong>Our promise:</strong> If your site doesn’t pay for itself within 90 days, we refund the build fee.</li>
     </ul>
 
     <h2 class="text-2xl font-bold mb-4 mt-8 text-center">Extras</h2>
@@ -187,7 +187,7 @@
       <li>On-site photo/video (Lower 48) – from $750</li>
       <li>Hand-off to your server – $199</li>
     </ul>
-    <p class="text-sm mt-1">Need something custom? <a href="/contact" class="text-brand-orange underline">Let us know.</a></p>
+    <p class="text-sm mt-4 text-center font-semibold">Need something custom? <a href="/contact" class="text-brand-orange underline">Let us know.</a></p>
   </div>
 </section>
     <section id="faq" class="scroll-mt-16 py-12 bg-white">

--- a/privacy/index.html
+++ b/privacy/index.html
@@ -94,7 +94,7 @@
   <header class="fixed top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
 <div id="promoBanner" class="bg-brand-orange text-white text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
   <span>Save 10% on your build — pay your deposit by Aug 30.</span>
-  <span class="text-xs"><a href="/pricing" class="underline">50% today, balance at launch – 90‑day ROI guarantee</a></span>
+  <span class="text-xs"><a href="/pricing#roi" class="underline">50% today, balance at launch – 90‑day ROI guarantee</a></span>
 </div>
     <nav class="max-w-7xl mx-auto relative flex items-center justify-between py-3 px-6">
       <a href="/" class="flex items-center gap-2"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-8 w-8"/><span class="site-title text-xl text-brand-charcoal"><span class="font-bold text-brand-orange">Scrapyard</span> <span class="font-bold">Sites</span></span></a>
@@ -108,7 +108,7 @@
         <li><a href="/services">Services</a></li>
         <li><a href="/process">Process</a></li>
         <li><a href="/demos">Demos</a></li>
-        <li><a href="/pricing">Pricing</a></li>
+        <li><a href="/pricing#roi">Pricing</a></li>
         <li><a href="/risk-calculator">Calculator</a></li>
         <li><a href="/about">About</a></li>
         <li><a href="/contact">Contact</a></li>
@@ -124,7 +124,7 @@
       <a href="/services">Services</a>
       <a href="/process">Process</a>
       <a href="/demos">Demos</a>
-      <a href="/pricing">Pricing</a>
+      <a href="/pricing#roi">Pricing</a>
       <a href="/risk-calculator">Calculator</a>
       <a href="/about">About</a>
       <a href="/contact">Contact</a>
@@ -308,7 +308,7 @@
     <a href="/services">Services</a>
     <a href="/process">Process</a>
     <a href="/demos">Demos</a>
-    <a href="/pricing">Pricing</a>
+    <a href="/pricing#roi">Pricing</a>
     <a href="/risk-calculator">Calculator</a>
     <a href="/blog">Blog</a>
     <a href="/contact">Contact</a>

--- a/process/index.html
+++ b/process/index.html
@@ -93,7 +93,7 @@
   <header class="fixed top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
 <div id="promoBanner" class="bg-brand-orange text-white text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
   <span>Save 10% on your build — pay your deposit by Aug 30.</span>
-  <span class="text-xs"><a href="/pricing" class="underline">50% today, balance at launch – 90‑day ROI guarantee</a></span>
+  <span class="text-xs"><a href="/pricing#roi" class="underline">50% today, balance at launch – 90‑day ROI guarantee</a></span>
 </div>
     <nav class="max-w-7xl w-full mx-auto relative flex items-center justify-between py-3 px-6">
       <a href="/" class="flex items-center gap-2"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-8 w-8"/><span class="site-title text-xl text-brand-charcoal"><span class="font-bold text-brand-orange">Scrapyard</span> <span class="font-bold">Sites</span></span></a>
@@ -107,7 +107,7 @@
         <li><a href="/services">Services</a></li>
         <li><a href="/process">Process</a></li>
         <li><a href="/demos">Demos</a></li>
-        <li><a href="/pricing">Pricing</a></li>
+        <li><a href="/pricing#roi">Pricing</a></li>
         <li><a href="/risk-calculator">Calculator</a></li>
         <li><a href="/about">About</a></li>
         <li><a href="/contact">Contact</a></li>
@@ -123,7 +123,7 @@
       <a href="/services">Services</a>
       <a href="/process">Process</a>
       <a href="/demos">Demos</a>
-      <a href="/pricing">Pricing</a>
+      <a href="/pricing#roi">Pricing</a>
       <a href="/risk-calculator">Calculator</a>
       <a href="/about">About</a>
       <a href="/contact">Contact</a>
@@ -352,7 +352,7 @@
     <a href="/services">Services</a>
     <a href="/process">Process</a>
     <a href="/demos">Demos</a>
-    <a href="/pricing">Pricing</a>
+    <a href="/pricing#roi">Pricing</a>
     <a href="/risk-calculator">Calculator</a>
     <a href="/blog">Blog</a>
     <a href="/contact">Contact</a>

--- a/risk-calculator/index.html
+++ b/risk-calculator/index.html
@@ -92,7 +92,7 @@
     <header class="fixed top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
 <div id="promoBanner" class="bg-brand-orange text-white text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
   <span>Save 10% on your build — pay your deposit by Aug 30.</span>
-  <span class="text-xs"><a href="/pricing" class="underline">50% today, balance at launch – 90‑day ROI guarantee</a></span>
+  <span class="text-xs"><a href="/pricing#roi" class="underline">50% today, balance at launch – 90‑day ROI guarantee</a></span>
 </div>
       <nav
         class="max-w-7xl mx-auto relative flex items-center justify-between py-3 px-6"
@@ -136,7 +136,7 @@
           <li><a href="/services">Services</a></li>
           <li><a href="/process">Process</a></li>
           <li><a href="/demos">Demos</a></li>
-          <li><a href="/pricing">Pricing</a></li>
+          <li><a href="/pricing#roi">Pricing</a></li>
           <li><a href="/risk-calculator">Calculator</a></li>
           <li><a href="/about">About</a></li>
           <li><a href="/contact">Contact</a></li>
@@ -170,7 +170,7 @@
         <a href="/services">Services</a>
         <a href="/process">Process</a>
         <a href="/demos">Demos</a>
-        <a href="/pricing">Pricing</a>
+        <a href="/pricing#roi">Pricing</a>
         <a href="/risk-calculator">Calculator</a>
         <a href="/about">About</a>
         <a href="/contact">Contact</a>
@@ -256,7 +256,7 @@
                 A Standard Launch pays for itself in <strong id="roiDays">‑‑</strong> days.
               </p>
               <a id="contactBtn" href="https://book.stripe.com/eVqeVd8Vi9U45RbdJy73G00" class="btn-primary mt-6 inline-block">Pay Deposit & Reserve My Build Week</a>
-              <p class="text-xs text-brand-steel mt-2">50% deposit now, balance at launch. <a href="/pricing" class="underline">90‑day ROI guarantee</a>.</p>
+              <p class="text-xs text-brand-steel mt-2">50% deposit now, balance at launch. <a href="/pricing#roi" class="underline">90‑day ROI guarantee</a>.</p>
             </div>
           </div>
         </section>
@@ -274,7 +274,7 @@
         <a href="/services">Services</a>
         <a href="/process">Process</a>
         <a href="/demos">Demos</a>
-        <a href="/pricing">Pricing</a>
+        <a href="/pricing#roi">Pricing</a>
         <a href="/risk-calculator">Calculator</a>
         <a href="/blog">Blog</a>
         <a href="/contact">Contact</a>

--- a/services/index.html
+++ b/services/index.html
@@ -82,7 +82,7 @@
   <header class="fixed top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
 <div id="promoBanner" class="bg-brand-orange text-white text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
   <span>Save 10% on your build — pay your deposit by Aug 30.</span>
-  <span class="text-xs"><a href="/pricing" class="underline">50% today, balance at launch – 90‑day ROI guarantee</a></span>
+  <span class="text-xs"><a href="/pricing#roi" class="underline">50% today, balance at launch – 90‑day ROI guarantee</a></span>
 </div>
     <nav class="max-w-7xl mx-auto relative flex items-center justify-between py-3 px-6">
       <a href="/" class="flex items-center gap-2"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-8 w-8"/><span class="site-title text-xl text-brand-charcoal"><span class="font-bold text-brand-orange">Scrapyard</span> <span class="font-bold">Sites</span></span></a>
@@ -96,7 +96,7 @@
         <li><a href="/services">Services</a></li>
         <li><a href="/process">Process</a></li>
         <li><a href="/demos">Demos</a></li>
-        <li><a href="/pricing">Pricing</a></li>
+        <li><a href="/pricing#roi">Pricing</a></li>
         <li><a href="/risk-calculator">Calculator</a></li>
         <li><a href="/about">About</a></li>
         <li><a href="/contact">Contact</a></li>
@@ -112,7 +112,7 @@
       <a href="/services">Services</a>
       <a href="/process">Process</a>
       <a href="/demos">Demos</a>
-      <a href="/pricing">Pricing</a>
+      <a href="/pricing#roi">Pricing</a>
       <a href="/risk-calculator">Calculator</a>
       <a href="/about">About</a>
       <a href="/contact">Contact</a>
@@ -215,7 +215,7 @@
             <li class="flex items-center gap-2"><i data-lucide="minus" class="w-4 h-4 text-brand-steel"></i><span>Reliability</span></li>
           </ul>
           <p class="text-sm mb-4">Quick, reputable web presence.</p>
-          <a href="/pricing" class="btn-primary mt-auto">View Pricing</a>
+          <a href="/pricing#roi" class="btn-primary mt-auto">View Pricing</a>
         </div>
         <div class="carousel-item package-card bg-gray-50 border border-brand-steel/10 rounded-xl shadow-sm transition transform hover:-translate-y-1 p-6 flex flex-col text-center">
           <h3 class="font-semibold mb-3">Premium</h3>
@@ -226,7 +226,7 @@
             <li class="flex items-center gap-2"><i data-lucide="minus" class="w-4 h-4 text-brand-steel"></i><span>Reliability</span></li>
           </ul>
           <p class="text-sm mb-4">Dominate local search results.</p>
-          <a href="/pricing" class="btn-primary mt-auto">View Pricing</a>
+          <a href="/pricing#roi" class="btn-primary mt-auto">View Pricing</a>
         </div>
         <div class="carousel-item package-card bg-gray-50 border border-brand-steel/10 rounded-xl shadow-sm transition transform hover:-translate-y-1 p-6 flex flex-col text-center">
           <h3 class="font-semibold mb-3">Care Plan</h3>
@@ -237,7 +237,7 @@
             <li class="flex items-center gap-2"><i data-lucide="check" class="w-4 h-4 text-brand-orange"></i><span>Reliability</span></li>
           </ul>
           <p class="text-sm mb-4">Ongoing monitoring and updates.</p>
-          <a href="/pricing" class="btn-primary mt-auto">View Pricing</a>
+          <a href="/pricing#roi" class="btn-primary mt-auto">View Pricing</a>
         </div>
         </div>
         <p class="max-w-3xl mx-auto text-brand-charcoal text-center mt-8">Our seven‑day launch promise means your site goes live fast. We back every build with a satisfaction guarantee and ongoing support.</p>
@@ -288,7 +288,7 @@
       <a href="/services">Services</a>
       <a href="/process">Process</a>
       <a href="/demos">Demos</a>
-      <a href="/pricing">Pricing</a>
+      <a href="/pricing#roi">Pricing</a>
       <a href="/risk-calculator">Calculator</a>
       <a href="/blog">Blog</a>
       <a href="/contact">Contact</a>

--- a/terms-of-service/index.html
+++ b/terms-of-service/index.html
@@ -33,7 +33,7 @@
   <header class="fixed top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
 <div id="promoBanner" class="bg-brand-orange text-white text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
   <span>Save 10% on your build — pay your deposit by Aug 30.</span>
-  <span class="text-xs"><a href="/pricing" class="underline">50% today, balance at launch – 90‑day ROI guarantee</a></span>
+  <span class="text-xs"><a href="/pricing#roi" class="underline">50% today, balance at launch – 90‑day ROI guarantee</a></span>
 </div>
     <nav class="max-w-7xl mx-auto relative flex items-center justify-between py-3 px-6">
       <a href="/" class="flex items-center gap-2"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-8 w-8"/><span class="site-title text-xl text-brand-charcoal"><span class="font-bold text-brand-orange">Scrapyard</span> <span class="font-bold">Sites</span></span></a>
@@ -47,7 +47,7 @@
         <li><a href="/services">Services</a></li>
         <li><a href="/process">Process</a></li>
         <li><a href="/demos">Demos</a></li>
-        <li><a href="/pricing">Pricing</a></li>
+        <li><a href="/pricing#roi">Pricing</a></li>
         <li><a href="/risk-calculator">Calculator</a></li>
         <li><a href="/about">About</a></li>
         <li><a href="/contact">Contact</a></li>
@@ -63,7 +63,7 @@
       <a href="/services">Services</a>
       <a href="/process">Process</a>
       <a href="/demos">Demos</a>
-      <a href="/pricing">Pricing</a>
+      <a href="/pricing#roi">Pricing</a>
       <a href="/risk-calculator">Calculator</a>
       <a href="/about">About</a>
       <a href="/contact">Contact</a>
@@ -117,7 +117,7 @@
     <a href="/services">Services</a>
     <a href="/process">Process</a>
     <a href="/demos">Demos</a>
-    <a href="/pricing">Pricing</a>
+    <a href="/pricing#roi">Pricing</a>
     <a href="/risk-calculator">Calculator</a>
     <a href="/blog">Blog</a>
     <a href="/contact">Contact</a>


### PR DESCRIPTION
## Summary
- make ROI banner scroll to new `#roi` section on the pricing page
- anchor guarantee bullet and update links across site
- highlight the "Need something custom?" note

## Testing
- `npm test` *(fails: package.json missing)*
- `make test` *(fails: no rule)*

------
https://chatgpt.com/codex/tasks/task_e_68844cd7b1188329a7fb02d58712de8a