### PR TITLE
Remove demo 2 cards in let's talk scrap

### DIFF
--- a/demos/demo-yard-2/index.html
+++ b/demos/demo-yard-2/index.html
@@ -325,23 +325,23 @@
           <p class="mt-4 text-black">Have a question about pricing, large industrial profits or vehicle requirements? Reach out today and our buyers will respond promptly.</p>
 
           <dl class="mt-8 grid grid-cols-1 gap-4 text-black sm:grid-cols-2">
-            <div class="rounded-lg border border-gray-200 bg-gray-50 p-4">
+            <div>
               <dt class="text-sm font-medium text-black opacity-60">Phone</dt>
               <dd class="mt-1 font-semibold"><a href="tel:15001234567" class="text-brand-500 underline transition-colors hover:text-brand-600">500.123.4567</a></dd>
             </div>
-            <div class="rounded-lg border border-gray-200 bg-gray-50 p-4">
+            <div>
               <dt class="text-sm font-medium text-black opacity-60">Fax</dt>
               <dd class="mt-1 font-semibold"><a href="tel:111234567" class="text-brand-500 underline transition-colors hover:text-brand-600">111.234.567</a></dd>
             </div>
-            <div class="rounded-lg border border-gray-200 bg-gray-50 p-4">
+            <div>
               <dt class="text-sm font-medium text-black opacity-60">Email</dt>
               <dd class="mt-1 font-semibold"><a href="mailto:hello@scrapyardsites.com" class="text-brand-500 underline transition-colors hover:text-brand-600">hello@scrapyardsites.com</a></dd>
             </div>
-            <div class="rounded-lg border border-gray-200 bg-gray-50 p-4">
+            <div>
               <dt class="text-sm font-medium text-black opacity-60">Address</dt>
               <dd class="mt-1 font-semibold">123 Demo Road, Demo City, NY 12345</dd>
             </div>
-            <div class="rounded-lg border border-gray-200 bg-gray-50 p-4 sm:col-span-2">
+            <div class="sm:col-span-2">
               <dt class="text-sm font-medium text-black opacity-60">Hours</dt>
               <dd class="mt-1 font-semibold">Mon–Fri&nbsp;8:00&nbsp;AM – 4:30&nbsp;PM</dd>
             </div>


### PR DESCRIPTION
Remove card styling from contact information items in the 'Let's Talk Scrap' section on Demo 2.

---
<a href="https://cursor.com/background-agent?bcId=bc-83facf9f-b4a8-481b-a74f-473d83ac7b38">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-83facf9f-b4a8-481b-a74f-473d83ac7b38">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

