### PR TITLE
Reorder Missed Leads above Outdated Signals on homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -286,12 +286,12 @@
         <span><strong>Invisible to Sellers</strong> – No website means you don’t exist to new haulers.</span>
       </li>
       <li class="flex gap-3 items-start" data-aos="fade-up">
-        <span class="flex items-center justify-center w-10 h-10 bg-brand-orange text-white rounded-full flex-shrink-0"><i class="fa-solid fa-clock-rotate-left"></i></span>
-        <span><strong>Outdated Signals</strong> – An old site makes you look unlicensed or unreliable—or simply out of business.</span>
-      </li>
-      <li class="flex gap-3 items-start" data-aos="fade-up">
         <span class="flex items-center justify-center w-10 h-10 bg-brand-orange text-white rounded-full flex-shrink-0"><i class="fa-solid fa-phone-slash"></i></span>
         <span><strong>Missed Leads</strong> – Without a fast quote form, profits go to your competitor.</span>
+      </li>
+      <li class="flex gap-3 items-start" data-aos="fade-up">
+        <span class="flex items-center justify-center w-10 h-10 bg-brand-orange text-white rounded-full flex-shrink-0"><i class="fa-solid fa-clock-rotate-left"></i></span>
+        <span><strong>Outdated Signals</strong> – An old site makes you look unlicensed or unreliable—or simply out of business.</span>
       </li>
     </ul>
   </div>
@@ -364,16 +364,6 @@
               <p class="text-gray-700">No website means you don’t exist to new haulers.</p>
             </div>
           </div>
-          <!-- Outdated Signals -->
-          <div class="flex flex-col items-center text-center md:flex-row md:items-start md:text-left" data-aos="fade-up">
-            <div class="flex-shrink-0 w-12 h-12 flex items-center justify-center bg-brand-orange text-white rounded-full mb-4 md:mb-0 md:mr-4">
-              <i class="fa-solid fa-clock-rotate-left fa-lg"></i>
-            </div>
-            <div>
-              <h4 class="font-semibold text-gray-900 mb-1">Outdated Signals</h4>
-              <p class="text-gray-700">An old site makes you look unlicensed or unreliable—or simply out of business.</p>
-            </div>
-          </div>
           <!-- Missed Leads -->
           <div class="flex flex-col items-center text-center md:flex-row md:items-start md:text-left" data-aos="fade-up">
             <div class="flex-shrink-0 w-12 h-12 flex items-center justify-center bg-brand-orange text-white rounded-full mb-4 md:mb-0 md:mr-4">
@@ -382,6 +372,16 @@
             <div>
               <h4 class="font-semibold text-gray-900 mb-1">Missed Leads</h4>
               <p class="text-gray-700">Without a fast quote form, profits go to your competitor.</p>
+            </div>
+          </div>
+          <!-- Outdated Signals -->
+          <div class="flex flex-col items-center text-center md:flex-row md:items-start md:text-left" data-aos="fade-up">
+            <div class="flex-shrink-0 w-12 h-12 flex items-center justify-center bg-brand-orange text-white rounded-full mb-4 md:mb-0 md:mr-4">
+              <i class="fa-solid fa-clock-rotate-left fa-lg"></i>
+            </div>
+            <div>
+              <h4 class="font-semibold text-gray-900 mb-1">Outdated Signals</h4>
+              <p class="text-gray-700">An old site makes you look unlicensed or unreliable—or simply out of business.</p>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Reordered homepage bullet lists so "Missed Leads" appears before "Outdated Signals".

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688e54c755fc83299c247e6fbe03bd37