### PR TITLE
Align contact info sections across demo sites

### DIFF
--- a/demos/demo-yard-1/index.html
+++ b/demos/demo-yard-1/index.html
@@ -345,11 +345,20 @@
     </div>
     <div>
       <h2 class="text-3xl font-bold mb-4">Visit Our Yard</h2>
-      <p class="text-brand-steel text-base md:text-sm">
-        <strong>Hours:</strong> Mon–Fri 8 am–5 pm · Sat 8 am–1 pm<br/>
-        <strong>Address:</strong> 123 Demo Rd, Demo City, TX 77001<br/>
-        <strong>Phone:</strong> <a href="tel:+15551234567" class="underline">555‐123‐4567</a>
-      </p>
+      <dl class="text-brand-steel text-base md:text-sm space-y-2">
+        <div class="flex justify-between">
+          <dt class="font-bold">Hours:</dt>
+          <dd>Mon–Fri 8 am–5 pm · Sat 8 am–1 pm</dd>
+        </div>
+        <div class="flex justify-between">
+          <dt class="font-bold">Address:</dt>
+          <dd>123 Demo Rd, Demo City, TX 77001</dd>
+        </div>
+        <div class="flex justify-between">
+          <dt class="font-bold">Phone:</dt>
+          <dd><a href="tel:+15551234567" class="underline">555‑123‑4567</a></dd>
+        </div>
+      </dl>
     </div>
   </div>
 </section>

--- a/demos/demo-yard-2/index.html
+++ b/demos/demo-yard-2/index.html
@@ -316,13 +316,28 @@
             Reach out today and our buyers will respond promptly.
           </p>
 
-          <ul class="mt-8 space-y-4 text-black">
-            <li><strong>Phone:</strong> <a href="tel:15001234567" class="text-brand-500 underline transition-colors hover:text-brand-600">500.123.4567</a></li>
-            <li><strong>Fax:</strong> <a href="tel:111234567" class="text-brand-500 underline transition-colors hover:text-brand-600">111.234.567</a></li>
-            <li><strong>Email:</strong> <a href="mailto:hello@scrapyardsites.com" class="text-brand-500 underline transition-colors hover:text-brand-600">hello@scrapyardsites.com</a></li>
-            <li><strong>Address:</strong><br>123 Demo Road<br>Demo City, NY 12345</li>
-            <li><strong>Hours:</strong> Mon–Fri 8:00 AM – 4:30 PM</li>
-          </ul>
+          <dl class="mt-8 space-y-4 text-black">
+            <div class="flex justify-between">
+              <dt class="font-bold">Phone:</dt>
+              <dd><a href="tel:15001234567" class="text-brand-500 underline transition-colors hover:text-brand-600">500.123.4567</a></dd>
+            </div>
+            <div class="flex justify-between">
+              <dt class="font-bold">Fax:</dt>
+              <dd><a href="tel:111234567" class="text-brand-500 underline transition-colors hover:text-brand-600">111.234.567</a></dd>
+            </div>
+            <div class="flex justify-between">
+              <dt class="font-bold">Email:</dt>
+              <dd><a href="mailto:hello@scrapyardsites.com" class="text-brand-500 underline transition-colors hover:text-brand-600">hello@scrapyardsites.com</a></dd>
+            </div>
+            <div class="flex justify-between">
+              <dt class="font-bold">Address:</dt>
+              <dd>123 Demo Road, Demo City, NY 12345</dd>
+            </div>
+            <div class="flex justify-between">
+              <dt class="font-bold">Hours:</dt>
+              <dd>Mon–Fri&nbsp;8:00&nbsp;AM – 4:30&nbsp;PM</dd>
+            </div>
+          </dl>
 
 
         </div>

--- a/demos/demo-yard-3/about.html
+++ b/demos/demo-yard-3/about.html
@@ -252,10 +252,24 @@
       </div>
         <div>
           <h2 class="text-3xl font-bold mb-4">Visit Us Today</h2>
-          <p class="text-lg mb-2"><strong>Hours:</strong> Mon&ndash;Fri 8am&ndash;5pm</p>
-          <p class="text-lg mb-2"><strong>Address:</strong> 123 Demo Road, Demo City, NY&nbsp;12345</p>
-          <p class="text-lg mb-2"><strong>Phone:</strong> <a href="tel:5551234567" class="text-brand-orange hover:underline">555-123-4567</a></p>
-          <p class="text-lg"><strong>Email:</strong> <a href="mailto:info@demoyard.com" class="text-brand-orange hover:underline">info@demoyard.com</a></p>
+          <dl class="text-lg space-y-2">
+            <div class="flex justify-between">
+              <dt class="font-bold">Hours:</dt>
+              <dd>Mon&ndash;Fri 8am&ndash;5pm</dd>
+            </div>
+            <div class="flex justify-between">
+              <dt class="font-bold">Address:</dt>
+              <dd>123 Demo Road, Demo City, NY&nbsp;12345</dd>
+            </div>
+            <div class="flex justify-between">
+              <dt class="font-bold">Phone:</dt>
+              <dd><a href="tel:5551234567" class="text-brand-orange hover:underline">555-123-4567</a></dd>
+            </div>
+            <div class="flex justify-between">
+              <dt class="font-bold">Email:</dt>
+              <dd><a href="mailto:info@demoyard.com" class="text-brand-orange hover:underline">info@demoyard.com</a></dd>
+            </div>
+          </dl>
         </div>
     </div>
   </section>

--- a/demos/demo-yard-3/contact.html
+++ b/demos/demo-yard-3/contact.html
@@ -103,11 +103,20 @@
 <section id="contact" class="scroll-mt-16 py-20 bg-gray-100">
   <div class="mx-auto max-w-4xl px-6 text-center">
     <h2 class="text-3xl font-bold">Contact Us</h2>
-    <div class="mt-2 text-brand-steel text-base md:text-sm space-y-1">
-      <p><strong>Phone:</strong> <a href="tel:5551234567" class="underline text-brand-orange">555‑123‑4567</a></p>
-      <p><strong>Email:</strong> <a href="mailto:info@demoyard.com" class="underline text-brand-orange">info@demoyard.com</a></p>
-      <p><strong>Yard Address:</strong> 123 Demo Road, Demo City, NY 12345</p>
-    </div>
+    <dl class="mt-2 text-brand-steel text-base md:text-sm space-y-1 text-left inline-block">
+      <div class="flex justify-between">
+        <dt class="font-bold">Phone:</dt>
+        <dd><a href="tel:5551234567" class="underline text-brand-orange">555‑123‑4567</a></dd>
+      </div>
+      <div class="flex justify-between">
+        <dt class="font-bold">Email:</dt>
+        <dd><a href="mailto:info@demoyard.com" class="underline text-brand-orange">info@demoyard.com</a></dd>
+      </div>
+      <div class="flex justify-between">
+        <dt class="font-bold">Yard&nbsp;Address:</dt>
+        <dd>123 Demo Road, Demo City, NY 12345</dd>
+      </div>
+    </dl>
 
     <form action="https://formspree.io/f/yourID" method="POST" class="mt-10 grid gap-6">
       <input type="text" name="name" required placeholder="Name" class="w-full rounded-md px-4 py-3 bg-white border border-brand-steel/20 text-brand-charcoal" />

--- a/demos/demo-yard-3/index.html
+++ b/demos/demo-yard-3/index.html
@@ -379,10 +379,24 @@
       </div>
         <div>
           <h2 class="text-3xl font-bold mb-4">Visit Us Today</h2>
-          <p class="text-lg mb-2"><strong>Hours:</strong> Mon&ndash;Fri 8am&ndash;5pm</p>
-          <p class="text-lg mb-2"><strong>Address:</strong> 123 Demo Road, Demo City, NY&nbsp;12345</p>
-          <p class="text-lg mb-2"><strong>Phone:</strong> <a href="tel:5551234567" class="text-brand-orange hover:underline">555-123-4567</a></p>
-          <p class="text-lg"><strong>Email:</strong> <a href="mailto:info@demoyard.com" class="text-brand-orange hover:underline">info@demoyard.com</a></p>
+          <dl class="text-lg space-y-2">
+            <div class="flex justify-between">
+              <dt class="font-bold">Hours:</dt>
+              <dd>Mon&ndash;Fri 8am&ndash;5pm</dd>
+            </div>
+            <div class="flex justify-between">
+              <dt class="font-bold">Address:</dt>
+              <dd>123 Demo Road, Demo City, NY&nbsp;12345</dd>
+            </div>
+            <div class="flex justify-between">
+              <dt class="font-bold">Phone:</dt>
+              <dd><a href="tel:5551234567" class="text-brand-orange hover:underline">555-123-4567</a></dd>
+            </div>
+            <div class="flex justify-between">
+              <dt class="font-bold">Email:</dt>
+              <dd><a href="mailto:info@demoyard.com" class="text-brand-orange hover:underline">info@demoyard.com</a></dd>
+            </div>
+          </dl>
         </div>
     </div>
   </section>


### PR DESCRIPTION
## Summary
- Align location, hours, and phone/email details using flex description lists in each demo yard page
- Ensure contact blocks render with consistent left-right justification

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894d35194308329998f686a54c4043a