### PR TITLE
Adjust demo button colors

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -3,7 +3,7 @@
   align-items: center;
   justify-content: center;
   padding: 0.75rem 1.25rem;
-  background-color: #d75e02;
+  background-color: var(--btn-color, #d75e02);
   color: white;
   font-weight: 600;
   line-height: 1;
@@ -20,8 +20,8 @@
 @media (hover: hover) {
   .btn-primary:hover {
     background-color: white;
-    color: #d75e02;
-    border-color: #d75e02;
+    color: var(--btn-color, #d75e02);
+    border-color: var(--btn-color, #d75e02);
   }
 }
 

--- a/demos/index.html
+++ b/demos/index.html
@@ -128,7 +128,7 @@
               <li><strong>Visibility:</strong> SEO‑tuned pages help win “near me” searches.</li>
               <li><strong>Reliability:</strong> 24/7 uptime ensures you never miss a lead.</li>
             </ul>
-            <a href="demo-yard-1/" class="btn-primary md:mt-auto inline-block">View Demo</a>
+            <a href="demo-yard-1/" class="btn-primary md:mt-auto inline-block" style="--btn-color:#D75E02">View Demo</a>
           </div>
           <div class="carousel-item bg-gray-50 border border-brand-steel/10 rounded-xl shadow-sm p-6 flex flex-col h-full demo-card transition transform hover:-translate-y-1">
             <a href="demo-yard-2/">
@@ -142,7 +142,7 @@
               <li><strong>Visibility:</strong> Local SEO and speed boost mobile searches.</li>
               <li><strong>Reliability:</strong> Instant call button connects you fast.</li>
             </ul>
-            <a href="demo-yard-2/" class="btn-primary md:mt-auto inline-block">View Demo</a>
+            <a href="demo-yard-2/" class="btn-primary md:mt-auto inline-block" style="--btn-color:#2C663D">View Demo</a>
           </div>
           <div class="carousel-item bg-gray-50 border border-brand-steel/10 rounded-xl shadow-sm p-6 flex flex-col h-full demo-card transition transform hover:-translate-y-1">
             <a href="demo-yard-3/">
@@ -156,7 +156,7 @@
               <li><strong>Visibility:</strong> Optimized content attracts high-volume suppliers.</li>
               <li><strong>Reliability:</strong> Dependable uptime proves you're ready for big jobs.</li>
             </ul>
-            <a href="demo-yard-3/" class="btn-primary md:mt-auto inline-block">View Demo</a>
+            <a href="demo-yard-3/" class="btn-primary md:mt-auto inline-block" style="--btn-color:#4169e1">View Demo</a>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- make primary button color overridable via CSS variable
- match color of demo CTA buttons on demos page to each yard's theme

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6887a4902c0c8329b5bfaa624ff6b1bb