### PR TITLE
Remove DPF references from demo site

### DIFF
--- a/demos/demo-yard-3/accepted-materials.html
+++ b/demos/demo-yard-3/accepted-materials.html
@@ -124,7 +124,7 @@
       <a href="#cats" class="carousel-item group rounded-xl bg-white border border-brand-steel/10 shadow transition transform hover:-translate-y-1 p-6 flex flex-col items-center text-center">
         <img src="assets/catalytic.jpg" alt="Catalytic Converters" class="w-40 h-40 object-cover rounded-lg border border-brand-steel/10 group-hover:scale-105 transition" />
         <h3 class="font-semibold text-lg mt-4">Catalytic Converters</h3>
-        <p class="text-sm text-brand-steel">OEM &amp; DPF</p>
+        <p class="text-sm text-brand-steel">OEM units</p>
       </a>
       <a href="#escrap" class="carousel-item group rounded-xl bg-white border border-brand-steel/10 shadow transition transform hover:-translate-y-1 p-6 flex flex-col items-center text-center">
         <img src="assets/batteries.jpg" alt="E‑Scrap &amp; Batteries" class="w-40 h-40 object-cover rounded-lg border border-brand-steel/10 group-hover:scale-105 transition" />
@@ -257,7 +257,6 @@
             <h3 class="font-semibold mb-2">We pay top dollar for:</h3>
             <ul class="list-disc list-inside space-y-1">
               <li>OEM units</li>
-              <li>DPF and foil cats</li>
             </ul>
           </div>
           <div class="flex-1 md:pl-6 mt-6 md:mt-0">

--- a/demos/demo-yard-3/index.html
+++ b/demos/demo-yard-3/index.html
@@ -329,7 +329,7 @@
     <a href="accepted-materials.html#cats" class="carousel-item group rounded-xl bg-white border border-brand-steel/10 shadow transition transform hover:-translate-y-1 p-6 flex flex-col items-center text-center">
       <img src="assets/catalytic.jpg" alt="Catalytic Converters" class="w-40 h-40 object-cover rounded-lg border border-brand-steel/10 group-hover:scale-105 transition" />
       <h3 class="font-semibold text-lg mt-4">Catalytic Converters</h3>
-      <p class="text-sm text-brand-steel">OEM &amp; DPF</p>
+      <p class="text-sm text-brand-steel">OEM units</p>
     </a>
     <a href="accepted-materials.html#escrap" class="carousel-item group rounded-xl bg-white border border-brand-steel/10 shadow transition transform hover:-translate-y-1 p-6 flex flex-col items-center text-center">
       <img src="assets/batteries.jpg" alt="E‑Scrap &amp; Batteries" class="w-40 h-40 object-cover rounded-lg border border-brand-steel/10 group-hover:scale-105 transition" />

--- a/demos/demo-yard-3/services.html
+++ b/demos/demo-yard-3/services.html
@@ -276,7 +276,7 @@
     <div class="max-w-6xl mx-auto px-6 grid md:grid-cols-2 gap-10 items-center">
       <div class="order-2 md:order-1">
         <h2 class="text-3xl font-bold mb-4">Catalytic Converter Recycling</h2>
-        <p class="text-brand-steel">We accurately identify OEM, aftermarket, and DPF units with an industry database and pay on the spot. For high volumes we offer assay‑based settlements with transparent sampling procedures.</p>
+        <p class="text-brand-steel">We accurately identify OEM and aftermarket units with an industry database and pay on the spot. For high volumes we offer assay‑based settlements with transparent sampling procedures.</p>
         <ul class="mt-4 list-disc list-inside space-y-2 text-brand-steel text-sm">
           <li>OEM and aftermarket grading</li>
           <li>Assay-based payouts</li>


### PR DESCRIPTION
## Summary
- remove DPF references from catalytic converter descriptions in demo yard 3
- simplify accepted materials list to omit DPF

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6892912e1d60832988d9f41a14cea44c