### PR TITLE
Fix demo site 2 favicon color

### DIFF
--- a/demos/demo-yard-2/README.md
+++ b/demos/demo-yard-2/README.md
@@ -8,8 +8,8 @@ All images and downloadable files referenced by the HTML pages live in the `asse
 
 The site currently expects the following assets:
 
-- `../demo-yard-1/assets/logo.svg` – shared logo used for the favicon and navigation bar.
-- `../demo-yard-1/assets/logo.png` – PNG fallback for the favicon.
+- `assets/favicon.svg` – green favicon and navbar icon for this demo.
+- `assets/favicon.png` – PNG fallback for the favicon.
 - `assets/hero.jpg` – hero image used on both pages.
 
 - `assets/favicon.svg` – primary favicon in SVG format.

--- a/demos/demo-yard-2/index.html
+++ b/demos/demo-yard-2/index.html
@@ -5,8 +5,8 @@
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Scrapyard Sites | Standard Demo</title>
   <meta name="description" content="Recycle WV (West Virginia Recycling, Inc.) pays top dollar for scrap automobiles, copper, aluminum and appliances in Princeton, WV." />
-  <link rel="icon" type="image/svg+xml" href="../demo-yard-1/assets/logo.svg" />
-  <link rel="icon" type="image/png" href="../demo-yard-1/assets/logo.png" />
+  <link rel="icon" type="image/svg+xml" href="assets/favicon.svg" />
+  <link rel="icon" type="image/png" href="assets/favicon.png" />
   <link rel="stylesheet" href="tailwind.css">
   <style>
     :root {
@@ -146,7 +146,7 @@
     </div>
     <nav class="max-w-7xl mx-auto relative flex items-center justify-between py-3 px-6">
       <a href="index.html#home" class="flex items-center gap-2">
-        <img src="../demo-yard-1/assets/logo.svg" alt="Demo Yard logo" class="h-8 w-8"/>
+        <img src="assets/favicon.svg" alt="Demo Yard logo" class="h-8 w-8"/>
         <span class="site-title text-xl md:text-2xl font-black tracking-tight text-brand-charcoal">
           <span class="text-brand-500">Standard</span> Demo
         </span>


### PR DESCRIPTION
Switch Demo site 2 to use its correct green favicon and navbar icon instead of the orange Demo 1 assets.

---
<a href="https://cursor.com/background-agent?bcId=bc-5bed53b0-e23c-4bcd-b0da-299cb424298d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5bed53b0-e23c-4bcd-b0da-299cb424298d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

