### PR TITLE
Fix material card sizing and restore carousel dots

### DIFF
--- a/demos/demo-yard-3/assets/styles.css
+++ b/demos/demo-yard-3/assets/styles.css
@@ -385,6 +385,14 @@ header nav a:hover::after,
   }
 }
 
+/* Limit material card width for all screens */
+#materials-carousel > a,
+.carousel-item {
+  max-width: 16rem;
+  margin-left: auto;
+  margin-right: auto;
+}
+
 .carousel-indicators {
   display: flex;
   justify-content: center;

--- a/demos/demo-yard-3/script.js
+++ b/demos/demo-yard-3/script.js
@@ -350,19 +350,24 @@ function initTeamCarousel() {
 }
 
 function initMaterialsCarousel() {
-  if (!window.matchMedia('(max-width: 767px)').matches) return;
   const track = document.getElementById('materials-carousel');
   if (!track) return;
   const slides = Array.from(track.children);
-  const indicators = document.createElement('div');
-  indicators.className = 'carousel-indicators';
-  slides.forEach((_, i) => {
-    const dot = document.createElement('span');
-    if (i === 0) dot.classList.add('active');
+  let indicators = track.parentElement.querySelector('.carousel-indicators');
+  if (!indicators) {
+    indicators = document.createElement('div');
+    indicators.className = 'carousel-indicators';
+    slides.forEach((_, i) => {
+      const dot = document.createElement('span');
+      if (i === 0) dot.classList.add('active');
+      indicators.appendChild(dot);
+    });
+    track.after(indicators);
+  }
+  const dots = Array.from(indicators.querySelectorAll('span'));
+  dots.forEach((dot, i) => {
     dot.addEventListener('click', () => goTo(i));
-    indicators.appendChild(dot);
   });
-  track.after(indicators);
 
   let index = 0;
   const slideWidth = slides[1] ? slides[1].offsetLeft - slides[0].offsetLeft : track.clientWidth;


### PR DESCRIPTION
## Summary
- make material cards narrower on demo 3
- always generate indicators for the materials carousel and avoid duplicates

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6887c6fe0b288329a06418009bb7f9a4