### PR TITLE
Fix risk calculator CTA banner full width

### DIFF
--- a/risk-calculator/index.html
+++ b/risk-calculator/index.html
@@ -260,7 +260,7 @@
             </div>
           </div>
         </section>
-      <section class="py-12 bg-brand-orange text-white text-center">
+      <section class="py-12 bg-brand-orange text-white text-center -mx-6">
         <div class="max-w-4xl mx-auto px-6">
           <h2 class="text-2xl font-bold mb-2">Save 10 % on your build — pay your deposit by Aug 30</h2>
           <p class="mb-6">Secure your build—own page-one Google space before competitors wake up.</p>


### PR DESCRIPTION
## Summary
- extend the orange CTA banner on the calculator page to span the viewport

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6886aa3281c48329b11f1ffd2a5f4c88