### PR TITLE
Fix Demo Yard 2 nav bar position

### DIFF
--- a/demos/demo-yard-2/index.html
+++ b/demos/demo-yard-2/index.html
@@ -89,7 +89,7 @@
   </style>
 </head>
 <body class="font-sans antialiased text-black scroll-smooth flex flex-col min-h-screen overflow-x-hidden">
-  <header class="bg-white sticky top-0 w-full z-50 shadow-sm">
+  <header class="bg-white fixed top-0 inset-x-0 w-full z-50 shadow-sm">
     <div id="demoBanner" class="bg-brand-500 text-white text-center text-sm px-4 py-2 flex flex-col sm:flex-row items-center gap-2 justify-center">
       <a href="https://scrapyardsites.com" class="underline">Return to ScrapyardSites.com</a>
     </div>


### PR DESCRIPTION
## Summary
- ensure the navigation bar in demo yard 2 stays fixed to the top

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6887b8c54a0083299499e8243cedb70a