### PR TITLE
fix: stabilize desktop scrollbar

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -1,13 +1,6 @@
-/* Reserve space for scrollbars to prevent layout shift */
+/* Always reserve vertical scrollbar space to prevent layout shift and jitter */
 html {
-  scrollbar-gutter: stable;
-}
-
-/* Fallback for browsers that don't support `scrollbar-gutter` */
-@supports not (scrollbar-gutter: stable) {
-  html {
-    overflow-y: scroll;
-  }
+  overflow-y: scroll;
 }
 
 .btn-primary {


### PR DESCRIPTION
## Summary
- remove `scrollbar-gutter` usage and always reserve scrollbar space with `overflow-y: scroll`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6892948e14008329b2b87e1413bf0d87