### PR TITLE
Ensure square images for demo yard 2 material cards

### DIFF
--- a/demos/demo-yard-2/index.html
+++ b/demos/demo-yard-2/index.html
@@ -237,22 +237,22 @@
 
       <div id="materials-carousel" class="mt-16 carousel-track flex px-4 sm:grid sm:grid-cols-2 lg:grid-cols-4 gap-10">
         <div class="carousel-item rounded-lg bg-white p-6 text-center shadow border border-gray-200">
-          <img src="../demo-yard-3/assets/aluminum.jpg" alt="Aluminum scrap" class="w-full h-32 object-cover rounded mb-4">
+          <img src="../demo-yard-3/assets/aluminum.jpg" alt="Aluminum scrap" class="w-40 h-40 object-cover rounded mb-4 mx-auto">
           <h3 class="text-lg font-semibold">Aluminum</h3>
           <p class="mt-2 text-black">Cans, siding, wheels, cast &amp; sheet.</p>
         </div>
         <div class="carousel-item rounded-lg bg-white p-6 text-center shadow border border-gray-200">
-          <img src="../demo-yard-3/assets/copper.jpg" alt="Copper wire and tubing" class="w-full h-32 object-cover rounded mb-4">
+          <img src="../demo-yard-3/assets/copper.jpg" alt="Copper wire and tubing" class="w-40 h-40 object-cover rounded mb-4 mx-auto">
           <h3 class="text-lg font-semibold">Copper</h3>
           <p class="mt-2 text-black">Wire, tubing, insulated cable, motors.</p>
         </div>
         <div class="carousel-item rounded-lg bg-white p-6 text-center shadow border border-gray-200">
-          <img src="../demo-yard-3/assets/steel.jpg" alt="Scrap automobiles" class="w-full h-32 object-cover rounded mb-4">
+          <img src="../demo-yard-3/assets/steel.jpg" alt="Scrap automobiles" class="w-40 h-40 object-cover rounded mb-4 mx-auto">
           <h3 class="text-lg font-semibold">Automobiles</h3>
           <p class="mt-2 text-black">End‑of‑life vehicles (title required).</p>
         </div>
         <div class="carousel-item rounded-lg bg-white p-6 text-center shadow border border-gray-200">
-          <img src="../demo-yard-3/assets/stainless.jpg" alt="Appliances and mixed scrap" class="w-full h-32 object-cover rounded mb-4">
+          <img src="../demo-yard-3/assets/stainless.jpg" alt="Appliances and mixed scrap" class="w-40 h-40 object-cover rounded mb-4 mx-auto">
           <h3 class="text-lg font-semibold">Appliances &amp; Misc.</h3>
           <p class="mt-2 text-black">Refrigerators, washers, farm equipment &amp; mixed scrap.</p>
         </div>


### PR DESCRIPTION
## Summary
- resize material card images for Demo Yard 2 so they use consistent square dimensions

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6887c081072c8329839367da8eca8397