### PR TITLE
fix: stabilize scrollbar handling

### DIFF
--- a/assets/mobile-menu.js
+++ b/assets/mobile-menu.js
@@ -12,13 +12,22 @@ function toggleMobileMenu() {
 
   if (isOpen) {
     scrollPosition = window.scrollY;
+    const scrollBarWidth = window.innerWidth - document.documentElement.clientWidth;
+    document.documentElement.classList.add('overflow-hidden');
+    document.body.classList.add('overflow-hidden');
     document.body.style.top = `-${scrollPosition}px`;
     document.body.style.position = 'fixed';
-    document.body.classList.add('overflow-hidden');
+    document.body.style.width = '100%';
+    if (scrollBarWidth) {
+      document.body.style.paddingRight = `${scrollBarWidth}px`;
+    }
   } else {
+    document.documentElement.classList.remove('overflow-hidden');
     document.body.classList.remove('overflow-hidden');
     document.body.style.position = '';
     document.body.style.top = '';
+    document.body.style.width = '';
+    document.body.style.paddingRight = '';
     window.scrollTo(0, scrollPosition);
   }
 

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -1,3 +1,8 @@
+/* Reserve space for scrollbars to prevent layout shift */
+html {
+  scrollbar-gutter: stable;
+}
+
 .btn-primary {
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- lock `<html>` and `<body>` scrolling when the mobile menu is open
- compensate for scrollbar width to stop layout jump
- reserve space for scrollbars in CSS

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68929091aefc8329a9e78a40798d8e89