### PR TITLE
Fix mobile carousel and match homepage material cards

### DIFF
--- a/demos/demo-yard-3/assets/styles.css
+++ b/demos/demo-yard-3/assets/styles.css
@@ -370,6 +370,7 @@ header nav a:hover::after,
 
 /* Mobile carousel styles reused from the main site */
 @media (max-width: 767px) {
+  #materials-carousel,
   .carousel-track {
     display: flex;
     overflow-x: auto;
@@ -377,6 +378,7 @@ header nav a:hover::after,
     -webkit-overflow-scrolling: touch;
     scroll-behavior: smooth;
   }
+  #materials-carousel > a,
   .carousel-item {
     flex: 0 0 100%;
     scroll-snap-align: center;

--- a/demos/demo-yard-3/index.html
+++ b/demos/demo-yard-3/index.html
@@ -306,42 +306,36 @@
   </div>
 
   <div class="mt-12 grid grid-cols-2 gap-6 sm:grid-cols-3 md:grid-cols-3 max-w-6xl mx-auto px-6">
-    <div class="rounded-xl bg-white border border-brand-steel/10 shadow transition transform hover:-translate-y-1 p-6 flex flex-col items-center text-center">
-      <div class="mb-3 w-full aspect-square rounded-lg overflow-hidden border border-brand-steel/10">
-        <img src="assets/copper.jpg" alt="Copper &amp; Brass" class="w-full h-full object-cover">
-      </div>
-      <h3 class="font-semibold">Copper &amp; Brass</h3>
-    </div>
-    <div class="rounded-xl bg-white border border-brand-steel/10 shadow transition transform hover:-translate-y-1 p-6 flex flex-col items-center text-center">
-      <div class="mb-3 w-full aspect-square rounded-lg overflow-hidden border border-brand-steel/10">
-        <img src="assets/aluminum.jpg" alt="Aluminum" class="w-full h-full object-cover">
-      </div>
-      <h3 class="font-semibold">Aluminum</h3>
-    </div>
-    <div class="rounded-xl bg-white border border-brand-steel/10 shadow transition transform hover:-translate-y-1 p-6 flex flex-col items-center text-center">
-      <div class="mb-3 w-full aspect-square rounded-lg overflow-hidden border border-brand-steel/10">
-        <img src="assets/steel.jpg" alt="Steel &amp; Iron" class="w-full h-full object-cover">
-      </div>
-      <h3 class="font-semibold">Steel &amp; Iron</h3>
-    </div>
-    <div class="rounded-xl bg-white border border-brand-steel/10 shadow transition transform hover:-translate-y-1 p-6 flex flex-col items-center text-center">
-      <div class="mb-3 w-full aspect-square rounded-lg overflow-hidden border border-brand-steel/10">
-        <img src="assets/stainless.jpg" alt="Stainless Steel" class="w-full h-full object-cover">
-      </div>
-      <h3 class="font-semibold">Stainless Steel</h3>
-    </div>
-    <div class="rounded-xl bg-white border border-brand-steel/10 shadow transition transform hover:-translate-y-1 p-6 flex flex-col items-center text-center">
-      <div class="mb-3 w-full aspect-square rounded-lg overflow-hidden border border-brand-steel/10">
-        <img src="assets/catalytic.jpg" alt="Catalytic Converters" class="w-full h-full object-cover">
-      </div>
-      <h3 class="font-semibold">Catalytic Converters</h3>
-    </div>
-    <div class="rounded-xl bg-white border border-brand-steel/10 shadow transition transform hover:-translate-y-1 p-6 flex flex-col items-center text-center">
-      <div class="mb-3 w-full aspect-square rounded-lg overflow-hidden border border-brand-steel/10">
-        <img src="assets/batteries.jpg" alt="E-Scrap &amp; Batteries" class="w-full h-full object-cover">
-      </div>
-      <h3 class="font-semibold">E-Scrap &amp; Batteries</h3>
-    </div>
+    <a href="accepted-materials.html#copper" class="group rounded-xl bg-white border border-brand-steel/10 shadow transition transform hover:-translate-y-1 p-6 flex flex-col items-center text-center">
+      <img src="assets/copper.jpg" alt="Copper &amp; Brass" class="w-40 h-40 object-cover rounded-lg border border-brand-steel/10 group-hover:scale-105 transition" />
+      <h3 class="font-semibold text-lg mt-4">Copper &amp; Brass</h3>
+      <p class="text-sm text-brand-steel">Highest copper prices in county</p>
+    </a>
+    <a href="accepted-materials.html#aluminum" class="group rounded-xl bg-white border border-brand-steel/10 shadow transition transform hover:-translate-y-1 p-6 flex flex-col items-center text-center">
+      <img src="assets/aluminum.jpg" alt="Aluminum" class="w-40 h-40 object-cover rounded-lg border border-brand-steel/10 group-hover:scale-105 transition" />
+      <h3 class="font-semibold text-lg mt-4">Aluminum</h3>
+      <p class="text-sm text-brand-steel">Clean extrusion &amp; sheet</p>
+    </a>
+    <a href="accepted-materials.html#steel" class="group rounded-xl bg-white border border-brand-steel/10 shadow transition transform hover:-translate-y-1 p-6 flex flex-col items-center text-center">
+      <img src="assets/steel.jpg" alt="Steel &amp; Iron" class="w-40 h-40 object-cover rounded-lg border border-brand-steel/10 group-hover:scale-105 transition" />
+      <h3 class="font-semibold text-lg mt-4">Steel &amp; Iron</h3>
+      <p class="text-sm text-brand-steel">HMS &amp; prepared plate</p>
+    </a>
+    <a href="accepted-materials.html#stainless" class="group rounded-xl bg-white border border-brand-steel/10 shadow transition transform hover:-translate-y-1 p-6 flex flex-col items-center text-center">
+      <img src="assets/stainless.jpg" alt="Stainless Steel" class="w-40 h-40 object-cover rounded-lg border border-brand-steel/10 group-hover:scale-105 transition" />
+      <h3 class="font-semibold text-lg mt-4">Stainless Steel</h3>
+      <p class="text-sm text-brand-steel">304/316 solids</p>
+    </a>
+    <a href="accepted-materials.html#cats" class="group rounded-xl bg-white border border-brand-steel/10 shadow transition transform hover:-translate-y-1 p-6 flex flex-col items-center text-center">
+      <img src="assets/catalytic.jpg" alt="Catalytic Converters" class="w-40 h-40 object-cover rounded-lg border border-brand-steel/10 group-hover:scale-105 transition" />
+      <h3 class="font-semibold text-lg mt-4">Catalytic Converters</h3>
+      <p class="text-sm text-brand-steel">OEM &amp; DPF</p>
+    </a>
+    <a href="accepted-materials.html#escrap" class="group rounded-xl bg-white border border-brand-steel/10 shadow transition transform hover:-translate-y-1 p-6 flex flex-col items-center text-center">
+      <img src="assets/batteries.jpg" alt="E‑Scrap &amp; Batteries" class="w-40 h-40 object-cover rounded-lg border border-brand-steel/10 group-hover:scale-105 transition" />
+      <h3 class="font-semibold text-lg mt-4">E‑Scrap &amp; Batteries</h3>
+      <p class="text-sm text-brand-steel">Boards and lead‑acid</p>
+    </a>
 
   </div> <!-- grid -->
   <div class="mt-8 text-center">


### PR DESCRIPTION
## Summary
- adjust materials carousel CSS so it always overrides the grid layout
- restyle homepage material cards to match the carousel cards

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6887bbd9e98c83298fca9e06efb98d08