### PR TITLE
Limit materials carousel to mobile

### DIFF
--- a/demos/demo-yard-3/script.js
+++ b/demos/demo-yard-3/script.js
@@ -352,6 +352,9 @@ function initTeamCarousel() {
 function initMaterialsCarousel() {
   const track = document.getElementById('materials-carousel');
   if (!track) return;
+  // Only enable the carousel on small screens
+  const isMobile = window.matchMedia('(max-width: 767px)').matches;
+  if (!isMobile) return;
   const slides = Array.from(track.children);
   let indicators = track.parentElement.querySelector('.carousel-indicators');
   if (!indicators) {


### PR DESCRIPTION
## Summary
- on demo yard 3, only enable the materials carousel for screens 767px wide or smaller

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6887c9462514832983f13ae8b554d804