### PR TITLE
Enable mobile carousel for materials on demo 3 home

### DIFF
--- a/demos/demo-yard-3/index.html
+++ b/demos/demo-yard-3/index.html
@@ -305,33 +305,33 @@
     <p class="text-brand-steel mb-12">These common items bring the best rates.</p>
   </div>
 
-  <div class="mt-12 grid grid-cols-2 gap-6 sm:grid-cols-3 md:grid-cols-3 max-w-6xl mx-auto px-6">
-    <a href="accepted-materials.html#copper" class="group rounded-xl bg-white border border-brand-steel/10 shadow transition transform hover:-translate-y-1 p-6 flex flex-col items-center text-center">
+  <div id="materials-carousel" class="mt-12 carousel-track grid grid-cols-2 gap-6 md:grid-cols-3 max-w-[1140px] mx-auto px-6">
+    <a href="accepted-materials.html#copper" class="carousel-item group rounded-xl bg-white border border-brand-steel/10 shadow transition transform hover:-translate-y-1 p-6 flex flex-col items-center text-center">
       <img src="assets/copper.jpg" alt="Copper &amp; Brass" class="w-40 h-40 object-cover rounded-lg border border-brand-steel/10 group-hover:scale-105 transition" />
       <h3 class="font-semibold text-lg mt-4">Copper &amp; Brass</h3>
       <p class="text-sm text-brand-steel">Highest copper prices in county</p>
     </a>
-    <a href="accepted-materials.html#aluminum" class="group rounded-xl bg-white border border-brand-steel/10 shadow transition transform hover:-translate-y-1 p-6 flex flex-col items-center text-center">
+    <a href="accepted-materials.html#aluminum" class="carousel-item group rounded-xl bg-white border border-brand-steel/10 shadow transition transform hover:-translate-y-1 p-6 flex flex-col items-center text-center">
       <img src="assets/aluminum.jpg" alt="Aluminum" class="w-40 h-40 object-cover rounded-lg border border-brand-steel/10 group-hover:scale-105 transition" />
       <h3 class="font-semibold text-lg mt-4">Aluminum</h3>
       <p class="text-sm text-brand-steel">Clean extrusion &amp; sheet</p>
     </a>
-    <a href="accepted-materials.html#steel" class="group rounded-xl bg-white border border-brand-steel/10 shadow transition transform hover:-translate-y-1 p-6 flex flex-col items-center text-center">
+    <a href="accepted-materials.html#steel" class="carousel-item group rounded-xl bg-white border border-brand-steel/10 shadow transition transform hover:-translate-y-1 p-6 flex flex-col items-center text-center">
       <img src="assets/steel.jpg" alt="Steel &amp; Iron" class="w-40 h-40 object-cover rounded-lg border border-brand-steel/10 group-hover:scale-105 transition" />
       <h3 class="font-semibold text-lg mt-4">Steel &amp; Iron</h3>
       <p class="text-sm text-brand-steel">HMS &amp; prepared plate</p>
     </a>
-    <a href="accepted-materials.html#stainless" class="group rounded-xl bg-white border border-brand-steel/10 shadow transition transform hover:-translate-y-1 p-6 flex flex-col items-center text-center">
+    <a href="accepted-materials.html#stainless" class="carousel-item group rounded-xl bg-white border border-brand-steel/10 shadow transition transform hover:-translate-y-1 p-6 flex flex-col items-center text-center">
       <img src="assets/stainless.jpg" alt="Stainless Steel" class="w-40 h-40 object-cover rounded-lg border border-brand-steel/10 group-hover:scale-105 transition" />
       <h3 class="font-semibold text-lg mt-4">Stainless Steel</h3>
       <p class="text-sm text-brand-steel">304/316 solids</p>
     </a>
-    <a href="accepted-materials.html#cats" class="group rounded-xl bg-white border border-brand-steel/10 shadow transition transform hover:-translate-y-1 p-6 flex flex-col items-center text-center">
+    <a href="accepted-materials.html#cats" class="carousel-item group rounded-xl bg-white border border-brand-steel/10 shadow transition transform hover:-translate-y-1 p-6 flex flex-col items-center text-center">
       <img src="assets/catalytic.jpg" alt="Catalytic Converters" class="w-40 h-40 object-cover rounded-lg border border-brand-steel/10 group-hover:scale-105 transition" />
       <h3 class="font-semibold text-lg mt-4">Catalytic Converters</h3>
       <p class="text-sm text-brand-steel">OEM &amp; DPF</p>
     </a>
-    <a href="accepted-materials.html#escrap" class="group rounded-xl bg-white border border-brand-steel/10 shadow transition transform hover:-translate-y-1 p-6 flex flex-col items-center text-center">
+    <a href="accepted-materials.html#escrap" class="carousel-item group rounded-xl bg-white border border-brand-steel/10 shadow transition transform hover:-translate-y-1 p-6 flex flex-col items-center text-center">
       <img src="assets/batteries.jpg" alt="E‑Scrap &amp; Batteries" class="w-40 h-40 object-cover rounded-lg border border-brand-steel/10 group-hover:scale-105 transition" />
       <h3 class="font-semibold text-lg mt-4">E‑Scrap &amp; Batteries</h3>
       <p class="text-sm text-brand-steel">Boards and lead‑acid</p>


### PR DESCRIPTION
## Summary
- convert materials grid on the demo 3 home page into a mobile carousel

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6887c014c0b48329a7f9c6d77e929372