### PR TITLE
Fix contact section layout on demo yard 2

### DIFF
--- a/demos/demo-yard-2/index.html
+++ b/demos/demo-yard-2/index.html
@@ -348,7 +348,6 @@
           </div>
           <p class="mt-4 text-xs text-black">We’ll never share your info.</p>
         </form>
-      </div>
     </div>
     <div class="mt-8 flex flex-col gap-4 max-w-6xl mx-auto px-6">
         <a href="#" class="inline-block rounded-md bg-brand-500 px-6 py-3 text-center font-semibold text-white hover:bg-brand-600 transition-colors">Open Positions</a>


### PR DESCRIPTION
## Summary
- fix closing div so contact form lines up beside the Lets Talk Scrap text

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6887c0b38c1c83299010aeb066628e0a