### PR TITLE
Reduce founder image size

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -121,7 +121,7 @@
 </section>
 <section class="bg-gray-50 py-16">
   <div class="max-w-6xl mx-auto grid md:grid-cols-2 gap-10 items-center px-6">
-    <img src="/assets/founder.jpg" alt="Elias Burlison" class="rounded-lg shadow" />
+    <img src="/assets/founder.jpg" alt="Elias Burlison" class="rounded-lg shadow max-w-xs md:max-w-sm w-full mx-auto" />
     <div>
       <h2 class="text-2xl font-semibold">Our Story</h2>
       <p class="mt-4">


### PR DESCRIPTION
## Summary
- restrict width of the founder portrait on the about page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6886a9ff7238832999cbacd6d9017fc7