### PR TITLE
Add material images to demo yard 2

### DIFF
--- a/demos/demo-yard-2/README.md
+++ b/demos/demo-yard-2/README.md
@@ -12,5 +12,9 @@ The site currently expects the following assets:
 - `assets/hero.jpg` – hero image used on both pages.
 - `assets/favicon.svg` – primary favicon in SVG format.
 - `assets/favicon.png` – fallback favicon in PNG format.
+- `../demo-yard-3/assets/aluminum.jpg` – sample aluminum image used on the materials card.
+- `../demo-yard-3/assets/copper.jpg` – sample copper image used on the materials card.
+- `../demo-yard-3/assets/steel.jpg` – sample automobiles image used on the materials card.
+- `../demo-yard-3/assets/stainless.jpg` – sample appliances image used on the materials card.
 
 Image files are not tracked in version control. Ensure any additional images or documents are saved in the `assets/` folder and referenced by their relative path.

--- a/demos/demo-yard-2/index.html
+++ b/demos/demo-yard-2/index.html
@@ -206,18 +206,22 @@
 
       <div class="mt-16 grid gap-10 sm:grid-cols-2 lg:grid-cols-4">
         <div class="rounded-lg bg-white p-6 text-center shadow border border-gray-200">
+          <img src="../demo-yard-3/assets/aluminum.jpg" alt="Aluminum scrap" class="w-full h-32 object-cover rounded mb-4">
           <h3 class="text-lg font-semibold">Aluminum</h3>
           <p class="mt-2 text-black">Cans, siding, wheels, cast &amp; sheet.</p>
         </div>
         <div class="rounded-lg bg-white p-6 text-center shadow border border-gray-200">
+          <img src="../demo-yard-3/assets/copper.jpg" alt="Copper wire and tubing" class="w-full h-32 object-cover rounded mb-4">
           <h3 class="text-lg font-semibold">Copper</h3>
           <p class="mt-2 text-black">Wire, tubing, insulated cable, motors.</p>
         </div>
         <div class="rounded-lg bg-white p-6 text-center shadow border border-gray-200">
+          <img src="../demo-yard-3/assets/steel.jpg" alt="Scrap automobiles" class="w-full h-32 object-cover rounded mb-4">
           <h3 class="text-lg font-semibold">Automobiles</h3>
           <p class="mt-2 text-black">End‑of‑life vehicles (title required).</p>
         </div>
         <div class="rounded-lg bg-white p-6 text-center shadow border border-gray-200">
+          <img src="../demo-yard-3/assets/stainless.jpg" alt="Appliances and mixed scrap" class="w-full h-32 object-cover rounded mb-4">
           <h3 class="text-lg font-semibold">Appliances &amp; Misc.</h3>
           <p class="mt-2 text-black">Refrigerators, washers, farm equipment &amp; mixed scrap.</p>
         </div>


### PR DESCRIPTION
## Summary
- show metal photos on demo yard 2 material cards
- document referenced material images in README

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6887a26d41608329b9d0493776c645fa