### PR TITLE
Update demo-yard-2 favicon

### DIFF
--- a/demos/demo-yard-2/README.md
+++ b/demos/demo-yard-2/README.md
@@ -9,8 +9,7 @@ All images and downloadable files referenced by the HTML pages live in the `asse
 The site currently expects the following assets:
 
 - `../demo-yard-1/assets/logo.svg` – shared logo used for the favicon and navigation bar.
+- `../demo-yard-1/assets/logo.png` – PNG fallback for the favicon.
 - `assets/hero.jpg` – hero image used on both pages.
-- `assets/favicon.svg` – primary favicon in SVG format.
-- `assets/favicon.png` – fallback favicon in PNG format.
 
 Image files are not tracked in version control. Ensure any additional images or documents are saved in the `assets/` folder and referenced by their relative path.

--- a/demos/demo-yard-2/index.html
+++ b/demos/demo-yard-2/index.html
@@ -5,8 +5,8 @@
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Scrapyard Sites | Standard Demo</title>
   <meta name="description" content="Recycle WV (West Virginia Recycling, Inc.) pays top dollar for scrap automobiles, copper, aluminum and appliances in Princeton, WV." />
-  <link rel="icon" type="image/svg+xml" href="assets/favicon.svg" />
-  <link rel="icon" type="image/png" href="assets/favicon.png" />
+  <link rel="icon" type="image/svg+xml" href="../demo-yard-1/assets/logo.svg" />
+  <link rel="icon" type="image/png" href="../demo-yard-1/assets/logo.png" />
   <link rel="stylesheet" href="tailwind.css">
   <style>
     :root {


### PR DESCRIPTION
## Summary
- point favicon to the same logo used in the navigation bar
- update README instructions for Demo Yard 2

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6887a430c1e0832982fa0477628691e8