### PR TITLE
Fix CTA banner scrolling

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -38,7 +38,7 @@
   <header class="fixed top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
 <div id="promoBanner" class="bg-brand-orange text-white text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
   <span>Save 10% on your build — pay your deposit by Aug 30.</span>
-  <span class="text-xs"><a href="/pricing#roi" class="underline">50% today, balance at launch – 90‑day ROI guarantee</a></span>
+  <span class="text-xs"><a href="/pricing" class="underline">50% today, balance at launch – 90‑day ROI guarantee</a></span>
 </div>
     <nav class="max-w-7xl mx-auto relative flex items-center justify-between py-3 px-6">
       <a href="/" class="flex items-center gap-2"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-8 w-8"/><span class="site-title text-xl text-brand-charcoal"><span class="font-bold text-brand-orange">Scrapyard</span> <span class="font-bold">Sites</span></span></a>

--- a/blog/index.html
+++ b/blog/index.html
@@ -29,7 +29,7 @@
   <header class="fixed top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
 <div id="promoBanner" class="bg-brand-orange text-white text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
   <span>Save 10% on your build — pay your deposit by Aug 30.</span>
-  <span class="text-xs"><a href="/pricing#roi" class="underline">50% today, balance at launch – 90‑day ROI guarantee</a></span>
+  <span class="text-xs"><a href="/pricing" class="underline">50% today, balance at launch – 90‑day ROI guarantee</a></span>
 </div>
     <nav class="max-w-7xl mx-auto relative flex items-center justify-between py-3 px-6">
       <a href="/" class="flex items-center gap-2"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-8 w-8"/><span class="site-title text-xl text-brand-charcoal"><span class="font-bold text-brand-orange">Scrapyard</span> <span class="font-bold">Sites</span></span></a>

--- a/blog/post-template.html
+++ b/blog/post-template.html
@@ -29,7 +29,7 @@
   <header class="fixed top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
 <div id="promoBanner" class="bg-brand-orange text-white text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
   <span>Save 10% on your build — pay your deposit by Aug 30.</span>
-  <span class="text-xs"><a href="/pricing#roi" class="underline">50% today, balance at launch – 90‑day ROI guarantee</a></span>
+  <span class="text-xs"><a href="/pricing" class="underline">50% today, balance at launch – 90‑day ROI guarantee</a></span>
 </div>
     <nav class="max-w-7xl mx-auto relative flex items-center justify-between py-3 px-6">
       <a href="/" class="flex items-center gap-2"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-8 w-8"/><span class="site-title text-xl text-brand-charcoal"><span class="font-bold text-brand-orange">Scrapyard</span> <span class="font-bold">Sites</span></span></a>

--- a/blog/posts/care-plan-essentials.html
+++ b/blog/posts/care-plan-essentials.html
@@ -29,7 +29,7 @@
   <header class="fixed top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
 <div id="promoBanner" class="bg-brand-orange text-white text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
   <span>Save 10% on your build — pay your deposit by Aug 30.</span>
-  <span class="text-xs"><a href="/pricing#roi" class="underline">50% today, balance at launch – 90‑day ROI guarantee</a></span>
+  <span class="text-xs"><a href="/pricing" class="underline">50% today, balance at launch – 90‑day ROI guarantee</a></span>
 </div>
     <nav class="max-w-7xl mx-auto relative flex items-center justify-between py-3 px-6">
       <a href="/" class="flex items-center gap-2"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-8 w-8"/><span class="site-title text-xl text-brand-charcoal"><span class="font-bold text-brand-orange">Scrapyard</span> <span class="font-bold">Sites</span></span></a>

--- a/blog/posts/pre-qualify-scrap-sellers.html
+++ b/blog/posts/pre-qualify-scrap-sellers.html
@@ -29,7 +29,7 @@
   <header class="fixed top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
 <div id="promoBanner" class="bg-brand-orange text-white text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
   <span>Save 10% on your build — pay your deposit by Aug 30.</span>
-  <span class="text-xs"><a href="/pricing#roi" class="underline">50% today, balance at launch – 90‑day ROI guarantee</a></span>
+  <span class="text-xs"><a href="/pricing" class="underline">50% today, balance at launch – 90‑day ROI guarantee</a></span>
 </div>
     <nav class="max-w-7xl mx-auto relative flex items-center justify-between py-3 px-6">
       <a href="/" class="flex items-center gap-2"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-8 w-8"/><span class="site-title text-xl text-brand-charcoal"><span class="font-bold text-brand-orange">Scrapyard</span> <span class="font-bold">Sites</span></span></a>

--- a/blog/posts/seo-basics-for-scrap-yards.html
+++ b/blog/posts/seo-basics-for-scrap-yards.html
@@ -29,7 +29,7 @@
   <header class="fixed top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
 <div id="promoBanner" class="bg-brand-orange text-white text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
   <span>Save 10% on your build — pay your deposit by Aug 30.</span>
-  <span class="text-xs"><a href="/pricing#roi" class="underline">50% today, balance at launch – 90‑day ROI guarantee</a></span>
+  <span class="text-xs"><a href="/pricing" class="underline">50% today, balance at launch – 90‑day ROI guarantee</a></span>
 </div>
     <nav class="max-w-7xl mx-auto relative flex items-center justify-between py-3 px-6">
       <a href="/" class="flex items-center gap-2"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-8 w-8"/><span class="site-title text-xl text-brand-charcoal"><span class="font-bold text-brand-orange">Scrapyard</span> <span class="font-bold">Sites</span></span></a>

--- a/calculator/index.html
+++ b/calculator/index.html
@@ -92,7 +92,7 @@
     <header class="fixed top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
 <div id="promoBanner" class="bg-brand-orange text-white text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
   <span>Save 10% on your build — pay your deposit by Aug 30.</span>
-  <span class="text-xs"><a href="/pricing#roi" class="underline">50% today, balance at launch – 90‑day ROI guarantee</a></span>
+  <span class="text-xs"><a href="/pricing" class="underline">50% today, balance at launch – 90‑day ROI guarantee</a></span>
 </div>
       <nav
         class="max-w-7xl mx-auto relative flex items-center justify-between py-3 px-6"

--- a/contact/index.html
+++ b/contact/index.html
@@ -29,7 +29,7 @@
   <header class="fixed top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
 <div id="promoBanner" class="bg-brand-orange text-white text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
   <span>Save 10% on your build — pay your deposit by Aug 30.</span>
-  <span class="text-xs"><a href="/pricing#roi" class="underline">50% today, balance at launch – 90‑day ROI guarantee</a></span>
+  <span class="text-xs"><a href="/pricing" class="underline">50% today, balance at launch – 90‑day ROI guarantee</a></span>
 </div>
     <nav class="max-w-7xl mx-auto relative flex items-center justify-between py-3 px-6">
       <a href="/" class="flex items-center gap-2"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-8 w-8"/><span class="site-title text-xl text-brand-charcoal"><span class="font-bold text-brand-orange">Scrapyard</span> <span class="font-bold">Sites</span></span></a>

--- a/demos/demo-yard-1/index.html
+++ b/demos/demo-yard-1/index.html
@@ -28,7 +28,7 @@
   <header class="fixed top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
 <div id="promoBanner" class="bg-brand-orange text-white text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
   <span>Save 10% on your build — pay your deposit by Aug 30.</span>
-  <span class="text-xs"><a href="/pricing#roi" class="underline">50% today, balance at launch – 90‑day ROI guarantee</a></span>
+  <span class="text-xs"><a href="/pricing" class="underline">50% today, balance at launch – 90‑day ROI guarantee</a></span>
 </div>
     <div class="mx-auto max-w-7xl relative flex items-center justify-between px-6 py-3">
       <a href="/" class="flex items-center gap-2">

--- a/demos/demo-yard-2/index.html
+++ b/demos/demo-yard-2/index.html
@@ -28,7 +28,7 @@
   <header class="fixed top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
 <div id="promoBanner" class="bg-brand-orange text-white text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
   <span>Save 10% on your build — pay your deposit by Aug 30.</span>
-  <span class="text-xs"><a href="/pricing#roi" class="underline">50% today, balance at launch – 90‑day ROI guarantee</a></span>
+  <span class="text-xs"><a href="/pricing" class="underline">50% today, balance at launch – 90‑day ROI guarantee</a></span>
 </div>
     <div class="mx-auto max-w-7xl relative flex items-center justify-between px-6 py-3">
       <a href="/" class="flex items-center gap-2">

--- a/demos/demo-yard-3/index.html
+++ b/demos/demo-yard-3/index.html
@@ -28,7 +28,7 @@
   <header class="fixed top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
 <div id="promoBanner" class="bg-brand-orange text-white text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
   <span>Save 10% on your build — pay your deposit by Aug 30.</span>
-  <span class="text-xs"><a href="/pricing#roi" class="underline">50% today, balance at launch – 90‑day ROI guarantee</a></span>
+  <span class="text-xs"><a href="/pricing" class="underline">50% today, balance at launch – 90‑day ROI guarantee</a></span>
 </div>
     <div class="mx-auto max-w-7xl relative flex items-center justify-between px-6 py-3">
       <a href="/" class="flex items-center gap-2">

--- a/demos/index.html
+++ b/demos/index.html
@@ -33,7 +33,7 @@
   <header class="fixed top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
 <div id="promoBanner" class="bg-brand-orange text-white text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
   <span>Save 10% on your build — pay your deposit by Aug 30.</span>
-  <span class="text-xs"><a href="/pricing#roi" class="underline">50% today, balance at launch – 90‑day ROI guarantee</a></span>
+  <span class="text-xs"><a href="/pricing" class="underline">50% today, balance at launch – 90‑day ROI guarantee</a></span>
 </div>
     <nav class="max-w-7xl mx-auto relative flex items-center justify-between py-3 px-6">
       <a href="/" class="flex items-center gap-2"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-8 w-8"/><span class="site-title text-xl text-brand-charcoal"><span class="font-bold text-brand-orange">Scrapyard</span> <span class="font-bold">Sites</span></span></a>

--- a/index.html
+++ b/index.html
@@ -174,7 +174,7 @@
   <header class="fixed top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
 <div id="promoBanner" class="bg-brand-orange text-white text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
   <span>Save 10% on your build — pay your deposit by Aug 30.</span>
-  <span class="text-xs"><a href="/pricing#roi" class="underline">50% today, balance at launch – 90‑day ROI guarantee</a></span>
+  <span class="text-xs"><a href="/pricing" class="underline">50% today, balance at launch – 90‑day ROI guarantee</a></span>
 </div>
     <nav class="max-w-7xl mx-auto relative flex items-center justify-between py-3 px-6">
       <a href="/" class="flex items-center gap-2"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-8 w-8"/><span class="site-title text-xl text-brand-charcoal"><span class="font-bold text-brand-orange">Scrapyard</span> <span class="font-bold">Sites</span></span></a>

--- a/pricing/index.html
+++ b/pricing/index.html
@@ -254,8 +254,10 @@
       link.addEventListener('click',e=>{
         e.preventDefault();
         const header=document.querySelector('header');
+        const nav=header?header.querySelector('nav'):null;
         const section=document.getElementById('how-it-works');
-        const top=section.getBoundingClientRect().top+window.pageYOffset-header.getBoundingClientRect().height;
+        const offset=nav?nav.getBoundingClientRect().height:header.getBoundingClientRect().height;
+        const top=section.getBoundingClientRect().top+window.pageYOffset-offset;
         window.scrollTo({top,behavior:'smooth'});
         const highlight=document.querySelector('#roi strong');
         if(highlight){

--- a/privacy/index.html
+++ b/privacy/index.html
@@ -94,7 +94,7 @@
   <header class="fixed top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
 <div id="promoBanner" class="bg-brand-orange text-white text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
   <span>Save 10% on your build — pay your deposit by Aug 30.</span>
-  <span class="text-xs"><a href="/pricing#roi" class="underline">50% today, balance at launch – 90‑day ROI guarantee</a></span>
+  <span class="text-xs"><a href="/pricing" class="underline">50% today, balance at launch – 90‑day ROI guarantee</a></span>
 </div>
     <nav class="max-w-7xl mx-auto relative flex items-center justify-between py-3 px-6">
       <a href="/" class="flex items-center gap-2"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-8 w-8"/><span class="site-title text-xl text-brand-charcoal"><span class="font-bold text-brand-orange">Scrapyard</span> <span class="font-bold">Sites</span></span></a>

--- a/process/index.html
+++ b/process/index.html
@@ -93,7 +93,7 @@
   <header class="fixed top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
 <div id="promoBanner" class="bg-brand-orange text-white text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
   <span>Save 10% on your build — pay your deposit by Aug 30.</span>
-  <span class="text-xs"><a href="/pricing#roi" class="underline">50% today, balance at launch – 90‑day ROI guarantee</a></span>
+  <span class="text-xs"><a href="/pricing" class="underline">50% today, balance at launch – 90‑day ROI guarantee</a></span>
 </div>
     <nav class="max-w-7xl w-full mx-auto relative flex items-center justify-between py-3 px-6">
       <a href="/" class="flex items-center gap-2"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-8 w-8"/><span class="site-title text-xl text-brand-charcoal"><span class="font-bold text-brand-orange">Scrapyard</span> <span class="font-bold">Sites</span></span></a>

--- a/services/index.html
+++ b/services/index.html
@@ -82,7 +82,7 @@
   <header class="fixed top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
 <div id="promoBanner" class="bg-brand-orange text-white text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
   <span>Save 10% on your build — pay your deposit by Aug 30.</span>
-  <span class="text-xs"><a href="/pricing#roi" class="underline">50% today, balance at launch – 90‑day ROI guarantee</a></span>
+  <span class="text-xs"><a href="/pricing" class="underline">50% today, balance at launch – 90‑day ROI guarantee</a></span>
 </div>
     <nav class="max-w-7xl mx-auto relative flex items-center justify-between py-3 px-6">
       <a href="/" class="flex items-center gap-2"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-8 w-8"/><span class="site-title text-xl text-brand-charcoal"><span class="font-bold text-brand-orange">Scrapyard</span> <span class="font-bold">Sites</span></span></a>

--- a/terms-of-service/index.html
+++ b/terms-of-service/index.html
@@ -33,7 +33,7 @@
   <header class="fixed top-0 left-0 right-0 w-full z-50 bg-white shadow-sm">
 <div id="promoBanner" class="bg-brand-orange text-white text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
   <span>Save 10% on your build — pay your deposit by Aug 30.</span>
-  <span class="text-xs"><a href="/pricing#roi" class="underline">50% today, balance at launch – 90‑day ROI guarantee</a></span>
+  <span class="text-xs"><a href="/pricing" class="underline">50% today, balance at launch – 90‑day ROI guarantee</a></span>
 </div>
     <nav class="max-w-7xl mx-auto relative flex items-center justify-between py-3 px-6">
       <a href="/" class="flex items-center gap-2"><img src="/assets/logo.svg" alt="Scrapyard Sites logo" class="h-8 w-8"/><span class="site-title text-xl text-brand-charcoal"><span class="font-bold text-brand-orange">Scrapyard</span> <span class="font-bold">Sites</span></span></a>


### PR DESCRIPTION
## Summary
- stop banner links from auto-scrolling by removing the `#roi` fragment on all pages except pricing
- correct scroll position on pricing page when clicking the ROI banner

## Testing
- `grep -R "pricing#roi" -n`


------
https://chatgpt.com/codex/tasks/task_e_6886ae4b121c832986f982e53ab2bc13