### PR TITLE
Fix nav CTA overlapping the title

### DIFF
--- a/demos/demo-yard-1/index.html
+++ b/demos/demo-yard-1/index.html
@@ -186,7 +186,7 @@
       <li><a href="#contact"   class="hover:text-brand-orange">Contact</a></li>
       <li><a href="#faq"       class="hover:text-brand-orange">FAQ</a></li>
     </ul>
-    <a href="#contact" class="btn-primary">Request&nbsp;a&nbsp;Quote</a>
+    <a href="#contact" class="btn-primary ml-auto">Request&nbsp;a&nbsp;Quote</a>
   </nav>
 </header>
 


### PR DESCRIPTION
## Summary
- fix header spacing in demo yard 1 so CTA doesn't overlap the title on mobile

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6887b7bf426483299a304c6f2b49b55e