### PR TITLE
Clarify demo site scrap removal wording

### DIFF
--- a/demos/demo-yard-1/index.html
+++ b/demos/demo-yard-1/index.html
@@ -261,7 +261,7 @@
       </div>
       <div class="rounded-lg border border-brand-steel/20 bg-white p-6 flex flex-col items-center gap-3 shadow transition transform hover:-translate-y-1" data-aos data-aos-delay="50">
         <i class="fa-solid fa-recycle text-3xl text-brand-orange"></i>
-        <p>Demo scrap removal</p>
+        <p>Demo site scrap removal</p>
       </div>
       <div class="rounded-lg border border-brand-steel/20 bg-white p-6 flex flex-col items-center gap-3 shadow transition transform hover:-translate-y-1" data-aos data-aos-delay="100">
         <i class="fa-solid fa-calendar-check text-3xl text-brand-orange"></i>


### PR DESCRIPTION
## Summary
- clarify scrap removal wording in demo yard 1 commercial services section

## Testing
- `npm test` (fails: ENOENT package.json)
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68928de12b008329a939d0a89b16b026