### PR TITLE
Fix demo yard mobile menu

### DIFF
--- a/demos/demo-yard-3/about.html
+++ b/demos/demo-yard-3/about.html
@@ -73,7 +73,7 @@
       <a href="services.html" class="text-sm font-medium text-gray-300">Services</a><a href="process.html" class="text-sm font-medium text-gray-300">Process</a><a href="accepted-materials.html" class="text-sm font-medium text-gray-300">Materials</a><a href="about.html" class="text-sm font-medium text-brand-orange">About Us</a><a href="our-team.html" class="text-sm font-medium text-gray-300">Our Team</a><a href="contact.html" class="text-sm font-medium text-gray-300">Contact</a><a href="faq.html" class="text-sm font-medium text-gray-300">FAQ</a>
     </nav>
     <a href="contact.html" class="hidden md:inline-block rounded-md bg-brand-orange px-5 py-2 font-semibold text-white shadow-sm hover:opacity-90 transition ml-6">Request a Quote</a>
-    <a href="contact.html" class="md:hidden inline-block rounded-md bg-brand-orange px-3 py-1.5 text-sm font-semibold text-white shadow-sm hover:opacity-90 transition ml-auto mr-3">Request a Quote</a>
+    <!-- Mobile CTA removed -->
     <button id="menuButton" class="md:hidden text-gray-300 focus:outline-none">
       <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"></path>
@@ -81,6 +81,7 @@
     </button>
     </div>
     <div id="mobileMenu" class="fixed inset-0 bg-white z-60 flex flex-col items-center justify-center space-y-6 text-xl text-white transform translate-x-full transition-transform duration-300 md:hidden hidden">
+      <a href="index.html" class="absolute inset-x-0 top-0 flex justify-center items-center no-highlight"><img src="assets/logo.svg" alt="Demo Yard logo" class="h-20 w-20"/></a>
       <button id="closeMenu" class="absolute top-4 right-4 text-white focus:outline-none">
         <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>

--- a/demos/demo-yard-3/accepted-materials.html
+++ b/demos/demo-yard-3/accepted-materials.html
@@ -55,7 +55,7 @@
       <a href="services.html" class="text-sm font-medium text-gray-300">Services</a><a href="process.html" class="text-sm font-medium text-gray-300">Process</a><a href="accepted-materials.html" class="text-sm font-medium text-brand-orange">Materials</a><a href="about.html" class="text-sm font-medium text-gray-300">About Us</a><a href="our-team.html" class="text-sm font-medium text-gray-300">Our Team</a><a href="contact.html" class="text-sm font-medium text-gray-300">Contact</a><a href="faq.html" class="text-sm font-medium text-gray-300">FAQ</a>
     </nav>
     <a href="contact.html" class="hidden md:inline-block rounded-md bg-brand-orange px-5 py-2 font-semibold text-white shadow-sm hover:opacity-90 transition ml-6">Request a Quote</a>
-    <a href="contact.html" class="md:hidden inline-block rounded-md bg-brand-orange px-3 py-1.5 text-sm font-semibold text-white shadow-sm hover:opacity-90 transition ml-auto mr-3">Request a Quote</a>
+    <!-- Mobile CTA removed -->
     <button id="menuButton" class="md:hidden text-gray-300 focus:outline-none">
       <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"></path>
@@ -63,6 +63,7 @@
     </button>
     </div>
     <div id="mobileMenu" class="fixed inset-0 bg-white z-60 flex flex-col items-center justify-center space-y-6 text-xl text-white transform translate-x-full transition-transform duration-300 md:hidden hidden">
+      <a href="index.html" class="absolute inset-x-0 top-0 flex justify-center items-center no-highlight"><img src="assets/logo.svg" alt="Demo Yard logo" class="h-20 w-20"/></a>
       <button id="closeMenu" class="absolute top-4 right-4 text-white focus:outline-none">
         <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>

--- a/demos/demo-yard-3/contact.html
+++ b/demos/demo-yard-3/contact.html
@@ -73,7 +73,7 @@
       <a href="services.html" class="text-sm font-medium text-gray-300">Services</a><a href="process.html" class="text-sm font-medium text-gray-300">Process</a><a href="accepted-materials.html" class="text-sm font-medium text-gray-300">Materials</a><a href="about.html" class="text-sm font-medium text-gray-300">About Us</a><a href="our-team.html" class="text-sm font-medium text-gray-300">Our Team</a><a href="contact.html" class="text-sm font-medium text-brand-orange">Contact</a><a href="faq.html" class="text-sm font-medium text-gray-300">FAQ</a>
     </nav>
     <a href="contact.html" class="hidden md:inline-block rounded-md bg-brand-orange px-5 py-2 font-semibold text-white shadow-sm hover:opacity-90 transition ml-6">Request a Quote</a>
-    <a href="contact.html" class="md:hidden inline-block rounded-md bg-brand-orange px-3 py-1.5 text-sm font-semibold text-white shadow-sm hover:opacity-90 transition ml-auto mr-3">Request a Quote</a>
+    <!-- Mobile CTA removed -->
     <button id="menuButton" class="md:hidden text-gray-300 focus:outline-none">
       <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"></path>
@@ -81,6 +81,7 @@
     </button>
     </div>
     <div id="mobileMenu" class="fixed inset-0 bg-white z-60 flex flex-col items-center justify-center space-y-6 text-xl text-white transform translate-x-full transition-transform duration-300 md:hidden hidden">
+      <a href="index.html" class="absolute inset-x-0 top-0 flex justify-center items-center no-highlight"><img src="assets/logo.svg" alt="Demo Yard logo" class="h-20 w-20"/></a>
       <button id="closeMenu" class="absolute top-4 right-4 text-white focus:outline-none">
         <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>

--- a/demos/demo-yard-3/faq.html
+++ b/demos/demo-yard-3/faq.html
@@ -74,7 +74,7 @@
       <a href="services.html" class="text-sm font-medium text-gray-300">Services</a><a href="process.html" class="text-sm font-medium text-gray-300">Process</a><a href="accepted-materials.html" class="text-sm font-medium text-gray-300">Materials</a><a href="about.html" class="text-sm font-medium text-gray-300">About Us</a><a href="our-team.html" class="text-sm font-medium text-gray-300">Our Team</a><a href="contact.html" class="text-sm font-medium text-gray-300">Contact</a><a href="faq.html" class="text-sm font-medium text-brand-orange">FAQ</a>
     </nav>
     <a href="contact.html" class="hidden md:inline-block rounded-md bg-brand-orange px-5 py-2 font-semibold text-white shadow-sm hover:opacity-90 transition ml-6">Request a Quote</a>
-    <a href="contact.html" class="md:hidden inline-block rounded-md bg-brand-orange px-3 py-1.5 text-sm font-semibold text-white shadow-sm hover:opacity-90 transition ml-auto mr-3">Request a Quote</a>
+    <!-- Mobile CTA removed -->
     <button id="menuButton" class="md:hidden text-gray-300 focus:outline-none">
       <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"></path>
@@ -82,6 +82,7 @@
     </button>
     </div>
     <div id="mobileMenu" class="fixed inset-0 bg-white z-60 flex flex-col items-center justify-center space-y-6 text-xl text-white transform translate-x-full transition-transform duration-300 md:hidden hidden">
+      <a href="index.html" class="absolute inset-x-0 top-0 flex justify-center items-center no-highlight"><img src="assets/logo.svg" alt="Demo Yard logo" class="h-20 w-20"/></a>
       <button id="closeMenu" class="absolute top-4 right-4 text-white focus:outline-none">
         <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>

--- a/demos/demo-yard-3/index.html
+++ b/demos/demo-yard-3/index.html
@@ -74,7 +74,7 @@
       <a href="services.html" class="text-sm font-medium text-gray-300">Services</a><a href="process.html" class="text-sm font-medium text-gray-300">Process</a><a href="accepted-materials.html" class="text-sm font-medium text-gray-300">Materials</a><a href="about.html" class="text-sm font-medium text-gray-300">About Us</a><a href="our-team.html" class="text-sm font-medium text-gray-300">Our Team</a><a href="contact.html" class="text-sm font-medium text-gray-300">Contact</a><a href="faq.html" class="text-sm font-medium text-gray-300">FAQ</a>
     </nav>
     <a href="contact.html" class="hidden md:inline-block rounded-md bg-brand-orange px-5 py-2 font-semibold text-white shadow-sm hover:opacity-90 transition ml-6">Request a Quote</a>
-    <a href="contact.html" class="md:hidden inline-block rounded-md bg-brand-orange px-3 py-1.5 text-sm font-semibold text-white shadow-sm hover:opacity-90 transition ml-auto mr-3">Request a Quote</a>
+    <!-- Mobile CTA removed -->
     <button id="menuButton" class="md:hidden text-gray-300 focus:outline-none">
       <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"></path>
@@ -82,6 +82,7 @@
     </button>
     </div>
     <div id="mobileMenu" class="fixed inset-0 bg-white z-60 flex flex-col items-center justify-center space-y-6 text-xl text-white transform translate-x-full transition-transform duration-300 md:hidden hidden">
+      <a href="index.html" class="absolute inset-x-0 top-0 flex justify-center items-center no-highlight"><img src="assets/logo.svg" alt="Demo Yard logo" class="h-20 w-20"/></a>
       <button id="closeMenu" class="absolute top-4 right-4 text-white focus:outline-none">
         <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>

--- a/demos/demo-yard-3/our-team.html
+++ b/demos/demo-yard-3/our-team.html
@@ -55,7 +55,7 @@
       <a href="services.html" class="text-sm font-medium text-gray-300">Services</a><a href="process.html" class="text-sm font-medium text-gray-300">Process</a><a href="accepted-materials.html" class="text-sm font-medium text-gray-300">Materials</a><a href="about.html" class="text-sm font-medium text-gray-300">About Us</a><a href="our-team.html" class="text-sm font-medium text-brand-orange">Our Team</a><a href="contact.html" class="text-sm font-medium text-gray-300">Contact</a><a href="faq.html" class="text-sm font-medium text-gray-300">FAQ</a>
     </nav>
     <a href="contact.html" class="hidden md:inline-block rounded-md bg-brand-orange px-5 py-2 font-semibold text-white shadow-sm hover:opacity-90 transition ml-6">Request a Quote</a>
-    <a href="contact.html" class="md:hidden inline-block rounded-md bg-brand-orange px-3 py-1.5 text-sm font-semibold text-white shadow-sm hover:opacity-90 transition ml-auto mr-3">Request a Quote</a>
+    <!-- Mobile CTA removed -->
     <button id="menuButton" class="md:hidden text-gray-300 focus:outline-none">
       <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"></path>
@@ -63,6 +63,7 @@
     </button>
     </div>
     <div id="mobileMenu" class="fixed inset-0 bg-white z-60 flex flex-col items-center justify-center space-y-6 text-xl text-white transform translate-x-full transition-transform duration-300 md:hidden hidden">
+      <a href="index.html" class="absolute inset-x-0 top-0 flex justify-center items-center no-highlight"><img src="assets/logo.svg" alt="Demo Yard logo" class="h-20 w-20"/></a>
       <button id="closeMenu" class="absolute top-4 right-4 text-white focus:outline-none">
         <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>

--- a/demos/demo-yard-3/process.html
+++ b/demos/demo-yard-3/process.html
@@ -74,7 +74,7 @@
       <a href="services.html" class="text-sm font-medium text-gray-300">Services</a><a href="process.html" class="text-sm font-medium text-brand-orange">Process</a><a href="accepted-materials.html" class="text-sm font-medium text-gray-300">Materials</a><a href="about.html" class="text-sm font-medium text-gray-300">About Us</a><a href="our-team.html" class="text-sm font-medium text-gray-300">Our Team</a><a href="contact.html" class="text-sm font-medium text-gray-300">Contact</a><a href="faq.html" class="text-sm font-medium text-gray-300">FAQ</a>
     </nav>
     <a href="contact.html" class="hidden md:inline-block rounded-md bg-brand-orange px-5 py-2 font-semibold text-white shadow-sm hover:opacity-90 transition ml-6">Request a Quote</a>
-    <a href="contact.html" class="md:hidden inline-block rounded-md bg-brand-orange px-3 py-1.5 text-sm font-semibold text-white shadow-sm hover:opacity-90 transition ml-auto mr-3">Request a Quote</a>
+    <!-- Mobile CTA removed -->
     <button id="menuButton" class="md:hidden text-gray-300 focus:outline-none">
       <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"></path>
@@ -82,6 +82,7 @@
     </button>
     </div>
     <div id="mobileMenu" class="fixed inset-0 bg-white z-60 flex flex-col items-center justify-center space-y-6 text-xl text-white transform translate-x-full transition-transform duration-300 md:hidden hidden">
+      <a href="index.html" class="absolute inset-x-0 top-0 flex justify-center items-center no-highlight"><img src="assets/logo.svg" alt="Demo Yard logo" class="h-20 w-20"/></a>
       <button id="closeMenu" class="absolute top-4 right-4 text-white focus:outline-none">
         <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>

--- a/demos/demo-yard-3/services.html
+++ b/demos/demo-yard-3/services.html
@@ -75,7 +75,7 @@
       <a href="services.html" class="text-sm font-medium text-brand-orange">Services</a><a href="process.html" class="text-sm font-medium text-gray-300">Process</a><a href="accepted-materials.html" class="text-sm font-medium text-gray-300">Materials</a><a href="about.html" class="text-sm font-medium text-gray-300">About Us</a><a href="our-team.html" class="text-sm font-medium text-gray-300">Our Team</a><a href="contact.html" class="text-sm font-medium text-gray-300">Contact</a><a href="faq.html" class="text-sm font-medium text-gray-300">FAQ</a>
     </nav>
     <a href="contact.html" class="hidden md:inline-block rounded-md bg-brand-orange px-5 py-2 font-semibold text-white shadow-sm hover:opacity-90 transition ml-6">Request a Quote</a>
-    <a href="contact.html" class="md:hidden inline-block rounded-md bg-brand-orange px-3 py-1.5 text-sm font-semibold text-white shadow-sm hover:opacity-90 transition ml-auto mr-3">Request a Quote</a>
+    <!-- Mobile CTA removed -->
     <button id="menuButton" class="md:hidden text-gray-300 focus:outline-none">
       <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"></path>
@@ -83,6 +83,7 @@
     </button>
     </div>
     <div id="mobileMenu" class="fixed inset-0 bg-white z-60 flex flex-col items-center justify-center space-y-6 text-xl text-white transform translate-x-full transition-transform duration-300 md:hidden hidden">
+      <a href="index.html" class="absolute inset-x-0 top-0 flex justify-center items-center no-highlight"><img src="assets/logo.svg" alt="Demo Yard logo" class="h-20 w-20"/></a>
       <button id="closeMenu" class="absolute top-4 right-4 text-white focus:outline-none">
         <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>


### PR DESCRIPTION
## Summary
- remove mobile CTA buttons from Demo Yard Three
- show the logo in Demo Yard Three's mobile menu

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6887b94936548329a770d863c410c4f2