### PR TITLE
Increase hero height on About page

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -108,7 +108,7 @@
 
   </script>
   <main class="pb-20 px-0">
-<section class="relative text-center flex items-center justify-center min-h-[60vh]">
+<section class="relative text-center flex items-center justify-center min-h-[70vh]">
   <img src="/assets/hero.jpg" alt="Scrapyard hero" class="absolute inset-0 w-full h-full object-cover" />
   <div class="absolute inset-0 bg-black/80"></div>
   <div class="relative z-10 px-6 text-white">


### PR DESCRIPTION
## Summary
- make the About page hero 70vh instead of 60vh so the copy isn't crowded on mobile

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6886bdaf381c832985f4e7810f0a14f4