### PR TITLE
Update demo site 2 icons with green

### DIFF
--- a/demos/demo-yard-2/assets/favicon.svg
+++ b/demos/demo-yard-2/assets/favicon.svg
@@ -1,20 +1,28 @@
-<svg xmlns="http://www.w3.org/2000/svg"
-     width="400px" height="400px"
-     viewBox="0 0 400 400">
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="200" height="200" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
+  <!-- white background -->
+  <rect width="200" height="200" fill="#FFFFFF"/>
 
-  <!-- Solid white background -->
-  <rect width="400" height="400" fill="#ffffff" />
+  <!-- Steel-gray tether (bottom layer) -->
+  <line x1="90" y1="-20" x2="135" y2="75"
+        stroke="#5E6367" stroke-width="6" stroke-linecap="butt"/>
 
-  <!-- RWV lettering -->
-  <text x="35" y="250"                        
-        font-family="Arial, Helvetica, sans-serif"
-        font-size="140px"
-        font-weight="700">
+  <!-- Thicker green border (replaces orange) -->
+  <rect x="5" y="5" width="190" height="190"
+        fill="none" stroke="#2C663D" stroke-width="10"/>
 
-    <!-- Black R -->
-    <tspan fill="#000000">R</tspan>
+  <!-- Angled green lifting magnet (replaces orange) -->
+  <g transform="translate(135 75) rotate(18)">
+    <circle cx="0" cy="0" r="34" fill="#2C663D"/>
+  </g>
 
-    <!-- Green WV, shifted left to close the gap -->
-    <tspan fill="#006837" dx="-20">WV</tspan>
-  </text>
+  <!-- Scrap pile (overlaps border) -->
+  <path d="
+        M0 135
+        Q50 120 100 130
+        T200 135
+        L200 200
+        L0 200
+        Z"
+        fill="#2B2B2B"/>
 </svg>

--- a/demos/demo-yard-2/index.html
+++ b/demos/demo-yard-2/index.html
@@ -5,8 +5,11 @@
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Scrapyard Sites | Standard Demo</title>
   <meta name="description" content="Recycle WV (West Virginia Recycling, Inc.) pays top dollar for scrap automobiles, copper, aluminum and appliances in Princeton, WV." />
+  <meta name="theme-color" content="#2C663D" />
   <link rel="icon" type="image/svg+xml" href="assets/favicon.svg" />
   <link rel="icon" type="image/png" href="assets/favicon.png" />
+  <link rel="mask-icon" href="assets/favicon.svg" color="#2C663D" />
+  <link rel="apple-touch-icon" href="assets/favicon.svg" />
   <link rel="stylesheet" href="tailwind.css">
   <style>
     :root {
@@ -43,7 +46,7 @@
       color: #2C663D;
     }
 
-    /* Force "Scrapyard" word to appear orange */
+    /* Force "Scrapyard" word to appear green */
     .site-title span:first-child {
       color: #2C663D !important;
     }
@@ -65,7 +68,7 @@
       color: currentColor !important; /* keep existing color on hover */
     }
 
-    /* Keep active nav item orange even when hovered */
+    /* Keep active nav item green even when hovered */
     header nav ul a.text-brand-500:hover {
       color: var(--color-links) !important;
     }


### PR DESCRIPTION
Update Demo Site 2's favicon and theme color to use a green color scheme.

---
<a href="https://cursor.com/background-agent?bcId=bc-207515fc-e2d9-4e68-aff4-65f13d6f02fa">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-207515fc-e2d9-4e68-aff4-65f13d6f02fa">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

