### PR TITLE
Fix layout for map and contact sections in demo yard 2

### DIFF
--- a/demos/demo-yard-2/index.html
+++ b/demos/demo-yard-2/index.html
@@ -258,12 +258,20 @@
 
   <!-- ========== LOCATION ========== -->
   <section id="map" class="bg-gray-50 py-20 scroll-mt-20">
-  <div class="max-w-6xl mx-auto px-6 grid md:grid-cols-2 gap-10 items-center">
-    <div class="rounded-xl bg-white border border-gray-200 shadow-sm overflow-hidden">
-      <iframe class="w-full h-96" src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3105.0618258223353!2d-77.03171872383582!3d38.89970147172352!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x89b7b7bee1b5b123:0x5026809f2561b278!2sRecycled%20Materials%20Association!5e0!3m2!1sen!2sus!4v1751164589301!5m2!1sen!2sus" style="border:0;" allowfullscreen="" loading="eager" referrerpolicy="no-referrer-when-downgrade"></iframe>
+    <div class="max-w-6xl mx-auto px-6 grid md:grid-cols-2 gap-10 items-center">
+      <div class="rounded-xl bg-white border border-gray-200 shadow-sm overflow-hidden">
+        <iframe class="w-full h-96" src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3105.0618258223353!2d-77.03171872383582!3d38.89970147172352!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x89b7b7bee1b5b123:0x5026809f2561b278!2sRecycled%20Materials%20Association!5e0!3m2!1sen!2sus!4v1751164589301!5m2!1sen!2sus" style="border:0;" allowfullscreen="" loading="eager" referrerpolicy="no-referrer-when-downgrade"></iframe>
+      </div>
+      <div>
+        <h2 class="text-3xl font-bold mb-4">Visit&nbsp;Us</h2>
+        <ul class="space-y-2 text-black">
+          <li>123&nbsp;Demo&nbsp;Road<br>Demo&nbsp;City,&nbsp;NY&nbsp;12345</li>
+          <li><strong>Phone:</strong> <a href="tel:15001234567" class="text-brand-500 underline transition-colors hover:text-brand-600">500.123.4567</a></li>
+          <li><strong>Hours:</strong> Mon–Fri&nbsp;8:00&nbsp;AM – 4:30&nbsp;PM</li>
+        </ul>
+      </div>
     </div>
-  </div>
-</section>
+  </section>
   <!-- ========== CONTACT ========== -->
   <section id="contact" class="bg-white py-20 scroll-mt-20">
     <div class="max-w-6xl mx-auto px-6 grid md:grid-cols-2 gap-10 items-start">
@@ -306,12 +314,12 @@
           <p class="mt-4 text-xs text-black">We’ll never share your info.</p>
         </form>
       </div>
-      <div class="mt-8 flex flex-col gap-4 max-w-6xl mx-auto px-6">
+    </div>
+    <div class="mt-8 flex flex-col gap-4 max-w-6xl mx-auto px-6">
         <a href="#" class="inline-block rounded-md bg-brand-500 px-6 py-3 text-center font-semibold text-white hover:bg-brand-600 transition-colors">Open Positions</a>
         <a href="#" class="inline-block rounded-md border border-brand-500 px-6 py-3 text-center font-semibold text-brand-500 hover:bg-brand-50 transition-colors">Driver Application</a>
         <a href="#" class="inline-block rounded-md border border-brand-500 px-6 py-3 text-center font-semibold text-brand-500 hover:bg-brand-50 transition-colors">Job Application</a>
       </div>
-    </div>
   </section>
   </main>
 


### PR DESCRIPTION
## Summary
- reintroduce two-column layout for the map section with contact info
- move CTA links outside the grid so the contact section spans correctly on desktop

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6887a3ec37e883299a200032e0749376