### PR TITLE
Fix about page discount banner style

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -189,11 +189,11 @@
     </li>
   </ul>
 </section>
-<section class="py-12 text-center">
+<section class="beta-invite bg-brand-orange text-white py-12 text-center">
   <div class="max-w-4xl mx-auto px-6">
     <h2 class="text-2xl font-semibold mb-2">Save 10 % on your build — pay your deposit by Aug 30</h2>
     <p class="mb-6 text-sm">Secure your build—own page-one Google space before competitors wake up.</p>
-    <a href="https://book.stripe.com/eVqeVd8Vi9U45RbdJy73G00" class="btn-primary">Pay Deposit →</a>
+    <a href="https://book.stripe.com/eVqeVd8Vi9U45RbdJy73G00" class="btn-secondary">Pay Deposit →</a>
   </div>
 </section>
 </main>


### PR DESCRIPTION
## Summary
- use `beta-invite` style for the 10% discount section
- make button white by switching to `btn-secondary`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6886a6b458a483298efa89b90903af42