### PR TITLE
Add ScrapyardSites return banner to all demo pages

### DIFF
--- a/demos/demo-yard-1/index.html
+++ b/demos/demo-yard-1/index.html
@@ -132,6 +132,22 @@
       transform: translateY(0);
       transition: opacity 0.6s ease-out, transform 0.6s ease-out;
     }
+
+    /* Banner linking back to ScrapyardSites.com */
+    #demoBanner {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      gap: 0.25rem;
+      padding: 0.5rem 1rem;
+      background-color: #d75e02;
+      color: #fff;
+      text-align: center;
+    }
+    @media (min-width: 640px) {
+      #demoBanner { flex-direction: row; }
+    }
   </style>
 
   <!-- JSON‑LD (unchanged) -->
@@ -165,6 +181,9 @@
 
 <!-- ── Header ───────────────────────────────────────────────-->
 <header class="bg-white fixed top-0 inset-x-0 w-full z-50 shadow-sm">
+  <div id="demoBanner" class="bg-brand-orange text-white text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
+    <a href="https://scrapyardsites.com" class="underline">Return to ScrapyardSites.com</a>
+  </div>
   <div class="max-w-7xl mx-auto relative flex items-center justify-between px-6 py-3">
     <a href="#top" class="flex items-center gap-2">
       <img src="assets/logo.svg" alt="Demo Yard logo" class="h-6 w-6 md:h-8 md:w-8"/>

--- a/demos/demo-yard-2/common.js
+++ b/demos/demo-yard-2/common.js
@@ -1,9 +1,9 @@
 document.addEventListener('DOMContentLoaded', () => {
   if (location.hash) {
     const target = document.querySelector(location.hash);
-    const nav = document.querySelector('nav');
-    if (target && nav) {
-      const offset = nav.getBoundingClientRect().height;
+    const header = document.querySelector('header');
+    if (target && header) {
+      const offset = header.getBoundingClientRect().height;
       const top = target.getBoundingClientRect().top + window.pageYOffset - offset;
       window.scrollTo({ top, behavior: 'smooth' });
     }
@@ -22,9 +22,9 @@ document.addEventListener('DOMContentLoaded', () => {
       event.preventDefault();
       const id = href.substring(href.indexOf('#'));
       const target = document.querySelector(id);
-      const nav = document.querySelector('nav');
-      if (target && nav) {
-        const offset = nav.getBoundingClientRect().height;
+      const header = document.querySelector('header');
+      if (target && header) {
+        const offset = header.getBoundingClientRect().height;
         const top = target.getBoundingClientRect().top + window.pageYOffset - offset;
         window.scrollTo({ top, behavior: 'smooth' });
         history.pushState(null, '', id);

--- a/demos/demo-yard-2/index.html
+++ b/demos/demo-yard-2/index.html
@@ -8,24 +8,35 @@
   <link rel="icon" type="image/svg+xml" href="assets/favicon.svg" />
   <link rel="icon" type="image/png" href="assets/favicon.png" />
   <link rel="stylesheet" href="tailwind.css">
-  
-
+  <style>
+    #demoBanner{
+      background-color:#D75E02;
+    }
+    @media (min-width:640px){
+      #demoBanner{flex-direction:row;}
+    }
+  </style>
 </head>
 <body class="font-sans antialiased text-black scroll-smooth flex flex-col min-h-screen overflow-x-hidden">
-  <nav style="position:fixed;top:0;z-index:20;width:100%;" class="bg-white flex w-full items-center justify-between px-6 py-4 lg:px-8 text-black shadow">
-    <a href="index.html#home" class="mr-6"><img src="assets/logo.jpg" alt="Recycle WV logo" class="h-8 w-auto" /></a>
-      <ul class="hidden md:flex flex-wrap gap-4 text-sm">
-        <li><a href="index.html#services" class="transition-colors hover:text-brand-100">Services</a></li>
-        <li><a href="index.html#materials" class="transition-colors hover:text-brand-100">Materials</a></li>
-        <li><a href="index.html#process" class="transition-colors hover:text-brand-100">How&nbsp;It&nbsp;Works</a></li>
-        <li><a href="index.html#map" class="transition-colors hover:text-brand-100">Directions</a></li>
-        <li><a href="index.html#contact" class="transition-colors hover:text-brand-100">Contact</a></li>
-      </ul>
-    <div class="ml-auto">
-      <a href="tel:13044251788" class="inline-flex items-center gap-2 rounded-md bg-brand-500 px-4 py-2 text-sm font-medium text-white hover:bg-brand-600 transition-colors">Call&nbsp;Now</a>
+  <header style="position:fixed;top:0;z-index:20;width:100%;">
+    <div id="demoBanner" class="text-white text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
+      <a href="https://scrapyardsites.com" class="underline">Return to ScrapyardSites.com</a>
     </div>
-  </nav>
-  <main class="flex-grow pt-20">
+    <nav class="bg-white flex w-full items-center justify-between px-6 py-4 lg:px-8 text-black shadow">
+      <a href="index.html#home" class="mr-6"><img src="assets/logo.jpg" alt="Recycle WV logo" class="h-8 w-auto" /></a>
+        <ul class="hidden md:flex flex-wrap gap-4 text-sm">
+          <li><a href="index.html#services" class="transition-colors hover:text-brand-100">Services</a></li>
+          <li><a href="index.html#materials" class="transition-colors hover:text-brand-100">Materials</a></li>
+          <li><a href="index.html#process" class="transition-colors hover:text-brand-100">How&nbsp;It&nbsp;Works</a></li>
+          <li><a href="index.html#map" class="transition-colors hover:text-brand-100">Directions</a></li>
+          <li><a href="index.html#contact" class="transition-colors hover:text-brand-100">Contact</a></li>
+        </ul>
+      <div class="ml-auto">
+        <a href="tel:13044251788" class="inline-flex items-center gap-2 rounded-md bg-brand-500 px-4 py-2 text-sm font-medium text-white hover:bg-brand-600 transition-colors">Call&nbsp;Now</a>
+      </div>
+    </nav>
+  </header>
+  <main class="flex-grow pt-24">
   <!-- ========== HERO ========== -->
   <header id="home" class="relative isolate bg-black flex items-center justify-center overflow-hidden min-h-screen">
     <img src="assets/hero.jpg" alt="Scrap metal piles ready for recycling"

--- a/demos/demo-yard-3/about.html
+++ b/demos/demo-yard-3/about.html
@@ -58,6 +58,9 @@
 </head>
 <body class="font-sans text-brand-charcoal antialiased bg-white min-h-screen flex flex-col">
 <header class="bg-white sticky top-0 w-full z-50 shadow-sm navbar-border">
+  <div id="demoBanner" class="bg-brand-orange text-white text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
+    <a href="https://scrapyardsites.com" class="underline">Return to ScrapyardSites.com</a>
+  </div>
   <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 flex items-center h-16">
     <a id="homeButton" href="index.html" class="flex items-center gap-2">
       <img src="assets/logo.svg" alt="Demo Yard logo" class="h-6 w-6 md:h-8 md:w-8">

--- a/demos/demo-yard-3/accepted-materials.html
+++ b/demos/demo-yard-3/accepted-materials.html
@@ -40,6 +40,9 @@
 </head>
 <body class="font-sans text-brand-charcoal antialiased bg-white min-h-screen flex flex-col">
 <header class="bg-white sticky top-0 w-full z-50 shadow-sm navbar-border">
+  <div id="demoBanner" class="bg-brand-orange text-white text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
+    <a href="https://scrapyardsites.com" class="underline">Return to ScrapyardSites.com</a>
+  </div>
   <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 flex items-center h-16">
     <a id="homeButton" href="index.html" class="flex items-center gap-2">
       <img src="assets/logo.svg" alt="Demo Yard logo" class="h-6 w-6 md:h-8 md:w-8">

--- a/demos/demo-yard-3/assets/styles.css
+++ b/demos/demo-yard-3/assets/styles.css
@@ -59,6 +59,27 @@ body {
 .from-red-500 { --tw-gradient-from: var(--color-links) var(--tw-gradient-from-position); }
 .to-red-700 { --tw-gradient-to: var(--color-success) var(--tw-gradient-to-position); }
 
+/* Banner linking back to ScrapyardSites.com */
+#demoBanner {
+  position: relative;
+  z-index: 60;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.25rem;
+  padding: 0.5rem 1rem;
+  background-color: #d75e02;
+  color: #fff;
+  text-align: center;
+}
+
+@media (min-width: 640px) {
+  #demoBanner {
+    flex-direction: row;
+  }
+}
+
 .bg-green-700 { background-color: var(--color-success) !important; }
 
 /* Brand utility classes mirroring ScrapyardSites.com */

--- a/demos/demo-yard-3/contact.html
+++ b/demos/demo-yard-3/contact.html
@@ -58,6 +58,9 @@
 </head>
 <body class="font-sans text-brand-charcoal antialiased bg-white min-h-screen flex flex-col">
 <header class="bg-white sticky top-0 w-full z-50 shadow-sm navbar-border">
+  <div id="demoBanner" class="bg-brand-orange text-white text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
+    <a href="https://scrapyardsites.com" class="underline">Return to ScrapyardSites.com</a>
+  </div>
   <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 flex items-center h-16">
     <a id="homeButton" href="index.html" class="flex items-center gap-2">
       <img src="assets/logo.svg" alt="Demo Yard logo" class="h-6 w-6 md:h-8 md:w-8">

--- a/demos/demo-yard-3/faq.html
+++ b/demos/demo-yard-3/faq.html
@@ -59,6 +59,9 @@
 </head>
 <body class="font-sans text-brand-charcoal antialiased bg-white min-h-screen flex flex-col">
 <header class="bg-white sticky top-0 w-full z-50 shadow-sm navbar-border">
+  <div id="demoBanner" class="bg-brand-orange text-white text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
+    <a href="https://scrapyardsites.com" class="underline">Return to ScrapyardSites.com</a>
+  </div>
   <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 flex items-center h-16">
     <a id="homeButton" href="index.html" class="flex items-center gap-2">
       <img src="assets/logo.svg" alt="Demo Yard logo" class="h-6 w-6 md:h-8 md:w-8">

--- a/demos/demo-yard-3/index.html
+++ b/demos/demo-yard-3/index.html
@@ -59,6 +59,9 @@
 </head>
 <body class="font-sans text-brand-charcoal antialiased bg-white min-h-screen flex flex-col">
 <header class="bg-white sticky top-0 w-full z-50 shadow-sm navbar-border">
+  <div id="demoBanner" class="bg-brand-orange text-white text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
+    <a href="https://scrapyardsites.com" class="underline">Return to ScrapyardSites.com</a>
+  </div>
   <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 flex items-center h-16">
     <a id="homeButton" href="index.html" class="flex items-center gap-2">
       <img src="assets/logo.svg" alt="Demo Yard logo" class="h-6 w-6 md:h-8 md:w-8">

--- a/demos/demo-yard-3/our-team.html
+++ b/demos/demo-yard-3/our-team.html
@@ -40,6 +40,9 @@
 </head>
 <body class="font-sans text-brand-charcoal antialiased bg-white min-h-screen flex flex-col">
 <header class="bg-white sticky top-0 w-full z-50 shadow-sm navbar-border">
+  <div id="demoBanner" class="bg-brand-orange text-white text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
+    <a href="https://scrapyardsites.com" class="underline">Return to ScrapyardSites.com</a>
+  </div>
   <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 flex items-center h-16">
     <a id="homeButton" href="index.html" class="flex items-center gap-2">
       <img src="assets/logo.svg" alt="Demo Yard logo" class="h-6 w-6 md:h-8 md:w-8">

--- a/demos/demo-yard-3/process.html
+++ b/demos/demo-yard-3/process.html
@@ -59,6 +59,9 @@
 </head>
 <body class="font-sans text-brand-charcoal antialiased bg-white min-h-screen flex flex-col">
 <header class="bg-white sticky top-0 w-full z-50 shadow-sm navbar-border">
+  <div id="demoBanner" class="bg-brand-orange text-white text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
+    <a href="https://scrapyardsites.com" class="underline">Return to ScrapyardSites.com</a>
+  </div>
   <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 flex items-center h-16">
     <a id="homeButton" href="index.html" class="flex items-center gap-2">
       <img src="assets/logo.svg" alt="Demo Yard logo" class="h-6 w-6 md:h-8 md:w-8">

--- a/demos/demo-yard-3/script.js
+++ b/demos/demo-yard-3/script.js
@@ -1,8 +1,12 @@
 function toggleMenu() {
   const menu = document.getElementById('mobileMenu');
+  const banner = document.getElementById('demoBanner');
   if (menu) {
     menu.classList.toggle('hidden');
     menu.classList.toggle('translate-x-full');
+    const isOpen = !menu.classList.contains('hidden');
+    document.body.classList.toggle('overflow-hidden', isOpen);
+    if (banner) banner.classList.toggle('hidden', isOpen);
   }
 }
 

--- a/demos/demo-yard-3/services.html
+++ b/demos/demo-yard-3/services.html
@@ -60,6 +60,9 @@
 </head>
 <body class="font-sans text-brand-charcoal antialiased bg-white min-h-screen flex flex-col">
 <header class="bg-white sticky top-0 w-full z-50 navbar-border">
+  <div id="demoBanner" class="bg-brand-orange text-white text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
+    <a href="https://scrapyardsites.com" class="underline">Return to ScrapyardSites.com</a>
+  </div>
   <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 flex items-center h-16">
     <a id="homeButton" href="index.html" class="flex items-center gap-2">
       <img src="assets/logo.svg" alt="Demo Yard logo" class="h-6 w-6 md:h-8 md:w-8">


### PR DESCRIPTION
## Summary
- add `demoBanner` styles
- insert return banner and adjust mobile menu script for demo-yard-3
- insert banner with styles on demo-yard-1
- restructure demo-yard-2 header with banner and update scroll script

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6886c3b8b25483299adf55e50c9a60b2