### PR TITLE
Remove outdated reputation tagline

### DIFF
--- a/index.html
+++ b/index.html
@@ -259,7 +259,7 @@
       Your Digital Yard&nbsp;Is&nbsp;Your&nbsp;Reputation
     </h2>
     <p class="text-lg text-gray-700" data-aos="fade-up">
-      Before a single load hits your scale, sellers decide if they trust you—based solely on what they see online. In scrap, your name is currency; your website should prove it.
+      Before a single load hits your scale, sellers decide if they trust you—based solely on what they see online.
     </p>
   </div>
 
@@ -329,7 +329,7 @@
       Your Digital Yard Is Your Reputation
     </h2>
     <p class="text-xl text-gray-700 max-w-3xl mx-auto mb-6" data-aos="fade-up">
-      Before a single load hits your scale, sellers decide if they trust you—based solely on what they see online. In scrap, your name is currency; your website should prove it.
+      Before a single load hits your scale, sellers decide if they trust you—based solely on what they see online.
     </p>
 
     <!-- Stats row -->


### PR DESCRIPTION
## Summary
- drop 'your name is currency; your website should prove it' line from reputation section on the home page

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688e4f3049e083298223a1c632267eb7