### PR TITLE
fix: stabilize scroll offset

### DIFF
--- a/assets/header-offset.js
+++ b/assets/header-offset.js
@@ -6,6 +6,7 @@
     const height=header.getBoundingClientRect().height;
     main.style.paddingTop=height+'px';
   }
+  window.applyHeaderOffset=applyOffset;
   window.addEventListener('load', applyOffset);
   document.addEventListener('DOMContentLoaded', applyOffset);
   window.addEventListener('resize', applyOffset);

--- a/assets/mobile-menu.js
+++ b/assets/mobile-menu.js
@@ -36,7 +36,7 @@ function toggleMobileMenu() {
 
   const themeMeta = document.querySelector('meta[name=theme-color]');
   if (themeMeta) themeMeta.setAttribute('content', isOpen ? '#ffffff' : '#D75E02');
-  window.dispatchEvent(new Event('resize'));
+  if (typeof window.applyHeaderOffset === 'function') window.applyHeaderOffset();
 }
 
 document.addEventListener('DOMContentLoaded', () => {


### PR DESCRIPTION
## Summary
- expose reusable `applyHeaderOffset` function
- refresh header offset after mobile menu toggles without firing resize events

## Testing
- `node --check assets/mobile-menu.js`
- `node --check assets/header-offset.js`


------
https://chatgpt.com/codex/tasks/task_e_689297575a148329bcd4ddd4d62e488f