### PR TITLE
Adjust material card width

### DIFF
--- a/demos/demo-yard-3/assets/styles.css
+++ b/demos/demo-yard-3/assets/styles.css
@@ -388,7 +388,7 @@ header nav a:hover::after,
 /* Limit material card width for all screens */
 #materials-carousel > a,
 .carousel-item {
-  max-width: 16rem;
+  max-width: 14rem;
   margin-left: auto;
   margin-right: auto;
 }


### PR DESCRIPTION
## Summary
- adjust material card maximum width so cards appear narrower

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6887c97e8cac8329b960b39545e7165f