### PR TITLE
Remove greasy material exclusions from demo yard

### DIFF
--- a/demos/demo-yard-3/accepted-materials.html
+++ b/demos/demo-yard-3/accepted-materials.html
@@ -160,7 +160,6 @@
             <h3 class="font-semibold mb-2">We can&rsquo;t accept:</h3>
             <ul class="list-disc list-inside space-y-1">
               <li>Air-conditioning coils with freon</li>
-              <li>Greasy or food-contaminated copper</li>
             </ul>
           </div>
         </div>
@@ -188,7 +187,6 @@
             <h3 class="font-semibold mb-2">We can&rsquo;t accept:</h3>
             <ul class="list-disc list-inside space-y-1">
               <li>Foil pans</li>
-              <li>Food-contaminated scrap</li>
             </ul>
           </div>
         </div>
@@ -238,12 +236,6 @@
             <ul class="list-disc list-inside space-y-1">
               <li>304/316 solids</li>
               <li>Food-grade tanks</li>
-            </ul>
-          </div>
-          <div class="flex-1 md:pl-6 mt-6 md:mt-0">
-            <h3 class="font-semibold mb-2">We can&rsquo;t accept:</h3>
-            <ul class="list-disc list-inside space-y-1">
-              <li>Greasy restaurant scrap</li>
             </ul>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Remove mention of greasy or food-contaminated materials from Demo Yard 3's accepted materials page.

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68928ec36ad48329ad08c5ba36df9f3b