### PR TITLE
Fix missing hero-cta class on About page

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -116,7 +116,7 @@
     <p class="text-lg max-w-lg mx-auto mt-4">
       I’m a scrap‑industry R&D analyst who builds websites for scrapyards. When suppliers can’t load your site, you lose the foot‑tons they’re ready to drop—so I created Scrapyard Sites to fix that gap with the same methodical approach I use on the production floor: measure, improve, and lock‑in.
     </p>
-    <a href="/contact" class="btn-primary mt-6">Book a Discovery Call</a>
+    <a href="/contact" class="btn-primary hero-cta mt-6">Book a Discovery Call</a>
   </div>
 </section>
 <section class="bg-gray-50 py-16">


### PR DESCRIPTION
## Summary
- add `hero-cta` class to the About page hero button so hover border doesn't appear

## Testing
- `npx htmlhint about/index.html` *(fails: 403 Forbidden due to lack of network access)*

------
https://chatgpt.com/codex/tasks/task_e_6886a9e53c14832983cb87131d06a143