### PR TITLE
Add mobile carousel for materials

### DIFF
--- a/demos/demo-yard-3/accepted-materials.html
+++ b/demos/demo-yard-3/accepted-materials.html
@@ -99,33 +99,33 @@
     <div class="mx-auto max-w-6xl px-6 text-center">
       <h2 class="text-3xl font-bold mb-8">What We Buy</h2>
     </div>
-    <div class="mt-12 grid grid-cols-2 gap-6 sm:grid-cols-3 lg:grid-cols-3 max-w-[1140px] mx-auto px-6">
-      <a href="#copper" class="group rounded-xl bg-white border border-brand-steel/10 shadow transition transform hover:-translate-y-1 p-6 flex flex-col items-center text-center">
+    <div id="materials-carousel" class="mt-12 carousel-track grid grid-cols-2 gap-6 md:grid-cols-3 max-w-[1140px] mx-auto px-6">
+      <a href="#copper" class="carousel-item group rounded-xl bg-white border border-brand-steel/10 shadow transition transform hover:-translate-y-1 p-6 flex flex-col items-center text-center">
         <img src="assets/copper.jpg" alt="Copper &amp; Brass" class="w-40 h-40 object-cover rounded-lg border border-brand-steel/10 group-hover:scale-105 transition" />
         <h3 class="font-semibold text-lg mt-4">Copper &amp; Brass</h3>
         <p class="text-sm text-brand-steel">Highest copper prices in county</p>
       </a>
-      <a href="#aluminum" class="group rounded-xl bg-white border border-brand-steel/10 shadow transition transform hover:-translate-y-1 p-6 flex flex-col items-center text-center">
+      <a href="#aluminum" class="carousel-item group rounded-xl bg-white border border-brand-steel/10 shadow transition transform hover:-translate-y-1 p-6 flex flex-col items-center text-center">
         <img src="assets/aluminum.jpg" alt="Aluminum" class="w-40 h-40 object-cover rounded-lg border border-brand-steel/10 group-hover:scale-105 transition" />
         <h3 class="font-semibold text-lg mt-4">Aluminum</h3>
         <p class="text-sm text-brand-steel">Clean extrusion &amp; sheet</p>
       </a>
-      <a href="#steel" class="group rounded-xl bg-white border border-brand-steel/10 shadow transition transform hover:-translate-y-1 p-6 flex flex-col items-center text-center">
+      <a href="#steel" class="carousel-item group rounded-xl bg-white border border-brand-steel/10 shadow transition transform hover:-translate-y-1 p-6 flex flex-col items-center text-center">
         <img src="assets/steel.jpg" alt="Steel &amp; Iron" class="w-40 h-40 object-cover rounded-lg border border-brand-steel/10 group-hover:scale-105 transition" />
         <h3 class="font-semibold text-lg mt-4">Steel &amp; Iron</h3>
         <p class="text-sm text-brand-steel">HMS &amp; prepared plate</p>
       </a>
-      <a href="#stainless" class="group rounded-xl bg-white border border-brand-steel/10 shadow transition transform hover:-translate-y-1 p-6 flex flex-col items-center text-center">
+      <a href="#stainless" class="carousel-item group rounded-xl bg-white border border-brand-steel/10 shadow transition transform hover:-translate-y-1 p-6 flex flex-col items-center text-center">
         <img src="assets/stainless.jpg" alt="Stainless Steel" class="w-40 h-40 object-cover rounded-lg border border-brand-steel/10 group-hover:scale-105 transition" />
         <h3 class="font-semibold text-lg mt-4">Stainless Steel</h3>
         <p class="text-sm text-brand-steel">304/316 solids</p>
       </a>
-      <a href="#cats" class="group rounded-xl bg-white border border-brand-steel/10 shadow transition transform hover:-translate-y-1 p-6 flex flex-col items-center text-center">
+      <a href="#cats" class="carousel-item group rounded-xl bg-white border border-brand-steel/10 shadow transition transform hover:-translate-y-1 p-6 flex flex-col items-center text-center">
         <img src="assets/catalytic.jpg" alt="Catalytic Converters" class="w-40 h-40 object-cover rounded-lg border border-brand-steel/10 group-hover:scale-105 transition" />
         <h3 class="font-semibold text-lg mt-4">Catalytic Converters</h3>
         <p class="text-sm text-brand-steel">OEM &amp; DPF</p>
       </a>
-      <a href="#escrap" class="group rounded-xl bg-white border border-brand-steel/10 shadow transition transform hover:-translate-y-1 p-6 flex flex-col items-center text-center">
+      <a href="#escrap" class="carousel-item group rounded-xl bg-white border border-brand-steel/10 shadow transition transform hover:-translate-y-1 p-6 flex flex-col items-center text-center">
         <img src="assets/batteries.jpg" alt="E‑Scrap &amp; Batteries" class="w-40 h-40 object-cover rounded-lg border border-brand-steel/10 group-hover:scale-105 transition" />
         <h3 class="font-semibold text-lg mt-4">E‑Scrap &amp; Batteries</h3>
         <p class="text-sm text-brand-steel">Boards and lead‑acid</p>

--- a/demos/demo-yard-3/assets/styles.css
+++ b/demos/demo-yard-3/assets/styles.css
@@ -367,3 +367,37 @@ header nav a:hover::after,
 .fade-in {
   animation: values-fade-in 0.5s ease;
 }
+
+/* Mobile carousel styles reused from the main site */
+@media (max-width: 767px) {
+  .carousel-track {
+    display: flex;
+    overflow-x: auto;
+    scroll-snap-type: x mandatory;
+    -webkit-overflow-scrolling: touch;
+    scroll-behavior: smooth;
+  }
+  .carousel-item {
+    flex: 0 0 100%;
+    scroll-snap-align: center;
+  }
+}
+
+.carousel-indicators {
+  display: flex;
+  justify-content: center;
+  gap: 0.5rem;
+  margin-top: 2.5rem;
+}
+.carousel-indicators span {
+  background: var(--color-links);
+  border-radius: 9999px;
+  width: 0.5rem;
+  height: 0.5rem;
+  opacity: 0.5;
+  transition: width 0.3s ease, opacity 0.3s ease;
+}
+.carousel-indicators span.active {
+  width: 1.5rem;
+  opacity: 1;
+}

--- a/demos/demo-yard-3/script.js
+++ b/demos/demo-yard-3/script.js
@@ -349,6 +349,45 @@ function initTeamCarousel() {
 
 }
 
+function initMaterialsCarousel() {
+  if (!window.matchMedia('(max-width: 767px)').matches) return;
+  const track = document.getElementById('materials-carousel');
+  if (!track) return;
+  const slides = Array.from(track.children);
+  const indicators = document.createElement('div');
+  indicators.className = 'carousel-indicators';
+  slides.forEach((_, i) => {
+    const dot = document.createElement('span');
+    if (i === 0) dot.classList.add('active');
+    dot.addEventListener('click', () => goTo(i));
+    indicators.appendChild(dot);
+  });
+  track.after(indicators);
+
+  let index = 0;
+  const slideWidth = slides[1] ? slides[1].offsetLeft - slides[0].offsetLeft : track.clientWidth;
+
+  function updateDots(i) {
+    indicators.querySelectorAll('span').forEach((dot, idx) => {
+      dot.classList.toggle('active', idx === i);
+    });
+  }
+
+  function goTo(i) {
+    index = i;
+    track.scrollTo({ left: slideWidth * index, behavior: 'smooth' });
+    updateDots(index);
+  }
+
+  track.addEventListener('scroll', () => {
+    const i = Math.round(track.scrollLeft / slideWidth);
+    if (i !== index) {
+      index = i;
+      updateDots(index);
+    }
+  });
+}
+
 function initPage() {
   highlightActiveNav();
   initMenu();
@@ -368,6 +407,8 @@ function initPage() {
   initValuesCarousel();
 
   initTeamCarousel();
+
+  initMaterialsCarousel();
 
 
 }


### PR DESCRIPTION
## Summary
- add mobile carousel styling with royal blue dots
- convert material cards to carousel
- initialize carousel via new script

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6887b864ff748329b306711d8e7c6cd6