### PR TITLE
chore: hide mobile carousel scrollbars

### DIFF
--- a/demos/demo-yard-2/index.html
+++ b/demos/demo-yard-2/index.html
@@ -96,6 +96,11 @@
         scroll-snap-type: x mandatory;
         -webkit-overflow-scrolling: touch;
         scroll-behavior: smooth;
+        scrollbar-width: none;
+        -ms-overflow-style: none;
+      }
+      .carousel-track::-webkit-scrollbar {
+        display: none;
       }
       .carousel-item {
         flex: 0 0 100%;

--- a/demos/demo-yard-3/assets/styles.css
+++ b/demos/demo-yard-3/assets/styles.css
@@ -377,6 +377,12 @@ header nav a:hover::after,
     scroll-snap-type: x mandatory;
     -webkit-overflow-scrolling: touch;
     scroll-behavior: smooth;
+    scrollbar-width: none;
+    -ms-overflow-style: none;
+  }
+  #materials-carousel::-webkit-scrollbar,
+  .carousel-track::-webkit-scrollbar {
+    display: none;
   }
   #materials-carousel > a,
   .carousel-item {

--- a/demos/index.html
+++ b/demos/index.html
@@ -21,7 +21,7 @@
     header nav ul a::after,#mobileMenu a:not(.bg-yellow-500):not(.btn-primary)::after{content:'';position:absolute;left:0;bottom:-2px;width:0;height:2px;background-color:var(--color-links);transition:width .3s ease;}
     header nav ul a:hover::after,#mobileMenu a:not(.bg-yellow-500):not(.btn-primary):hover::after{width:100%;}
     .site-title{position:relative;display:inline-block;}
-    @media (max-width: 767px){.carousel-track{display:flex;overflow-x:auto;scroll-snap-type:x mandatory;-webkit-overflow-scrolling:touch;scroll-behavior:smooth;}.carousel-item{flex:0 0 100%;scroll-snap-align:center;}}
+    @media (max-width: 767px){.carousel-track{display:flex;overflow-x:auto;scroll-snap-type:x mandatory;-webkit-overflow-scrolling:touch;scroll-behavior:smooth;scrollbar-width:none;-ms-overflow-style:none;}.carousel-track::-webkit-scrollbar{display:none;}.carousel-item{flex:0 0 100%;scroll-snap-align:center;}}
     .carousel-indicators{display:flex;justify-content:center;gap:.5rem;margin-top:2.5rem;}
     .carousel-indicators span{background:#D75E02;border-radius:9999px;width:.5rem;height:.5rem;opacity:.5;transition:width .3s ease,opacity .3s ease;}
     .carousel-indicators span.active{width:1.5rem;opacity:1;}

--- a/index.html
+++ b/index.html
@@ -125,6 +125,11 @@
         scroll-snap-type: x mandatory;
         -webkit-overflow-scrolling: touch;
         scroll-behavior: smooth;
+        scrollbar-width: none;
+        -ms-overflow-style: none;
+      }
+      .carousel-track::-webkit-scrollbar {
+        display: none;
       }
       .carousel-item {
         flex: 0 0 100%;

--- a/pricing/index.html
+++ b/pricing/index.html
@@ -21,7 +21,7 @@
     header nav ul a::after,#mobileMenu a:not(.bg-yellow-500):not(.btn-primary)::after{content:'';position:absolute;left:0;bottom:-2px;width:0;height:2px;background-color:var(--color-links);transition:width .3s ease;}
     header nav ul a:hover::after,#mobileMenu a:not(.bg-yellow-500):not(.btn-primary):hover::after{width:100%;}
     .site-title{position:relative;display:inline-block;}
-    @media (max-width: 767px){.carousel-track{display:flex;overflow-x:auto;scroll-snap-type:x mandatory;-webkit-overflow-scrolling:touch;scroll-behavior:smooth;}.carousel-item{flex:0 0 100%;scroll-snap-align:center;}}
+    @media (max-width: 767px){.carousel-track{display:flex;overflow-x:auto;scroll-snap-type:x mandatory;-webkit-overflow-scrolling:touch;scroll-behavior:smooth;scrollbar-width:none;-ms-overflow-style:none;}.carousel-track::-webkit-scrollbar{display:none;}.carousel-item{flex:0 0 100%;scroll-snap-align:center;}}
     .carousel-indicators{display:flex;justify-content:center;gap:.5rem;margin-top:2.5rem;}
     .carousel-indicators span{background:#D75E02;border-radius:9999px;width:.5rem;height:.5rem;opacity:.5;transition:width .3s ease,opacity .3s ease;}
     .carousel-indicators span.active{width:1.5rem;opacity:1;}

--- a/process/index.html
+++ b/process/index.html
@@ -59,6 +59,11 @@
         scroll-snap-type: x mandatory;
         -webkit-overflow-scrolling: touch;
         scroll-behavior: smooth;
+        scrollbar-width: none;
+        -ms-overflow-style: none;
+      }
+      .carousel-track::-webkit-scrollbar {
+        display: none;
       }
       .carousel-item {
         flex: 0 0 100%;

--- a/services/index.html
+++ b/services/index.html
@@ -48,6 +48,11 @@
         scroll-snap-type: x mandatory;
         -webkit-overflow-scrolling: touch;
         scroll-behavior: smooth;
+        scrollbar-width: none;
+        -ms-overflow-style: none;
+      }
+      .carousel-track::-webkit-scrollbar {
+        display: none;
       }
       .carousel-item {
         flex: 0 0 100%;


### PR DESCRIPTION
## Summary
- hide scrollbars for mobile carousels across the site
- apply cross-browser scrollbar hiding styles to demo yard materials carousel

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68928b2617988329bdff96e0e7086310