### PR TITLE
Adjust CTA and footer spacing on about page

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -189,7 +189,7 @@
     </li>
   </ul>
 </section>
-<section class="beta-invite bg-brand-orange text-white py-12 text-center">
+<section class="beta-invite bg-brand-orange text-white py-10 text-center">
   <div class="max-w-4xl mx-auto px-6">
     <h2 class="text-2xl font-semibold mb-2">Save 10 % on your build — pay your deposit by Aug 30</h2>
     <p class="mb-6 text-sm">Secure your build—own page-one Google space before competitors wake up.</p>


### PR DESCRIPTION
## Summary
- fix spacing around the CTA banner on the about page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6886ccc07ef083298c7c06f2ba338ac8