### PR TITLE
Remove footer links to blog and Terms of Service

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -206,10 +206,8 @@
     <a href="/demos">Demos</a>
     <a href="/pricing">Pricing</a>
     <a href="/risk-calculator">Calculator</a>
-    <a href="/blog">Blog</a>
     <a href="/contact">Contact</a>
     <a href="/privacy">Privacy</a>
-    <a href="/terms-of-service">Terms</a>
   </nav>
   <p>© <span id="year"></span> Scrapyard Sites — All rights reserved.</p>
 </footer>

--- a/blog/index.html
+++ b/blog/index.html
@@ -156,10 +156,8 @@
     <a href="/demos">Demos</a>
     <a href="/pricing">Pricing</a>
     <a href="/risk-calculator">Calculator</a>
-    <a href="/blog">Blog</a>
     <a href="/contact">Contact</a>
     <a href="/privacy">Privacy</a>
-    <a href="/terms-of-service">Terms</a>
   </nav>
   <p>© <span id="year"></span> Scrapyard Sites — All rights reserved.</p>
 </footer>

--- a/blog/post-template.html
+++ b/blog/post-template.html
@@ -118,10 +118,8 @@
     <a href="/demos">Demos</a>
     <a href="/pricing">Pricing</a>
     <a href="/risk-calculator">Calculator</a>
-    <a href="/blog">Blog</a>
     <a href="/contact">Contact</a>
     <a href="/privacy">Privacy</a>
-    <a href="/terms-of-service">Terms</a>
   </nav>
   <p>© <span id="year"></span> Scrapyard Sites — All rights reserved.</p>
 </footer>

--- a/blog/posts/care-plan-essentials.html
+++ b/blog/posts/care-plan-essentials.html
@@ -118,10 +118,8 @@
     <a href="/demos">Demos</a>
     <a href="/pricing">Pricing</a>
     <a href="/risk-calculator">Calculator</a>
-    <a href="/blog">Blog</a>
     <a href="/contact">Contact</a>
     <a href="/privacy">Privacy</a>
-    <a href="/terms-of-service">Terms</a>
   </nav>
   <p>© <span id="year"></span> Scrapyard Sites — All rights reserved.</p>
 </footer>

--- a/blog/posts/pre-qualify-scrap-sellers.html
+++ b/blog/posts/pre-qualify-scrap-sellers.html
@@ -118,10 +118,8 @@
     <a href="/demos">Demos</a>
     <a href="/pricing">Pricing</a>
     <a href="/risk-calculator">Calculator</a>
-    <a href="/blog">Blog</a>
     <a href="/contact">Contact</a>
     <a href="/privacy">Privacy</a>
-    <a href="/terms-of-service">Terms</a>
   </nav>
   <p>© <span id="year"></span> Scrapyard Sites — All rights reserved.</p>
 </footer>

--- a/blog/posts/seo-basics-for-scrap-yards.html
+++ b/blog/posts/seo-basics-for-scrap-yards.html
@@ -118,10 +118,8 @@
     <a href="/demos">Demos</a>
     <a href="/pricing">Pricing</a>
     <a href="/risk-calculator">Calculator</a>
-    <a href="/blog">Blog</a>
     <a href="/contact">Contact</a>
     <a href="/privacy">Privacy</a>
-    <a href="/terms-of-service">Terms</a>
   </nav>
   <p>© <span id="year"></span> Scrapyard Sites — All rights reserved.</p>
 </footer>

--- a/contact/index.html
+++ b/contact/index.html
@@ -174,10 +174,8 @@
     <a href="/demos">Demos</a>
     <a href="/pricing">Pricing</a>
     <a href="/risk-calculator">Calculator</a>
-    <a href="/blog">Blog</a>
     <a href="/contact">Contact</a>
     <a href="/privacy">Privacy</a>
-    <a href="/terms-of-service">Terms</a>
   </nav>
   <p>© <span id="year"></span> Scrapyard Sites — All rights reserved.</p>
 </footer>

--- a/demos/demo-yard-1/index.html
+++ b/demos/demo-yard-1/index.html
@@ -80,10 +80,8 @@
     <a href="/demos">Demos</a>
     <a href="/pricing">Pricing</a>
     <a href="/risk-calculator">Calculator</a>
-    <a href="/blog">Blog</a>
     <a href="/contact">Contact</a>
     <a href="/privacy">Privacy</a>
-    <a href="/terms-of-service">Terms</a>
   </nav>
   <p>© <span id="year"></span> Scrapyard Sites — All rights reserved.</p>
 </footer>

--- a/demos/demo-yard-2/index.html
+++ b/demos/demo-yard-2/index.html
@@ -79,10 +79,8 @@
     <a href="/demos">Demos</a>
     <a href="/pricing">Pricing</a>
     <a href="/risk-calculator">Calculator</a>
-    <a href="/blog">Blog</a>
     <a href="/contact">Contact</a>
     <a href="/privacy">Privacy</a>
-    <a href="/terms-of-service">Terms</a>
   </nav>
   <p>© <span id="year"></span> Scrapyard Sites — All rights reserved.</p>
 </footer>

--- a/demos/demo-yard-3/index.html
+++ b/demos/demo-yard-3/index.html
@@ -80,10 +80,8 @@
     <a href="/demos">Demos</a>
     <a href="/pricing">Pricing</a>
     <a href="/risk-calculator">Calculator</a>
-    <a href="/blog">Blog</a>
     <a href="/contact">Contact</a>
     <a href="/privacy">Privacy</a>
-    <a href="/terms-of-service">Terms</a>
   </nav>
   <p>© <span id="year"></span> Scrapyard Sites — All rights reserved.</p>
 </footer>

--- a/demos/index.html
+++ b/demos/index.html
@@ -177,10 +177,8 @@
     <a href="/demos">Demos</a>
     <a href="/pricing">Pricing</a>
     <a href="/risk-calculator">Calculator</a>
-    <a href="/blog">Blog</a>
     <a href="/contact">Contact</a>
     <a href="/privacy">Privacy</a>
-    <a href="/terms-of-service">Terms</a>
   </nav>
   <p>© <span id="year"></span> Scrapyard Sites — All rights reserved.</p>
 </footer>

--- a/index.html
+++ b/index.html
@@ -673,10 +673,8 @@
     <a href="/demos">Demos</a>
     <a href="/pricing">Pricing</a>
     <a href="/risk-calculator">Calculator</a>
-    <a href="/blog">Blog</a>
     <a href="/contact">Contact</a>
     <a href="/privacy">Privacy</a>
-    <a href="/terms-of-service">Terms</a>
   </nav>
   <p>© <span id="year"></span> Scrapyard Sites — All rights reserved.</p>
 </footer>

--- a/pricing/index.html
+++ b/pricing/index.html
@@ -229,10 +229,8 @@
     <a href="/demos">Demos</a>
     <a href="/pricing">Pricing</a>
     <a href="/risk-calculator">Calculator</a>
-    <a href="/blog">Blog</a>
     <a href="/contact">Contact</a>
     <a href="/privacy">Privacy</a>
-    <a href="/terms-of-service">Terms</a>
   </nav>
   <p>© <span id="year"></span> Scrapyard Sites — All rights reserved.</p>
 </footer>

--- a/privacy/index.html
+++ b/privacy/index.html
@@ -313,10 +313,8 @@
     <a href="/demos">Demos</a>
     <a href="/pricing">Pricing</a>
     <a href="/risk-calculator">Calculator</a>
-    <a href="/blog">Blog</a>
     <a href="/contact">Contact</a>
     <a href="/privacy">Privacy</a>
-    <a href="/terms-of-service">Terms</a>
   </nav>
   <p>© <span id="year"></span> Scrapyard Sites — All rights reserved.</p>
 </footer>

--- a/process/index.html
+++ b/process/index.html
@@ -354,10 +354,8 @@
     <a href="/demos">Demos</a>
     <a href="/pricing">Pricing</a>
     <a href="/risk-calculator">Calculator</a>
-    <a href="/blog">Blog</a>
     <a href="/contact">Contact</a>
     <a href="/privacy">Privacy</a>
-    <a href="/terms-of-service">Terms</a>
   </nav>
   <p>© <span id="year"></span> Scrapyard Sites — All rights reserved.</p>
 </footer>

--- a/risk-calculator/index.html
+++ b/risk-calculator/index.html
@@ -277,10 +277,8 @@
         <a href="/demos">Demos</a>
         <a href="/pricing">Pricing</a>
         <a href="/risk-calculator">Calculator</a>
-        <a href="/blog">Blog</a>
         <a href="/contact">Contact</a>
         <a href="/privacy">Privacy</a>
-        <a href="/terms-of-service">Terms</a>
       </nav>
       <p>© <span id="year"></span> Scrapyard Sites — All rights reserved.</p>
     </footer>

--- a/services/index.html
+++ b/services/index.html
@@ -290,10 +290,8 @@
       <a href="/demos">Demos</a>
       <a href="/pricing">Pricing</a>
       <a href="/risk-calculator">Calculator</a>
-      <a href="/blog">Blog</a>
       <a href="/contact">Contact</a>
       <a href="/privacy">Privacy</a>
-      <a href="/terms-of-service">Terms</a>
     </nav>
     <p>© <span id="year"></span> Scrapyard Sites — All rights reserved.</p>
   </footer>

--- a/terms-of-service/index.html
+++ b/terms-of-service/index.html
@@ -122,10 +122,8 @@
     <a href="/demos">Demos</a>
     <a href="/pricing">Pricing</a>
     <a href="/risk-calculator">Calculator</a>
-    <a href="/blog">Blog</a>
     <a href="/contact">Contact</a>
     <a href="/privacy">Privacy</a>
-    <a href="/terms-of-service">Terms</a>
   </nav>
   <p>© <span id="year"></span> Scrapyard Sites — All rights reserved.</p>
 </footer>


### PR DESCRIPTION
## Summary
- remove blog and Terms links from footer navigation on all pages

## Testing
- `grep -R "<a href=\"/blog\">Blog</a>" -n` (no output)
- `grep -R "<a href=\"/terms-of-service\">Terms</a>" -n` (no output)


------
https://chatgpt.com/codex/tasks/task_e_6886a73a22488329835a364414419d95