### PR TITLE
Fix heading in calculator page

### DIFF
--- a/calculator/index.html
+++ b/calculator/index.html
@@ -222,7 +222,7 @@
     <main class="px-6">
       <section class="pt-12 pb-28 bg-gray-50 -mx-6">
         <div class="border border-brand-steel/20 rounded-xl p-6 bg-white mx-6 sm:mx-auto max-w-3xl px-6">
-          <h1 class="text-2xl font-bold text-center">Stop Losing Loads to Missed Calls</h1>
+          <h1 class="text-2xl font-bold text-center">Reputation Risk Calculator</h1>
             <p class="text-base leading-relaxed max-w-md mx-auto mt-2">
               Every unanswered call is a missed load and lost revenue. Our Risk
               Calculator helps you put a number on those lost loads and shows how


### PR DESCRIPTION
## Summary
- tweak heading on the calculator page

## Testing
- `npm test` *(fails: could not find package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6886b155cd888329938e6e239989ce63