### PR TITLE
Fix Demo 2 layout and logo color

### DIFF
--- a/demos/demo-yard-1/assets/logo.svg
+++ b/demos/demo-yard-1/assets/logo.svg
@@ -9,11 +9,11 @@
 
   <!-- Thicker orange border -->
   <rect x="5" y="5" width="190" height="190"
-        fill="none" stroke="#D75E02" stroke-width="10"/>
+        fill="none" stroke="#2C663D" stroke-width="10"/>
 
   <!-- Angled orange lifting magnet -->
   <g transform="translate(135 75) rotate(18)">
-    <circle cx="0" cy="0" r="34" fill="#D75E02"/>
+    <circle cx="0" cy="0" r="34" fill="#2C663D"/>
   </g>
 
   <!-- Scrap pile (overlaps border) -->

--- a/demos/demo-yard-2/index.html
+++ b/demos/demo-yard-2/index.html
@@ -114,7 +114,7 @@
           <span class="text-brand-500">Standard</span> Demo
         </span>
       </a>
-        <ul id="menu" class="text-brand-charcoal hidden md:flex flex-1 justify-center items-center gap-6 text-sm font-medium">
+        <ul id="menu" class="text-brand-charcoal hidden md:flex flex-1 justify-center items-center gap-6 text-sm font-medium list-none pl-0 mx-auto">
           <li><a href="index.html#services" class="transition-colors hover:text-brand-100">Services</a></li>
           <li><a href="index.html#materials" class="transition-colors hover:text-brand-100">Materials</a></li>
           <li><a href="index.html#process" class="transition-colors hover:text-brand-100">How&nbsp;It&nbsp;Works</a></li>
@@ -264,8 +264,11 @@
     </div>
   </div>
 </section>
-        <div>
-          <h2 class="text-3xl font-bold">Let’s Talk Scrap</h2>
+  <!-- ========== CONTACT ========== -->
+  <section id="contact" class="bg-white py-20 scroll-mt-20">
+    <div class="max-w-6xl mx-auto px-6 grid md:grid-cols-2 gap-10 items-start">
+      <div>
+        <h2 class="text-3xl font-bold">Let’s Talk Scrap</h2>
           <p class="mt-4 text-black">
             Have a question about pricing, large industrial loads or vehicle requirements?
             Reach out today and our buyers will respond promptly.
@@ -303,7 +306,7 @@
           <p class="mt-4 text-xs text-black">We’ll never share your info.</p>
         </form>
       </div>
-      <div class="mt-8 flex flex-col gap-4">
+      <div class="mt-8 flex flex-col gap-4 max-w-6xl mx-auto px-6">
         <a href="#" class="inline-block rounded-md bg-brand-500 px-6 py-3 text-center font-semibold text-white hover:bg-brand-600 transition-colors">Open Positions</a>
         <a href="#" class="inline-block rounded-md border border-brand-500 px-6 py-3 text-center font-semibold text-brand-500 hover:bg-brand-50 transition-colors">Driver Application</a>
         <a href="#" class="inline-block rounded-md border border-brand-500 px-6 py-3 text-center font-semibold text-brand-500 hover:bg-brand-50 transition-colors">Job Application</a>


### PR DESCRIPTION
## Summary
- recolor the shared logo to use brand green
- clean up Demo 2 contact section and margins
- center desktop navigation links

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68879f870f348329b17bbac87a718335