### PR TITLE
fix: add scrollbar fallback for unsupported browsers

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -3,6 +3,13 @@ html {
   scrollbar-gutter: stable;
 }
 
+/* Fallback for browsers that don't support `scrollbar-gutter` */
+@supports not (scrollbar-gutter: stable) {
+  html {
+    overflow-y: scroll;
+  }
+}
+
 .btn-primary {
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- ensure scrollbars remain stable by adding a fallback for browsers without `scrollbar-gutter`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6892922dc9b48329a11db3a52928be32