### PR TITLE
Add lathes to demo's industrial equipment list

### DIFF
--- a/demos/demo-yard-3/accepted-materials.html
+++ b/demos/demo-yard-3/accepted-materials.html
@@ -208,6 +208,7 @@
             <ul class="list-disc list-inside space-y-1">
               <li>HMS and prepared plate</li>
               <li>Cast iron machinery</li>
+              <li>Lathes</li>
               <li>Tin</li>
             </ul>
           </div>


### PR DESCRIPTION
## Summary
- include lathes as accepted industrial equipment on the premium demo

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68929160767c832998676a2482b24c10